### PR TITLE
fix: harden cli runner spawn handling

### DIFF
--- a/.changeset/twelve-radios-arrive.md
+++ b/.changeset/twelve-radios-arrive.md
@@ -1,0 +1,6 @@
+---
+'@openspecui/core': patch
+---
+
+Fix CLI runner probing and execution when `spawn()` throws synchronously for invalid commands.
+This prevents delayed `ReferenceError` failures and keeps CLI availability checks stable for the web and server integrations.

--- a/packages/core/src/cli-executor.test.ts
+++ b/packages/core/src/cli-executor.test.ts
@@ -78,6 +78,17 @@ describe('CliExecutor', () => {
       expect(result.success).toBe(false)
     })
 
+    it('should return a failure result for synchronous spawn errors', async () => {
+      await configManager.writeConfig({ cli: { command: 'node\u0000broken' } })
+      clearCache()
+
+      const result = await cliExecutor.execute(['arg'])
+
+      expect(result.success).toBe(false)
+      expect(result.exitCode).toBeNull()
+      expect(result.stderr).toContain('without null bytes')
+    })
+
     it('should use project directory as cwd', async () => {
       await configManager.writeConfig({ cli: { command: 'node' } })
       clearCache()
@@ -292,6 +303,30 @@ describe('CliExecutor', () => {
         events.some((event) => event.type === 'stdout' && event.data?.includes('raw-ok'))
       ).toBe(true)
       expect(events.at(-1)).toMatchObject({ type: 'exit', exitCode: 0 })
+    })
+
+    it('should emit stderr and exit for synchronous spawn errors', async () => {
+      await configManager.writeConfig({ cli: { command: 'node\u0000broken' } })
+      clearCache()
+
+      const events: CliStreamEvent[] = []
+      const done = new Promise<void>((resolve) => {
+        void cliExecutor.executeStream(['arg'], (event) => {
+          events.push(event)
+          if (event.type === 'exit') {
+            resolve()
+          }
+        })
+      })
+
+      await done
+
+      expect(
+        events.some(
+          (event) => event.type === 'stderr' && event.data?.includes('without null bytes')
+        )
+      ).toBe(true)
+      expect(events.at(-1)).toMatchObject({ type: 'exit', exitCode: null })
     })
   })
 

--- a/packages/core/src/cli-executor.ts
+++ b/packages/core/src/cli-executor.ts
@@ -1,5 +1,6 @@
-import { spawn, type ChildProcess } from 'child_process'
+import { type ChildProcess } from 'child_process'
 import { createCleanCliEnv, type ConfigManager } from './config.js'
+import { formatSpawnError, runBufferedCommand, spawnSafe } from './spawn-safe.js'
 
 /** CLI 执行结果 */
 export interface CliResult {
@@ -37,47 +38,33 @@ export class CliExecutor {
     return [...commandParts, ...args]
   }
 
-  private runCommandOnce(fullCommand: readonly string[]): Promise<CliResultInternal> {
+  private async runCommandOnce(fullCommand: readonly string[]): Promise<CliResultInternal> {
     const [cmd, ...cmdArgs] = fullCommand
-    return new Promise((resolve) => {
-      const child = spawn(cmd, cmdArgs, {
-        cwd: this.projectDir,
-        shell: false,
-        env: createCleanCliEnv(),
-      })
-
-      let stdout = ''
-      let stderr = ''
-
-      child.stdout?.on('data', (data) => {
-        stdout += data.toString()
-      })
-
-      child.stderr?.on('data', (data) => {
-        stderr += data.toString()
-      })
-
-      child.on('close', (exitCode) => {
-        resolve({
-          success: exitCode === 0,
-          stdout,
-          stderr,
-          exitCode,
-        })
-      })
-
-      child.on('error', (err) => {
-        const errorCode = (err as NodeJS.ErrnoException).code
-        const errorMessage = err.message + (errorCode ? ` (${errorCode})` : '')
-        resolve({
-          success: false,
-          stdout,
-          stderr: stderr ? `${stderr}\n${errorMessage}` : errorMessage,
-          exitCode: null,
-          errorCode,
-        })
-      })
+    const result = await runBufferedCommand({
+      command: cmd,
+      args: cmdArgs,
+      cwd: this.projectDir,
+      env: createCleanCliEnv(),
     })
+
+    if (result.spawnError) {
+      return {
+        success: false,
+        stdout: result.stdout,
+        stderr: result.stderr
+          ? `${result.stderr}\n${result.spawnError.message}`
+          : result.spawnError.message,
+        exitCode: null,
+        errorCode: result.spawnError.code,
+      }
+    }
+
+    return {
+      success: result.exitCode === 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    }
   }
 
   private async executeInternal(args: string[], allowRetry: boolean): Promise<CliResult> {
@@ -268,32 +255,47 @@ export class CliExecutor {
       onEvent({ type: 'command', data: fullCommand.join(' ') })
       const [cmd, ...cmdArgs] = fullCommand
 
-      const child = spawn(cmd, cmdArgs, {
+      const started = spawnSafe(cmd, cmdArgs, {
         cwd: this.projectDir,
         shell: false,
         env: createCleanCliEnv(),
       })
+
+      if (!started.ok) {
+        const { code, message } = started.error
+
+        if (allowRetry && code === 'ENOENT' && !cancelled) {
+          this.configManager.invalidateResolvedCliRunner()
+          void start(false)
+          return
+        }
+
+        onEvent({ type: 'stderr', data: message })
+        onEvent({ type: 'exit', exitCode: null })
+        return
+      }
+
+      const child = started.child
       activeChild = child
 
-      child.stdout?.on('data', (data) => {
+      child.stdout?.on('data', (data: Buffer) => {
         onEvent({ type: 'stdout', data: data.toString() })
       })
 
-      child.stderr?.on('data', (data) => {
+      child.stderr?.on('data', (data: Buffer) => {
         onEvent({ type: 'stderr', data: data.toString() })
       })
 
-      child.on('close', (exitCode) => {
+      child.on('close', (exitCode: number | null) => {
         if (activeChild !== child) return
         activeChild = null
         onEvent({ type: 'exit', exitCode })
       })
 
-      child.on('error', (err) => {
+      child.on('error', (err: Error) => {
         if (activeChild !== child) return
         activeChild = null
-        const code = (err as NodeJS.ErrnoException).code
-        const message = err.message + (code ? ` (${code})` : '')
+        const { code, message } = formatSpawnError(err)
 
         if (allowRetry && code === 'ENOENT' && !cancelled) {
           this.configManager.invalidateResolvedCliRunner()
@@ -392,27 +394,34 @@ export class CliExecutor {
 
     onEvent({ type: 'command', data: command.join(' ') })
 
-    const child = spawn(cmd, cmdArgs, {
+    const started = spawnSafe(cmd, cmdArgs, {
       cwd: this.projectDir,
       shell: false,
       env: createCleanCliEnv(),
     })
 
-    child.stdout?.on('data', (data) => {
+    if (!started.ok) {
+      onEvent({ type: 'stderr', data: started.error.message })
+      onEvent({ type: 'exit', exitCode: null })
+      return () => {}
+    }
+
+    const child = started.child
+
+    child.stdout?.on('data', (data: Buffer) => {
       onEvent({ type: 'stdout', data: data.toString() })
     })
 
-    child.stderr?.on('data', (data) => {
+    child.stderr?.on('data', (data: Buffer) => {
       onEvent({ type: 'stderr', data: data.toString() })
     })
 
-    child.on('close', (exitCode) => {
+    child.on('close', (exitCode: number | null) => {
       onEvent({ type: 'exit', exitCode })
     })
 
-    child.on('error', (err) => {
-      const code = (err as NodeJS.ErrnoException).code
-      const message = err.message + (code ? ` (${code})` : '')
+    child.on('error', (err: Error) => {
+      const { message } = formatSpawnError(err)
       onEvent({ type: 'stderr', data: message })
       onEvent({ type: 'exit', exitCode: null })
     })

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -279,7 +279,8 @@ describe('ConfigManager', () => {
 
       try {
         await expect(configManager.getCliCommand()).rejects.toThrow('without null bytes')
-        expect(setTimeoutSpy).not.toHaveBeenCalled()
+        const probeTimerCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 20_000)
+        expect(probeTimerCall).toBeUndefined()
       } finally {
         setTimeoutSpy.mockRestore()
       }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, readFile, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanupTempDir, createTempDir, waitForDebounce } from './__tests__/test-utils.js'
 import {
   ConfigManager,
@@ -268,6 +268,21 @@ describe('ConfigManager', () => {
       const config = await configManager.readConfig()
       expect(config.cli.command).toBe('nonexistent_command_12345')
       expect(config.cli.args).toBeUndefined()
+    })
+
+    it('should surface synchronous spawn errors without arming the probe timeout', async () => {
+      const invalidCommand = 'node\u0000broken'
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+      await configManager.writeConfig({ cli: { command: invalidCommand } })
+      clearCache()
+
+      try {
+        await expect(configManager.getCliCommand()).rejects.toThrow('without null bytes')
+        expect(setTimeoutSpy).not.toHaveBeenCalled()
+      } finally {
+        setTimeoutSpy.mockRestore()
+      }
     })
 
     it('should resolve openspec via shell lookup when PATH misses the shim directory', async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,9 +1,10 @@
-import { exec, execFile, spawn } from 'child_process'
+import { exec, execFile } from 'child_process'
 import { mkdir, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
 import { promisify } from 'util'
 import { z } from 'zod'
 import { reactiveReadFile, updateReactiveFileCache } from './reactive-fs/index.js'
+import { runBufferedCommand } from './spawn-safe.js'
 
 const execAsync = promisify(exec)
 const execFileAsync = promisify(execFile)
@@ -349,74 +350,52 @@ async function probeCliRunner(
   env: NodeJS.ProcessEnv
 ): Promise<CliRunnerAttempt> {
   const [cmd, ...cmdArgs] = candidate.commandParts
-  return new Promise((resolve) => {
-    let stdout = ''
-    let stderr = ''
-    let timedOut = false
-
-    const timer = setTimeout(() => {
-      timedOut = true
-      child.kill()
-    }, CLI_PROBE_TIMEOUT_MS)
-
-    const child = spawn(cmd, [...cmdArgs, '--version'], {
-      cwd,
-      shell: false,
-      env,
-    })
-
-    child.stdout?.on('data', (data) => {
-      stdout += data.toString()
-    })
-    child.stderr?.on('data', (data) => {
-      stderr += data.toString()
-    })
-
-    child.on('error', (err) => {
-      clearTimeout(timer)
-      const code = (err as NodeJS.ErrnoException).code
-      const suffix = code ? ` (${code})` : ''
-      resolve({
-        source: candidate.source,
-        command: commandToString(candidate.commandParts),
-        success: false,
-        error: `${err.message}${suffix}`,
-        exitCode: null,
-      })
-    })
-
-    child.on('close', (exitCode) => {
-      clearTimeout(timer)
-      if (timedOut) {
-        resolve({
-          source: candidate.source,
-          command: commandToString(candidate.commandParts),
-          success: false,
-          error: 'CLI probe timed out',
-          exitCode,
-        })
-        return
-      }
-      if (exitCode === 0) {
-        const version = stdout.trim().split('\n')[0] || undefined
-        resolve({
-          source: candidate.source,
-          command: commandToString(candidate.commandParts),
-          success: true,
-          version,
-          exitCode,
-        })
-        return
-      }
-      resolve({
-        source: candidate.source,
-        command: commandToString(candidate.commandParts),
-        success: false,
-        error: stderr.trim() || `Exit code ${exitCode ?? 'null'}`,
-        exitCode,
-      })
-    })
+  const result = await runBufferedCommand({
+    command: cmd,
+    args: [...cmdArgs, '--version'],
+    cwd,
+    env,
+    timeoutMs: CLI_PROBE_TIMEOUT_MS,
   })
+
+  if (result.timedOut) {
+    return {
+      source: candidate.source,
+      command: commandToString(candidate.commandParts),
+      success: false,
+      error: 'CLI probe timed out',
+      exitCode: result.exitCode,
+    }
+  }
+
+  if (result.spawnError) {
+    return {
+      source: candidate.source,
+      command: commandToString(candidate.commandParts),
+      success: false,
+      error: result.spawnError.message,
+      exitCode: null,
+    }
+  }
+
+  if (result.exitCode === 0) {
+    const version = result.stdout.trim().split('\n')[0] || undefined
+    return {
+      source: candidate.source,
+      command: commandToString(candidate.commandParts),
+      success: true,
+      version,
+      exitCode: result.exitCode,
+    }
+  }
+
+  return {
+    source: candidate.source,
+    command: commandToString(candidate.commandParts),
+    success: false,
+    error: result.stderr.trim() || `Exit code ${result.exitCode ?? 'null'}`,
+    exitCode: result.exitCode,
+  }
 }
 
 async function resolveCliRunner(

--- a/packages/core/src/spawn-safe.ts
+++ b/packages/core/src/spawn-safe.ts
@@ -1,0 +1,145 @@
+import { spawn, type ChildProcess, type SpawnOptionsWithoutStdio } from 'child_process'
+
+export interface SpawnErrorInfo {
+  code?: string
+  message: string
+}
+
+export interface BufferedSpawnResult {
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  timedOut: boolean
+  spawnError?: SpawnErrorInfo
+}
+
+type SafeSpawnResult =
+  | {
+      ok: true
+      child: ChildProcess
+    }
+  | {
+      ok: false
+      error: SpawnErrorInfo
+    }
+
+function getSpawnErrorCode(err: unknown): string | undefined {
+  if (typeof err !== 'object' || err === null || !('code' in err)) {
+    return undefined
+  }
+
+  const code = (err as { code?: unknown }).code
+  return typeof code === 'string' ? code : undefined
+}
+
+export function formatSpawnError(err: unknown): SpawnErrorInfo {
+  const message = err instanceof Error ? err.message : String(err)
+  const code = getSpawnErrorCode(err)
+  const suffix = code ? ` (${code})` : ''
+  return {
+    code,
+    message: `${message}${suffix}`,
+  }
+}
+
+export function spawnSafe(
+  command: string,
+  args: readonly string[],
+  options: SpawnOptionsWithoutStdio
+): SafeSpawnResult {
+  try {
+    return {
+      ok: true,
+      child: spawn(command, [...args], options),
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: formatSpawnError(err),
+    }
+  }
+}
+
+function killChild(child: ChildProcess): void {
+  try {
+    child.kill()
+  } catch {
+    // Ignore kill failures when the process already exited or was never started.
+  }
+}
+
+export function runBufferedCommand(options: {
+  command: string
+  args: readonly string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  timeoutMs?: number
+}): Promise<BufferedSpawnResult> {
+  return new Promise((resolve) => {
+    const started = spawnSafe(options.command, options.args, {
+      cwd: options.cwd,
+      shell: false,
+      env: options.env,
+    })
+
+    if (!started.ok) {
+      resolve({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: started.error,
+      })
+      return
+    }
+
+    const { child } = started
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+
+    let clearTimer = () => {}
+    if (options.timeoutMs !== undefined) {
+      const timer = setTimeout(() => {
+        timedOut = true
+        killChild(child)
+      }, options.timeoutMs)
+      clearTimer = () => clearTimeout(timer)
+    }
+
+    const finish = (result: BufferedSpawnResult) => {
+      if (settled) return
+      settled = true
+      clearTimer()
+      resolve(result)
+    }
+
+    child.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString()
+    })
+
+    child.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    child.on('error', (err: Error) => {
+      finish({
+        stdout,
+        stderr,
+        exitCode: null,
+        timedOut,
+        spawnError: formatSpawnError(err),
+      })
+    })
+
+    child.on('close', (exitCode: number | null) => {
+      finish({
+        stdout,
+        stderr,
+        exitCode,
+        timedOut,
+      })
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- add a shared core `spawn-safe` helper that catches synchronous `spawn()` failures and normalizes child-process errors
- route `probeCliRunner()` and `CliExecutor` through the same safe spawn path so invalid CLI commands fail immediately instead of tripping a delayed TDZ error
- add regression tests for synchronous spawn failures and include a patch changeset for `@openspecui/core`

## Validation
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
- pnpm build

## Release
- changeset status: patch bump for `@openspecui/core` and `@openspecui/server`