### PR TITLE
fix: preserve page scroll during routed tab transitions

### DIFF
--- a/.changeset/safari-routed-tab-scroll-freeze.md
+++ b/.changeset/safari-routed-tab-scroll-freeze.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Preserve page scroll during routed tab view transitions by freezing each tab panel to its visible height while transferring scroll state across the transition.

--- a/packages/web/src/components/git/git-panel-detail.test.tsx
+++ b/packages/web/src/components/git/git-panel-detail.test.tsx
@@ -30,10 +30,12 @@ vi.mock('@/components/tabs', () => ({
       tabs,
       selectedTab,
       onTabChange,
+      className,
     }: {
       tabs: Array<{ id: string; label: string; content: ReactNode }>
       selectedTab?: string
       onTabChange?: (id: string) => void
+      className?: string
     },
     ref: ForwardedRef<{
       root: HTMLElement | null
@@ -59,7 +61,12 @@ vi.mock('@/components/tabs', () => ({
     )
 
     return (
-      <div ref={rootRef} data-testid="tabs" data-active-tab={activeTab?.id ?? ''}>
+      <div
+        ref={rootRef}
+        data-testid="tabs"
+        data-active-tab={activeTab?.id ?? ''}
+        className={className}
+      >
         <div className="tabs-strip">
           {tabs.map((tab) => (
             <button
@@ -145,11 +152,45 @@ function stubWideResizeObserver() {
       this.callback = callback
     }
 
-    observe() {
+    observe(target: Element) {
+      const element = target as HTMLElement
       this.callback(
         [
           {
-            contentRect: { width: 1200 } as DOMRectReadOnly,
+            contentRect: {
+              width: 1200,
+              height: element.clientHeight || 320,
+            } as DOMRectReadOnly,
+          } as ResizeObserverEntry,
+        ],
+        this as unknown as ResizeObserver
+      )
+    }
+
+    disconnect() {}
+    unobserve() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+}
+
+function stubNarrowResizeObserver() {
+  class MockResizeObserver {
+    private readonly callback: ResizeObserverCallback
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback
+    }
+
+    observe(target: Element) {
+      const element = target as HTMLElement
+      this.callback(
+        [
+          {
+            contentRect: {
+              width: 480,
+              height: element.clientHeight || 320,
+            } as DOMRectReadOnly,
           } as ResizeObserverEntry,
         ],
         this as unknown as ResizeObserver
@@ -294,6 +335,27 @@ const revealFiles = [
   },
 ]
 
+const largeDiffFiles = Array.from({ length: 28 }, (_, index) => ({
+  ...baseFile,
+  fileId: `large-file-${index + 1}`,
+  path: `src/large-file-${index + 1}.ts`,
+  displayPath: `src/large-file-${index + 1}.ts`,
+}))
+
+const largeDiffPatchFiles = largeDiffFiles.map((file, index) => ({
+  ...basePatchFile,
+  fileId: file.fileId,
+  path: file.path,
+  displayPath: file.displayPath,
+  patch: [
+    `diff --git a/${file.path} b/${file.path}`,
+    '@@ -1,3 +1,3 @@',
+    `-export const before_${index + 1} = 0`,
+    `+export const after_${index + 1} = 1`,
+    `+export const stable_${index + 1} = true`,
+  ].join('\n'),
+}))
+
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
@@ -421,6 +483,85 @@ describe('GitEntryDetailPanel', () => {
     expect(frameStates.every((state) => state === 'diff')).toBe(true)
   })
 
+  it('renders full large narrow diff lists and switches back to diff after tree selection', async () => {
+    stubNarrowResizeObserver()
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      writable: true,
+      value: function mockGetBoundingClientRect(this: HTMLElement) {
+        if (this.dataset.testid === 'scroll-shell') {
+          return {
+            x: 0,
+            y: 40,
+            width: 420,
+            height: 320,
+            top: 40,
+            right: 420,
+            bottom: 360,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        if (this.dataset.testid === 'git-diff-viewport') {
+          return {
+            x: 0,
+            y: 104,
+            width: 420,
+            height: 240,
+            top: 104,
+            right: 420,
+            bottom: 344,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        return originalGetBoundingClientRect.call(this)
+      },
+    })
+
+    try {
+      renderWithQueryClient(
+        <div data-testid="scroll-shell" style={{ height: '320px', overflowY: 'auto' }}>
+          <GitEntryDetailPanel
+            selector={{ type: 'commit', hash: baseEntry.hash }}
+            entry={{
+              ...baseEntry,
+              diff: { files: largeDiffFiles.length, insertions: 56, deletions: 28 },
+            }}
+            files={largeDiffFiles}
+            eagerFiles={largeDiffPatchFiles}
+            isLoading={false}
+            error={null}
+          />
+        </div>
+      )
+      await waitFor(() => {
+        const renderedCount = screen
+          .getByTestId('git-diff-viewport')
+          .querySelectorAll('section[data-file-id]').length
+
+        expect(renderedCount).toBe(largeDiffFiles.length)
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+      fireEvent.click(screen.getByRole('treeitem', { name: /src\/large-file-28\.ts/i }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+      })
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        writable: true,
+        value: originalGetBoundingClientRect,
+      })
+    }
+  })
+
   it('switches to dual-pane layout when the container is wide enough', async () => {
     stubWideResizeObserver()
 
@@ -439,6 +580,55 @@ describe('GitEntryDetailPanel', () => {
       expect(screen.queryByTestId('tabs')).toBeNull()
       expect(screen.getByText('File Tree')).toBeTruthy()
       expect(screen.getByText('Diff Stream')).toBeTruthy()
+    })
+  })
+
+  it('keeps narrow tabs on the page scroll instead of introducing an inner viewport', () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      writable: true,
+      value: function mockGetBoundingClientRect(this: HTMLElement) {
+        if (this.dataset.testid === 'scroll-shell') {
+          return {
+            x: 0,
+            y: 40,
+            width: 420,
+            height: 320,
+            top: 40,
+            right: 420,
+            bottom: 360,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        return originalGetBoundingClientRect.call(this)
+      },
+    })
+
+    renderWithQueryClient(
+      <div data-testid="scroll-shell" style={{ height: '320px', overflowY: 'auto' }}>
+        <GitEntryDetailPanel
+          selector={{ type: 'commit', hash: baseEntry.hash }}
+          entry={baseEntry}
+          files={[baseFile]}
+          isLoading={false}
+          error={null}
+        />
+      </div>
+    )
+
+    fireEvent(window, new Event('resize'))
+
+    expect(screen.queryByTestId('git-pane-tabs-viewport')).toBeNull()
+    expect(screen.getByTestId('git-diff-viewport')).not.toHaveClass('overflow-y-auto')
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      writable: true,
+      value: originalGetBoundingClientRect,
     })
   })
 

--- a/packages/web/src/components/git/git-panel-detail.tsx
+++ b/packages/web/src/components/git/git-panel-detail.tsx
@@ -10,7 +10,15 @@ import type {
 } from '@openspecui/core'
 import { useQueries } from '@tanstack/react-query'
 import { AlertCircle, Files, GitCommitHorizontal, ListTree, LoaderCircle } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
 
 import {
   buildIntersectionThresholds,
@@ -212,16 +220,19 @@ export function GitEntryDetailPanel({
     queryKey: 'gitPane',
     tabs: paneTabs,
     initialTab: 'diff',
+    viewportSelector: '.main-content, .bottom-area',
   })
+  const eagerFileIdSet = useMemo(() => new Set(eagerFiles.map((file) => file.fileId)), [eagerFiles])
   const [requestedFileIds, setRequestedFileIds] = useState<string[]>([])
   const [diffScrollOffset, setDiffScrollOffset] = useState(DIFF_SCROLL_PADDING)
   const [diffScrollRoot, setDiffScrollRoot] = useState<HTMLElement | null>(null)
+  const [diffViewportNode, setDiffViewportNode] = useState<HTMLDivElement | null>(null)
   const [treeRevealRequest, setTreeRevealRequest] = useState<GitFileTreeRevealRequest | null>(null)
   const cardNodesRef = useRef(new Map<string, HTMLElement>())
   const pendingScrollFileIdRef = useRef<string | null>(null)
   const pendingScrollDeadlineRef = useRef(0)
   const pendingScrollFrameRef = useRef<number | null>(null)
-  const diffViewportRef = useRef<HTMLDivElement | null>(null)
+  const schedulePendingScrollRef = useRef<() => void>(() => {})
   const tabsRootRef = useRef<HTMLDivElement | null>(null)
   const treeRevealNonceRef = useRef(0)
   const revealNavigationSourceRef = useRef<'diff' | 'tree' | null>(null)
@@ -230,7 +241,6 @@ export function GitEntryDetailPanel({
     target: wideTreeViewportNode,
     enabled: wide,
   })
-  const eagerFileIdSet = useMemo(() => new Set(eagerFiles.map((file) => file.fileId)), [eagerFiles])
 
   const markTreeNavigation = useCallback(() => {
     revealNavigationSourceRef.current = 'tree'
@@ -271,7 +281,6 @@ export function GitEntryDetailPanel({
   useEffect(() => {
     setSelectedTab('diff')
     setRequestedFileIds([])
-    setDiffScrollRoot(null)
     setTreeRevealRequest(null)
     revealNavigationSourceRef.current = null
     cardNodesRef.current.clear()
@@ -368,7 +377,6 @@ export function GitEntryDetailPanel({
       ].join('|'),
     [eagerFiles, patchQueries]
   )
-
   const treeFiles = useMemo(
     () =>
       files.map((file) => {
@@ -388,6 +396,13 @@ export function GitEntryDetailPanel({
       }),
     [files, patchStateByFileId]
   )
+
+  useLayoutEffect(() => {
+    const nextRoot = findVerticalScrollContainer(diffViewportNode, {
+      allowNonScrollable: true,
+    })
+    setDiffScrollRoot((currentRoot) => (currentRoot === nextRoot ? currentRoot : nextRoot))
+  }, [activePane, diffViewportNode, wide])
 
   const handlePrefetchVisible = useCallback(
     (entries: VisibilityBatchEntry<string>[]) => {
@@ -488,11 +503,6 @@ export function GitEntryDetailPanel({
       return
     }
 
-    const node = cardNodesRef.current.get(fileId)
-    if (!node) {
-      return
-    }
-
     if (
       pendingScrollDeadlineRef.current > 0 &&
       window.performance.now() > pendingScrollDeadlineRef.current
@@ -502,14 +512,19 @@ export function GitEntryDetailPanel({
       return
     }
 
-    if (isCardAligned(node, diffViewportRef.current, diffScrollOffset)) {
+    const node = cardNodesRef.current.get(fileId)
+    if (!node) {
+      return
+    }
+
+    if (isCardAligned(node, diffViewportNode, diffScrollOffset)) {
       pendingScrollFileIdRef.current = null
       pendingScrollDeadlineRef.current = 0
       return
     }
 
-    scrollCardIntoView(node, diffViewportRef.current, diffScrollOffset)
-  }, [activePane, diffScrollOffset, wide])
+    scrollCardIntoView(node, diffViewportNode, diffScrollOffset)
+  }, [activePane, diffScrollOffset, diffViewportNode, wide])
 
   const schedulePendingScroll = useCallback(() => {
     if (pendingScrollFrameRef.current !== null) {
@@ -521,6 +536,7 @@ export function GitEntryDetailPanel({
       flushPendingScroll()
     })
   }, [flushPendingScroll])
+  schedulePendingScrollRef.current = schedulePendingScroll
 
   const queueScrollToFile = useCallback(
     (fileId: string) => {
@@ -697,6 +713,20 @@ export function GitEntryDetailPanel({
   const diffViewportStyle = {
     scrollPaddingTop: `${diffScrollOffset}px`,
   }
+  const renderDiffCard = (file: GitEntryFileSummary) => {
+    const patchState = patchStateByFileId.get(file.fileId)
+    return (
+      <GitPatchCard
+        key={file.fileId}
+        file={patchState?.file ?? file}
+        patch={patchState?.file ?? null}
+        status={patchState?.status ?? 'idle'}
+        error={patchState?.error ?? null}
+        onRegisterCard={registerCardNode}
+        scrollMarginTop={diffScrollOffset}
+      />
+    )
+  }
 
   const diffStreamContent =
     isLoading && files.length === 0 ? (
@@ -708,22 +738,7 @@ export function GitEntryDetailPanel({
         No changed files found for this entry.
       </div>
     ) : (
-      <div className="space-y-3">
-        {files.map((file) => {
-          const patchState = patchStateByFileId.get(file.fileId)
-          return (
-            <GitPatchCard
-              key={file.fileId}
-              file={patchState?.file ?? file}
-              patch={patchState?.file ?? null}
-              status={patchState?.status ?? 'idle'}
-              error={patchState?.error ?? null}
-              onRegisterCard={registerCardNode}
-              scrollMarginTop={diffScrollOffset}
-            />
-          )
-        })}
-      </div>
+      <div className="space-y-3">{files.map((file) => renderDiffCard(file))}</div>
     )
 
   return (
@@ -775,7 +790,11 @@ export function GitEntryDetailPanel({
               <Files className="h-4 w-4 shrink-0" />
               <span>Diff Stream</span>
             </div>
-            <div ref={diffViewportRef} data-testid="git-diff-viewport" style={diffViewportStyle}>
+            <div
+              ref={setDiffViewportNode}
+              data-testid="git-diff-viewport"
+              style={diffViewportStyle}
+            >
               {diffStreamContent}
             </div>
           </section>
@@ -794,7 +813,7 @@ export function GitEntryDetailPanel({
                 icon: <Files className="h-4 w-4" />,
                 content: (
                   <div
-                    ref={diffViewportRef}
+                    ref={setDiffViewportNode}
                     data-testid="git-diff-viewport"
                     className="pt-3"
                     style={diffViewportStyle}

--- a/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
+++ b/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
@@ -1,0 +1,210 @@
+import type { TabsHandle } from '@/components/tabs'
+
+const DATA_VISIBLE_HEIGHT = 'tabVisibleHeight'
+const DATA_TOP_INSET = 'tabTopInset'
+const DATA_SCROLL_OFFSET = 'tabScrollOffset'
+
+export interface TabScrollMemory {
+  innerScrollTop: number
+  topInset: number
+  visibleHeight: number
+}
+
+export interface FrozenTabState {
+  panel: HTMLElement
+  previousStyles: {
+    height: string
+    maxHeight: string
+    minHeight: string
+    overflowY: string
+  }
+  viewport: HTMLElement
+}
+
+interface ResolvedTabScrollElements {
+  panel: HTMLElement
+  viewport: HTMLElement
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function maxViewportScroll(viewport: HTMLElement): number {
+  return Math.max(viewport.scrollHeight - viewport.clientHeight, 0)
+}
+
+function maxPanelScroll(panel: HTMLElement, visibleHeight: number): number {
+  return Math.max(panel.scrollHeight - visibleHeight, 0)
+}
+
+function panelDocumentTop(panel: HTMLElement, viewport: HTMLElement): number {
+  const panelRect = panel.getBoundingClientRect()
+  const viewportRect = viewport.getBoundingClientRect()
+  return viewport.scrollTop + panelRect.top - viewportRect.top
+}
+
+function setFrozenMetrics(panel: HTMLElement, snapshot: TabScrollMemory): void {
+  panel.dataset[DATA_VISIBLE_HEIGHT] = String(snapshot.visibleHeight)
+  panel.dataset[DATA_TOP_INSET] = String(snapshot.topInset)
+  panel.dataset[DATA_SCROLL_OFFSET] = String(snapshot.innerScrollTop)
+}
+
+function clearFrozenMetrics(panel: HTMLElement): void {
+  delete panel.dataset[DATA_VISIBLE_HEIGHT]
+  delete panel.dataset[DATA_TOP_INSET]
+  delete panel.dataset[DATA_SCROLL_OFFSET]
+}
+
+function applyFrozenStyles(
+  panel: HTMLElement,
+  snapshot: TabScrollMemory
+): FrozenTabState['previousStyles'] {
+  const previousStyles = {
+    height: panel.style.height,
+    maxHeight: panel.style.maxHeight,
+    minHeight: panel.style.minHeight,
+    overflowY: panel.style.overflowY,
+  }
+  const height = `${snapshot.visibleHeight}px`
+  panel.style.height = height
+  panel.style.minHeight = height
+  panel.style.maxHeight = height
+  panel.style.overflowY = 'hidden'
+  setFrozenMetrics(panel, snapshot)
+  return previousStyles
+}
+
+function restorePanel(panel: HTMLElement, previousStyles: FrozenTabState['previousStyles']): void {
+  panel.style.height = previousStyles.height
+  panel.style.maxHeight = previousStyles.maxHeight
+  panel.style.minHeight = previousStyles.minHeight
+  panel.style.overflowY = previousStyles.overflowY
+  clearFrozenMetrics(panel)
+}
+
+export function resolveTabScrollElements(
+  handle: TabsHandle | null,
+  tabId: string,
+  viewportSelector?: string
+): ResolvedTabScrollElements | null {
+  if (!viewportSelector) return null
+  const panel = handle?.getPanel(tabId)
+  if (!(panel instanceof HTMLElement)) {
+    return null
+  }
+
+  let viewport: Element | null = null
+  try {
+    viewport = panel.closest(viewportSelector)
+  } catch {
+    return null
+  }
+  if (!(viewport instanceof HTMLElement)) {
+    return null
+  }
+
+  return { panel, viewport }
+}
+
+export function captureTabScrollMemory(
+  elements: ResolvedTabScrollElements
+): TabScrollMemory | null {
+  const { panel, viewport } = elements
+  const panelRect = panel.getBoundingClientRect()
+  const viewportRect = viewport.getBoundingClientRect()
+  const visibleHeight = clamp(
+    Math.min(panelRect.bottom, viewportRect.bottom) - Math.max(panelRect.top, viewportRect.top),
+    0,
+    viewport.clientHeight
+  )
+
+  if (visibleHeight <= 0) {
+    return null
+  }
+
+  const topInset = Math.max(panelRect.top - viewportRect.top, 0)
+  const innerScrollTop = clamp(
+    Math.max(viewportRect.top - panelRect.top, 0),
+    0,
+    maxPanelScroll(panel, visibleHeight)
+  )
+
+  return {
+    innerScrollTop,
+    topInset,
+    visibleHeight,
+  }
+}
+
+export function freezeOutgoingTab(
+  elements: ResolvedTabScrollElements,
+  snapshot: TabScrollMemory
+): FrozenTabState {
+  const previousStyles = applyFrozenStyles(elements.panel, snapshot)
+
+  elements.panel.scrollTop = snapshot.innerScrollTop
+  if (snapshot.innerScrollTop > 0) {
+    elements.viewport.scrollTop = clamp(
+      elements.viewport.scrollTop - snapshot.innerScrollTop,
+      0,
+      maxViewportScroll(elements.viewport)
+    )
+  }
+
+  return {
+    panel: elements.panel,
+    previousStyles,
+    viewport: elements.viewport,
+  }
+}
+
+export function freezeIncomingTab(
+  elements: ResolvedTabScrollElements,
+  snapshot: TabScrollMemory
+): FrozenTabState {
+  const normalizedSnapshot: TabScrollMemory = {
+    topInset: clamp(snapshot.topInset, 0, elements.viewport.clientHeight),
+    visibleHeight: clamp(snapshot.visibleHeight, 1, elements.viewport.clientHeight),
+    innerScrollTop: 0,
+  }
+
+  normalizedSnapshot.innerScrollTop = clamp(
+    snapshot.innerScrollTop,
+    0,
+    maxPanelScroll(elements.panel, normalizedSnapshot.visibleHeight)
+  )
+
+  const nextViewportScrollTop = clamp(
+    panelDocumentTop(elements.panel, elements.viewport) - normalizedSnapshot.topInset,
+    0,
+    maxViewportScroll(elements.viewport)
+  )
+
+  const previousStyles = applyFrozenStyles(elements.panel, normalizedSnapshot)
+
+  elements.viewport.scrollTop = nextViewportScrollTop
+  elements.panel.scrollTop = normalizedSnapshot.innerScrollTop
+
+  return {
+    panel: elements.panel,
+    previousStyles,
+    viewport: elements.viewport,
+  }
+}
+
+export function finalizeFrozenIncomingTab(state: FrozenTabState): void {
+  const transferScrollTop = state.panel.scrollTop
+  restorePanel(state.panel, state.previousStyles)
+  state.viewport.scrollTop = clamp(
+    state.viewport.scrollTop + transferScrollTop,
+    0,
+    maxViewportScroll(state.viewport)
+  )
+  state.panel.scrollTop = 0
+}
+
+export function cleanupFrozenTab(state: FrozenTabState): void {
+  restorePanel(state.panel, state.previousStyles)
+  state.panel.scrollTop = 0
+}

--- a/packages/web/src/lib/view-transitions/tabs.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.test.tsx
@@ -1,8 +1,28 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Tabs, type Tab } from '@/components/tabs'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useEffect, useMemo } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useRoutedCarouselTabs } from './tabs'
+
+const { runViewTransitionMock } = vi.hoisted(() => ({
+  runViewTransitionMock: vi.fn(
+    ({
+      collectAfterEntries,
+      collectBeforeEntries,
+      update,
+    }: {
+      collectAfterEntries?: () => unknown
+      collectBeforeEntries?: () => unknown
+      update: () => void
+    }) => {
+      collectBeforeEntries?.()
+      update()
+      collectAfterEntries?.()
+      return Promise.resolve()
+    }
+  ),
+}))
 
 vi.mock('@/lib/static-mode', () => ({
   getBasePath: () => '/',
@@ -10,10 +30,7 @@ vi.mock('@/lib/static-mode', () => ({
 }))
 
 vi.mock('./runtime', () => ({
-  runViewTransition: ({ update }: { update: () => void }) => {
-    update()
-    return Promise.resolve()
-  },
+  runViewTransition: runViewTransitionMock,
 }))
 
 function RoutedTabsResetHarness() {
@@ -42,9 +59,175 @@ function RoutedTabsResetHarness() {
   )
 }
 
+function RoutedTabsScrollHarness() {
+  const tabs = useMemo<Tab[]>(
+    () => [
+      {
+        id: 'diff',
+        label: 'Diff',
+        content: (
+          <div data-testid="diff-content">
+            <div style={{ height: '1400px' }} />
+          </div>
+        ),
+      },
+      {
+        id: 'files',
+        label: 'Files',
+        content: (
+          <div data-testid="files-content">
+            <div style={{ height: '900px' }} />
+          </div>
+        ),
+      },
+    ],
+    []
+  )
+  const { tabsRef, selectedTab, setSelectedTab, onTabChange } = useRoutedCarouselTabs({
+    queryKey: 'gitPane',
+    tabs,
+    initialTab: 'diff',
+    viewportSelector: '.main-content',
+  })
+
+  return (
+    <div className="main-content" data-testid="viewport" style={{ height: 240, overflowY: 'auto' }}>
+      <div data-testid="page-shell">
+        <div style={{ height: 120 }} />
+        <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
+      </div>
+      <button type="button" onClick={() => setSelectedTab('diff')}>
+        Restore diff
+      </button>
+      <button type="button" onClick={() => setSelectedTab('files')}>
+        Restore files
+      </button>
+    </div>
+  )
+}
+
+function installScrollableTabLayoutMocks() {
+  const viewport = screen.getByTestId('viewport')
+  const panelHeights: Record<'diff' | 'files', number> = {
+    diff: 1400,
+    files: 900,
+  }
+  const baseOffset = 168
+  const viewportHeight = 240
+  let viewportScrollTop = 0
+
+  const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    writable: true,
+    value: function mockGetBoundingClientRect(this: HTMLElement) {
+      if (this.dataset.testid === 'viewport') {
+        return {
+          x: 0,
+          y: 0,
+          width: 320,
+          height: viewportHeight,
+          top: 0,
+          right: 320,
+          bottom: viewportHeight,
+          left: 0,
+          toJSON: () => ({}),
+        } satisfies DOMRect
+      }
+
+      if (this.dataset.tabPanel) {
+        const panelId = this.dataset.tabPanel as keyof typeof panelHeights
+        const fallbackHeight = panelHeights[panelId] ?? viewportHeight
+        const height = this.style.height ? Number.parseFloat(this.style.height) : fallbackHeight
+        const top = baseOffset - viewportScrollTop
+        return {
+          x: 0,
+          y: top,
+          width: 320,
+          height,
+          top,
+          right: 320,
+          bottom: top + height,
+          left: 0,
+          toJSON: () => ({}),
+        } satisfies DOMRect
+      }
+
+      return originalGetBoundingClientRect.call(this)
+    },
+  })
+
+  Object.defineProperty(viewport, 'clientHeight', {
+    configurable: true,
+    get: () => viewportHeight,
+  })
+
+  Object.defineProperty(viewport, 'scrollHeight', {
+    configurable: true,
+    get: () => {
+      const activePanel = document.querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+      const activePanelId = activePanel?.dataset.tabPanel as keyof typeof panelHeights | undefined
+      const fallbackHeight =
+        activePanelId != null ? (panelHeights[activePanelId] ?? viewportHeight) : viewportHeight
+      const renderedHeight = activePanel?.style.height
+        ? Number.parseFloat(activePanel.style.height)
+        : fallbackHeight
+      return baseOffset + renderedHeight
+    },
+  })
+
+  Object.defineProperty(viewport, 'scrollTop', {
+    configurable: true,
+    get: () => viewportScrollTop,
+    set: (value: number) => {
+      viewportScrollTop = value
+    },
+  })
+
+  for (const panel of document.querySelectorAll<HTMLElement>('[data-tab-panel]')) {
+    const panelId = panel.dataset.tabPanel as keyof typeof panelHeights | undefined
+    const naturalHeight =
+      panelId != null ? (panelHeights[panelId] ?? viewportHeight) : viewportHeight
+    let panelScrollTop = 0
+
+    Object.defineProperty(panel, 'clientHeight', {
+      configurable: true,
+      get: () => (panel.style.height ? Number.parseFloat(panel.style.height) : naturalHeight),
+    })
+    Object.defineProperty(panel, 'scrollHeight', {
+      configurable: true,
+      get: () => naturalHeight,
+    })
+    Object.defineProperty(panel, 'scrollTop', {
+      configurable: true,
+      get: () => panelScrollTop,
+      set: (value: number) => {
+        panelScrollTop = value
+      },
+    })
+  }
+
+  return {
+    viewport,
+    restore() {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        writable: true,
+        value: originalGetBoundingClientRect,
+      })
+    },
+  }
+}
+
 describe('useRoutedCarouselTabs', () => {
   beforeEach(() => {
     window.history.replaceState(null, '', '/git/commit/abc12345?gitPane=diff')
+    runViewTransitionMock.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('keeps tab selection when caller effects depend on setSelectedTab identity', async () => {
@@ -57,5 +240,74 @@ describe('useRoutedCarouselTabs', () => {
     })
 
     expect(window.location.search).toBe('?gitPane=files')
+    expect(runViewTransitionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores page scroll after animated tab switches when viewportSelector is provided', async () => {
+    render(<RoutedTabsScrollHarness />)
+    const { restore, viewport } = installScrollableTabLayoutMocks()
+
+    try {
+      viewport.scrollTop = 420
+
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      await waitFor(() => {
+        const activePanel = screen
+          .getByTestId('viewport')
+          .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+        expect(activePanel?.dataset.tabPanel).toBe('files')
+      })
+
+      viewport.scrollTop = 300
+      fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+      await waitFor(() => {
+        const activePanel = screen
+          .getByTestId('viewport')
+          .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+        expect(activePanel?.dataset.tabPanel).toBe('diff')
+        expect(viewport.scrollTop).toBe(420)
+      })
+
+      const activePanel = screen
+        .getByTestId('viewport')
+        .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+      expect(activePanel?.style.height).toBe('')
+      expect(activePanel?.dataset.tabScrollOffset).toBeUndefined()
+    } finally {
+      restore()
+    }
+  })
+
+  it('restores page scroll for direct non-animated setSelectedTab calls', async () => {
+    render(<RoutedTabsScrollHarness />)
+    const { restore, viewport } = installScrollableTabLayoutMocks()
+
+    try {
+      viewport.scrollTop = 420
+
+      fireEvent.click(screen.getByRole('button', { name: 'Restore files' }))
+
+      await waitFor(() => {
+        const activePanel = screen
+          .getByTestId('viewport')
+          .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+        expect(activePanel?.dataset.tabPanel).toBe('files')
+      })
+
+      viewport.scrollTop = 300
+      fireEvent.click(screen.getByRole('button', { name: 'Restore diff' }))
+
+      await waitFor(() => {
+        const activePanel = screen
+          .getByTestId('viewport')
+          .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+        expect(activePanel?.dataset.tabPanel).toBe('diff')
+        expect(viewport.scrollTop).toBe(420)
+      })
+    } finally {
+      restore()
+    }
   })
 })

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -11,8 +11,19 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react'
+import { flushSync } from 'react-dom'
 import type { VTArea } from './route-semantics'
 import { runViewTransition } from './runtime'
+import {
+  captureTabScrollMemory,
+  cleanupFrozenTab,
+  finalizeFrozenIncomingTab,
+  freezeIncomingTab,
+  freezeOutgoingTab,
+  resolveTabScrollElements,
+  type FrozenTabState,
+  type TabScrollMemory,
+} from './tab-scroll-freeze'
 
 export interface UseRoutedCarouselTabsOptions<TTabId extends string> {
   queryKey: string
@@ -21,6 +32,7 @@ export interface UseRoutedCarouselTabsOptions<TTabId extends string> {
   area?: VTArea
   history?: 'replace' | 'push'
   allowUnknownSelection?: boolean
+  viewportSelector?: string
 }
 
 interface RoutedTabsLocation {
@@ -193,9 +205,12 @@ export function useRoutedCarouselTabs<TTabId extends string>({
   area,
   history = 'replace',
   allowUnknownSelection = false,
+  viewportSelector,
 }: UseRoutedCarouselTabsOptions<TTabId>) {
   const { location, router } = useRoutedTabsLocation()
   const tabsRef = useRef<TabsHandle | null>(null)
+  const scrollMemoryByTabRef = useRef(new Map<string, TabScrollMemory>())
+  const frozenTabsRef = useRef(new Map<string, FrozenTabState>())
   const selectedFromLocation = useMemo(
     () =>
       resolveSelectedTab({
@@ -218,6 +233,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     selectedFromLocation,
     selectedTab,
     tabs,
+    viewportSelector,
   })
 
   latestRef.current = {
@@ -230,13 +246,107 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     selectedFromLocation,
     selectedTab,
     tabs,
+    viewportSelector,
   }
+
+  const cleanupFrozenTabById = useCallback((tabId: string) => {
+    const frozenState = frozenTabsRef.current.get(tabId)
+    if (!frozenState) {
+      return
+    }
+
+    cleanupFrozenTab(frozenState)
+    frozenTabsRef.current.delete(tabId)
+  }, [])
+
+  const cleanupAllFrozenTabs = useCallback(() => {
+    for (const frozenState of frozenTabsRef.current.values()) {
+      cleanupFrozenTab(frozenState)
+    }
+    frozenTabsRef.current.clear()
+  }, [])
+
+  const captureOutgoingTab = useCallback(
+    (tabId: string, nextViewportSelector?: string) => {
+      const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
+      if (!elements) {
+        return
+      }
+
+      const snapshot = captureTabScrollMemory(elements)
+      if (!snapshot) {
+        return
+      }
+
+      scrollMemoryByTabRef.current.set(tabId, snapshot)
+      cleanupFrozenTabById(tabId)
+      frozenTabsRef.current.set(tabId, freezeOutgoingTab(elements, snapshot))
+    },
+    [cleanupFrozenTabById]
+  )
+
+  const prepareIncomingTab = useCallback(
+    (tabId: string, nextViewportSelector?: string) => {
+      const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
+      if (!elements) {
+        return false
+      }
+
+      const snapshot = scrollMemoryByTabRef.current.get(tabId) ?? captureTabScrollMemory(elements)
+      if (!snapshot) {
+        return false
+      }
+
+      cleanupFrozenTabById(tabId)
+      frozenTabsRef.current.set(tabId, freezeIncomingTab(elements, snapshot))
+      return true
+    },
+    [cleanupFrozenTabById]
+  )
+
+  const finalizeIncomingTab = useCallback((tabId: string) => {
+    const frozenState = frozenTabsRef.current.get(tabId)
+    if (!frozenState) {
+      return
+    }
+
+    finalizeFrozenIncomingTab(frozenState)
+    frozenTabsRef.current.delete(tabId)
+  }, [])
 
   useEffect(() => {
     setSelectedTabState((current) =>
       current === selectedFromLocation ? current : selectedFromLocation
     )
   }, [selectedFromLocation])
+
+  useEffect(() => {
+    const validIds = new Set(tabs.map((tab) => tab.id))
+
+    for (const tabId of scrollMemoryByTabRef.current.keys()) {
+      if (!validIds.has(tabId as TTabId)) {
+        scrollMemoryByTabRef.current.delete(tabId)
+      }
+    }
+
+    for (const tabId of Array.from(frozenTabsRef.current.keys())) {
+      if (!validIds.has(tabId as TTabId)) {
+        cleanupFrozenTabById(tabId)
+      }
+    }
+  }, [cleanupFrozenTabById, tabs])
+
+  useEffect(() => {
+    scrollMemoryByTabRef.current.clear()
+    cleanupAllFrozenTabs()
+  }, [cleanupAllFrozenTabs, location.pathname])
+
+  useEffect(
+    () => () => {
+      cleanupAllFrozenTabs()
+    },
+    [cleanupAllFrozenTabs]
+  )
 
   const setSelectedTab = useCallback(
     (
@@ -256,6 +366,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
         selectedFromLocation: latestSelectedFromLocation,
         selectedTab: currentTab,
         tabs: latestTabs,
+        viewportSelector: latestViewportSelector,
       } = latestRef.current
 
       const validIds = new Set(latestTabs.map((tab) => tab.id))
@@ -298,31 +409,58 @@ export function useRoutedCarouselTabs<TTabId extends string>({
         navController.push(nextArea, href, latestLocation.state)
       }
 
+      const runSelectionWithScrollTransfer = (animated: boolean) => {
+        captureOutgoingTab(currentTab, latestViewportSelector)
+
+        if (!animated) {
+          flushSync(() => {
+            commitSelection()
+          })
+          prepareIncomingTab(nextTabId, latestViewportSelector)
+          finalizeIncomingTab(nextTabId)
+          cleanupFrozenTabById(currentTab)
+          return
+        }
+
+        let hasPreparedIncoming = false
+        void runViewTransition({
+          intent: {
+            area: resolveTabArea(latestLocation.pathname, latestArea),
+            kind: 'tab-carousel',
+            direction,
+          },
+          collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
+          collectAfterEntries: () => {
+            if (!hasPreparedIncoming) {
+              hasPreparedIncoming = prepareIncomingTab(nextTabId, latestViewportSelector)
+            }
+            return collectTabEntries(tabsRef.current, nextTabId)
+          },
+          update: commitSelection,
+        }).finally(() => {
+          if (!hasPreparedIncoming) {
+            prepareIncomingTab(nextTabId, latestViewportSelector)
+          }
+          finalizeIncomingTab(nextTabId)
+          cleanupFrozenTabById(currentTab)
+        })
+      }
+
       if (!options?.animate || currentTab === nextTabId) {
-        commitSelection()
+        runSelectionWithScrollTransfer(false)
         return
       }
 
       const currentIndex = latestTabs.findIndex((tab) => tab.id === currentTab)
       const nextIndex = latestTabs.findIndex((tab) => tab.id === nextTabId)
       if (currentIndex < 0 || nextIndex < 0) {
-        commitSelection()
+        runSelectionWithScrollTransfer(false)
         return
       }
       const direction = nextIndex >= currentIndex ? 'forward' : 'backward'
-
-      void runViewTransition({
-        intent: {
-          area: resolveTabArea(latestLocation.pathname, latestArea),
-          kind: 'tab-carousel',
-          direction,
-        },
-        collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
-        collectAfterEntries: () => collectTabEntries(tabsRef.current, nextTabId),
-        update: commitSelection,
-      })
+      runSelectionWithScrollTransfer(true)
     },
-    []
+    [captureOutgoingTab, cleanupFrozenTabById, finalizeIncomingTab, prepareIncomingTab]
   )
 
   return {


### PR DESCRIPTION
## Summary
- preserve page scroll across routed tab transitions by freezing each tab panel to its visible height during VT
- keep narrow git detail tabs in single-scroll mode by opting into viewport-based scroll transfer
- add a patch changeset for the fixed release group

## Validation
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
