### PR TITLE
fix: useEffect is executed repeatedly after the repair archive is completed, causing the validate command to be triggered again after the change has been moved

### DIFF
--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,13 +2,24 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "paths": {
-      "@openspecui/core": ["../core/src/index.ts"],
-      "@openspecui/ai-provider": ["../ai-provider/src/index.ts"]
+      "@openspecui/core": [
+        "../core/src/index.ts"
+      ],
+      "@openspecui/ai-provider": [
+        "../ai-provider/src/index.ts"
+      ]
     }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
![img_v3_02sk_beafb5db-522e-4600-a840-ba10390e7adg](https://github.com/user-attachments/assets/a3ab386a-ba53-4429-86ef-8b252b6fcfa1)

修复存档完成后重复执行useEffect，导致更改移动后再次触发validate命令导致的报错