### PR TITLE
Fix ArtifactOutputViewer header state not changing if placing artifacts inside a sub folder

### DIFF
--- a/.changeset/pr93-reactive-artifact-output-tracking.md
+++ b/.changeset/pr93-reactive-artifact-output-tracking.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/core': patch
+---
+
+Complete reactive artifact output tracking for nested and globbed outputs.

--- a/.changeset/vast-buckets-win.md
+++ b/.changeset/vast-buckets-win.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/core': major
+---
+
+Modify fetchOpsxStatus to obtain the sub folder files reactivity

--- a/packages/core/src/opsx-kernel.test.ts
+++ b/packages/core/src/opsx-kernel.test.ts
@@ -1,0 +1,176 @@
+import { mkdir, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanupTempDir, createTempDir, waitFor } from './__tests__/test-utils.js'
+import { CliExecutor } from './cli-executor.js'
+import { ConfigManager } from './config.js'
+import { OpsxKernel } from './opsx-kernel.js'
+import { clearCache, initWatcherPool } from './reactive-fs/index.js'
+import { closeAllWatchers } from './reactive-fs/watcher-pool.js'
+
+describe('OpsxKernel artifact status reactivity', () => {
+  let tempDir: string
+  let kernel: OpsxKernel | null = null
+
+  beforeEach(async () => {
+    tempDir = await createTempDir()
+    await mkdir(join(tempDir, 'openspec'), { recursive: true })
+    await initWatcherPool(tempDir)
+    clearCache()
+  })
+
+  afterEach(async () => {
+    kernel?.dispose()
+    kernel = null
+    clearCache()
+    await closeAllWatchers()
+    await cleanupTempDir(tempDir)
+  })
+
+  async function prepareKernel(outputPath: string): Promise<{
+    changeDir: string
+    kernel: OpsxKernel
+  }> {
+    const changeId = 'demo-change'
+    const changeDir = join(tempDir, 'openspec', 'changes', changeId)
+    await mkdir(changeDir, { recursive: true })
+    await writeFile(join(tempDir, 'openspec', 'config.yaml'), 'name: test\n', 'utf-8')
+    await writeFile(join(changeDir, '.openspec.yaml'), 'schema: test\n', 'utf-8')
+
+    const cliScriptPath = join(tempDir, 'fake-openspec.mjs')
+    await writeFile(
+      cliScriptPath,
+      `
+import { existsSync, readdirSync } from 'node:fs'
+import { join, matchesGlob, relative, sep } from 'node:path'
+
+const outputPath = ${JSON.stringify(outputPath)}
+const args = process.argv.slice(2)
+
+function isGlobPattern(pattern) {
+  return pattern.includes('*') || pattern.includes('?') || pattern.includes('[')
+}
+
+function collectFiles(rootDir, currentDir = rootDir) {
+  if (!existsSync(currentDir)) {
+    return []
+  }
+
+  const entries = readdirSync(currentDir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const fullPath = join(currentDir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(rootDir, fullPath))
+      continue
+    }
+    if (entry.isFile()) {
+      const relativePath = relative(rootDir, fullPath).split(sep).join('/')
+      files.push(relativePath)
+    }
+  }
+
+  return files
+}
+
+if (args.includes('--version')) {
+  console.log('0.0.0-test')
+  process.exit(0)
+}
+
+if (args[0] === 'status' && args.includes('--json')) {
+  const changeIndex = args.indexOf('--change')
+  const changeId = changeIndex >= 0 ? args[changeIndex + 1] : 'unknown-change'
+  const changeDir = join(process.cwd(), 'openspec', 'changes', changeId)
+  const done = isGlobPattern(outputPath)
+    ? collectFiles(changeDir).some((path) => matchesGlob(path, outputPath))
+    : existsSync(join(changeDir, outputPath))
+
+  console.log(
+    JSON.stringify({
+      changeName: changeId,
+      schemaName: 'test',
+      isComplete: done,
+      applyRequires: [],
+      artifacts: [
+        {
+          id: 'artifact',
+          outputPath,
+          status: done ? 'done' : 'blocked',
+          missingDeps: done ? [] : [outputPath],
+        },
+      ],
+    })
+  )
+  process.exit(0)
+}
+
+console.error('Unsupported args:', args.join(' '))
+process.exit(1)
+      `.trimStart(),
+      'utf-8'
+    )
+
+    const configManager = new ConfigManager(tempDir)
+    await configManager.writeConfig({
+      cli: {
+        command: process.execPath,
+        args: [cliScriptPath],
+      },
+    })
+
+    const cliExecutor = new CliExecutor(configManager, tempDir)
+    kernel = new OpsxKernel(tempDir, cliExecutor)
+    return { changeDir, kernel }
+  }
+
+  it('refreshes status when a file appears inside an existing subdirectory', async () => {
+    const { changeDir, kernel } = await prepareKernel('loop/result.md')
+    await mkdir(join(changeDir, 'loop'), { recursive: true })
+
+    await kernel.ensureStatus('demo-change')
+    expect(kernel.getStatus('demo-change').artifacts[0]?.status).toBe('blocked')
+
+    await writeFile(join(changeDir, 'loop', 'result.md'), 'done\n', 'utf-8')
+
+    await waitFor(() => kernel.getStatus('demo-change').artifacts[0]?.status === 'done')
+  })
+
+  it('refreshes status when missing parent directories are created later', async () => {
+    const { changeDir, kernel } = await prepareKernel('loop/nested/result.md')
+
+    await kernel.ensureStatus('demo-change')
+    expect(kernel.getStatus('demo-change').artifacts[0]?.status).toBe('blocked')
+
+    await mkdir(join(changeDir, 'loop', 'nested'), { recursive: true })
+    await writeFile(join(changeDir, 'loop', 'nested', 'result.md'), 'done\n', 'utf-8')
+
+    await waitFor(() => kernel.getStatus('demo-change').artifacts[0]?.status === 'done')
+  })
+
+  it('refreshes status for glob artifacts when matching files appear in subdirectories', async () => {
+    const { changeDir, kernel } = await prepareKernel('loop/**/*.md')
+    await mkdir(join(changeDir, 'loop'), { recursive: true })
+
+    await kernel.ensureStatus('demo-change')
+    expect(kernel.getStatus('demo-change').artifacts[0]?.status).toBe('blocked')
+
+    await mkdir(join(changeDir, 'loop', 'docs'), { recursive: true })
+    await writeFile(join(changeDir, 'loop', 'docs', 'guide.md'), 'done\n', 'utf-8')
+
+    await waitFor(() => kernel.getStatus('demo-change').artifacts[0]?.status === 'done')
+  })
+
+  it('refreshes status for question-mark glob artifacts', async () => {
+    const { changeDir, kernel } = await prepareKernel('loop/file?.md')
+    await mkdir(join(changeDir, 'loop'), { recursive: true })
+
+    await kernel.ensureStatus('demo-change')
+    expect(kernel.getStatus('demo-change').artifacts[0]?.status).toBe('blocked')
+
+    await writeFile(join(changeDir, 'loop', 'file1.md'), 'done\n', 'utf-8')
+
+    await waitFor(() => kernel.getStatus('demo-change').artifacts[0]?.status === 'done')
+  })
+})

--- a/packages/core/src/opsx-kernel.ts
+++ b/packages/core/src/opsx-kernel.ts
@@ -17,7 +17,7 @@ import {
   type TemplatesMap,
 } from './opsx-types.js'
 import { ReactiveContext } from './reactive-fs/reactive-context.js'
-import { reactiveReadDir, reactiveReadFile, reactiveStat } from './reactive-fs/reactive-fs.js'
+import { reactiveExists, reactiveReadDir, reactiveReadFile, reactiveStat } from './reactive-fs/reactive-fs.js'
 import { ReactiveState } from './reactive-fs/reactive-state.js'
 import type { ChangeFile } from './schemas.js'
 
@@ -820,6 +820,11 @@ export class OpsxKernel {
     const changeRelDir = `openspec/changes/${changeId}`
     for (const artifact of status.artifacts) {
       artifact.relativePath = `${changeRelDir}/${artifact.outputPath}`
+      // Skip globs for simplicity, or handle their base dir
+      const fullPath = join(this.projectDir, artifact.relativePath)
+       if (!artifact.outputPath.includes('*')) {
+           await reactiveExists(fullPath)
+         }
     }
     return status
   }

--- a/packages/core/src/opsx-kernel.ts
+++ b/packages/core/src/opsx-kernel.ts
@@ -9,6 +9,7 @@ import {
   SchemaInfoSchema,
   SchemaResolutionSchema,
   TemplatesSchema,
+  isGlobPattern,
   type ApplyInstructions,
   type ArtifactInstructions,
   type ChangeStatus,
@@ -17,7 +18,12 @@ import {
   type TemplatesMap,
 } from './opsx-types.js'
 import { ReactiveContext } from './reactive-fs/reactive-context.js'
-import { reactiveReadDir, reactiveReadFile, reactiveStat } from './reactive-fs/reactive-fs.js'
+import {
+  reactiveExists,
+  reactiveReadDir,
+  reactiveReadFile,
+  reactiveStat,
+} from './reactive-fs/reactive-fs.js'
 import { ReactiveState } from './reactive-fs/reactive-state.js'
 import type { ChangeFile } from './schemas.js'
 
@@ -110,6 +116,22 @@ interface GlobArtifactFile {
   content: string
 }
 
+function splitRelativePathSegments(path: string): string[] {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean)
+}
+
+function getGlobStaticPrefix(outputPath: string): string {
+  const normalizedPath = outputPath.replace(/\\/g, '/')
+  const firstGlobIndex = normalizedPath.search(/[*?[]/)
+  if (firstGlobIndex === -1) {
+    return normalizedPath
+  }
+
+  const staticPrefix = normalizedPath.slice(0, firstGlobIndex)
+  const lastSlashIndex = staticPrefix.lastIndexOf('/')
+  return lastSlashIndex === -1 ? '' : staticPrefix.slice(0, lastSlashIndex)
+}
+
 async function readGlobArtifactFiles(
   projectDir: string,
   changeId: string,
@@ -152,6 +174,59 @@ async function touchOpsxChangeDeps(projectDir: string, changeId: string): Promis
   const changeDir = join(projectDir, 'openspec', 'changes', changeId)
   await reactiveReadDir(changeDir, { includeHidden: true })
   await reactiveReadFile(join(changeDir, '.openspec.yaml'))
+}
+
+async function touchDirectoryPathDeps(rootDir: string, relativePath: string): Promise<void> {
+  let currentPath = rootDir
+  for (const segment of splitRelativePathSegments(relativePath)) {
+    currentPath = join(currentPath, segment)
+    await reactiveExists(currentPath)
+  }
+}
+
+async function touchDirectoryTree(rootDir: string): Promise<void> {
+  const rootStat = await reactiveStat(rootDir)
+  if (!rootStat?.isDirectory) {
+    return
+  }
+
+  const entries = await reactiveReadDir(rootDir, { includeHidden: true })
+  await Promise.all(
+    entries.map(async (entryName) => {
+      const entryPath = join(rootDir, entryName)
+      const entryStat = await reactiveStat(entryPath)
+      if (entryStat?.isDirectory) {
+        await touchDirectoryTree(entryPath)
+      }
+    })
+  )
+}
+
+async function touchArtifactOutputDeps(
+  projectDir: string,
+  changeId: string,
+  outputPath: string
+): Promise<void> {
+  const changeDir = join(projectDir, 'openspec', 'changes', changeId)
+  const normalizedOutputPath = outputPath.replace(/\\/g, '/')
+
+  if (isGlobPattern(normalizedOutputPath)) {
+    const staticPrefix = getGlobStaticPrefix(normalizedOutputPath)
+    if (staticPrefix) {
+      await touchDirectoryPathDeps(changeDir, staticPrefix)
+    }
+
+    const globRoot = staticPrefix ? join(changeDir, staticPrefix) : changeDir
+    await touchDirectoryTree(globRoot)
+    return
+  }
+
+  const parentPath = splitRelativePathSegments(normalizedOutputPath).slice(0, -1).join('/')
+  if (parentPath) {
+    await touchDirectoryPathDeps(changeDir, parentPath)
+  }
+
+  await reactiveExists(join(changeDir, normalizedOutputPath))
 }
 
 // ---------------------------------------------------------------------------
@@ -820,6 +895,7 @@ export class OpsxKernel {
     const changeRelDir = `openspec/changes/${changeId}`
     for (const artifact of status.artifacts) {
       artifact.relativePath = `${changeRelDir}/${artifact.outputPath}`
+      await touchArtifactOutputDeps(this.projectDir, changeId, artifact.outputPath)
     }
     return status
   }


### PR DESCRIPTION

   ## Summary

   This PR fixes a bug in the `<ArtifactOutputViewer>` where the header status (e.g., "Blocked" vs "Done") would
   not update automatically when an artifact was generated inside a sub-folder (like `loop/`).

   - **The Problem:** The backend's `touchOpsxChangeDeps` used a shallow directory watch (`reactiveReadDir`) on the
   top-level change folder. When artifacts were created inside sub-folders like `loop/`, the OS file system events
   were ignored by the reactive system, preventing the UI header from re-fetching its status.
   - **The Fix:** Updated `fetchOpsxStatus` in `@openspecui/core` (`opsx-kernel.ts`) to explicitly register deep,
   surgical reactive dependencies on the exact expected file paths for every artifact returned by `openspec status`
   (skipping globs). This ensures the tRPC WebSocket subscription instantly pushes an update the moment the file
   hits the disk.

   ## Validation

   - Created an artifact inside a sub-folder and verified the UI header updates from "Blocked" (yellow) to "Done"
   (green) instantly without a manual page refresh.
   - `pnpm lint:ci`
   - `pnpm test:ci`

   ## Release

   - changeset status: patch bump for `@openspecui/core`