### PR TITLE
chore(release): apply changeset version

### DIFF
--- a/.changeset/twelve-radios-arrive.md
+++ b/.changeset/twelve-radios-arrive.md
@@ -1,6 +1,0 @@
----
-'@openspecui/core': patch
----
-
-Fix CLI runner probing and execution when `spawn()` throws synchronously for invalid commands.
-This prevents delayed `ReferenceError` failures and keeps CLI availability checks stable for the web and server integrations.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/core
 
+## 2.3.3
+
+### Patch Changes
+
+- 4b11a8a: Fix CLI runner probing and execution when `spawn()` throws synchronously for invalid commands.
+  This prevents delayed `ReferenceError` failures and keeps CLI availability checks stable for the web and server integrations.
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/core",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "description": "Core OpenSpec adapter and parser",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/server
 
+## 2.3.3
+
+### Patch Changes
+
+- Updated dependencies [4b11a8a]
+  - @openspecui/core@2.3.3
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/server",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "type": "module",
   "main": "dist/index.mjs",
   "exports": {


### PR DESCRIPTION
Automated by `pnpm changeversion`.

- Run `changeset version`
- Commit version/changelog updates
- Create PR and wait for required checks
- Merge PR, sync local main, and wait for GitHub release automation