### PR TITLE
fix: preserve Safari routed tab VT scroll state

### DIFF
--- a/.changeset/commit-detail-vt-scroll-memory.md
+++ b/.changeset/commit-detail-vt-scroll-memory.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Preserve commit detail tab viewport memory during routed view transitions, including file-tree route entry and single-scroll layouts where shorter tab content would otherwise clamp the restored scroll position.

--- a/.changeset/routed-tabs-scroll-root-memory.md
+++ b/.changeset/routed-tabs-scroll-root-memory.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Restore routed tab inner scroll roots after remounts, guard frozen tab cleanup across overlapping view transitions, and enable shared-element reuse for tab header layers during tab view transitions.

--- a/.changeset/safari-routed-tabs-selector-stability.md
+++ b/.changeset/safari-routed-tabs-selector-stability.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Avoid restoring stale routed-tab viewport scroll positions during Safari/WebKit tab rerenders, so commit-detail tree-to-diff reveals stay scrollable after roundtrips.

--- a/.changeset/safari-tab-vt-header-layering.md
+++ b/.changeset/safari-tab-vt-header-layering.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Keep routed tab headers above animating panel snapshots by splitting default tabs into dedicated view-transition layers for the header shell, active edge, and header foreground.

--- a/packages/web/src/components/git/git-file-tree.tsx
+++ b/packages/web/src/components/git/git-file-tree.tsx
@@ -365,6 +365,7 @@ export function GitFileTree({
       <div
         ref={scrollContainerRef}
         role="tree"
+        data-tab-scroll-root="true"
         aria-label="Changed files"
         onKeyDownCapture={(event) => {
           if (isVerticalScrollIntentKey(event.key)) {

--- a/packages/web/src/components/git/git-panel-detail.test.tsx
+++ b/packages/web/src/components/git/git-panel-detail.test.tsx
@@ -41,11 +41,17 @@ vi.mock('@/components/tabs', () => ({
       root: HTMLElement | null
       getTrigger: (tabId: string) => HTMLElement | null
       getPanel: (tabId: string) => HTMLElement | null
+      getHeaderShell: () => HTMLElement | null
+      getHeaderForeground: () => HTMLElement | null
+      getSelectionIndicator: () => HTMLElement | null
       getActiveTabId: () => string | null
     }>
   ) {
     const activeTab = tabs.find((tab) => tab.id === selectedTab) ?? tabs[0] ?? null
     const rootRef = useRef<HTMLDivElement | null>(null)
+    const headerShellRef = useRef<HTMLDivElement | null>(null)
+    const headerForegroundRef = useRef<HTMLDivElement | null>(null)
+    const selectionIndicatorRef = useRef<HTMLDivElement | null>(null)
     const triggerRefs = useRef(new Map<string, HTMLButtonElement | null>())
     const panelRefs = useRef(new Map<string, HTMLDivElement | null>())
 
@@ -55,6 +61,9 @@ vi.mock('@/components/tabs', () => ({
         root: rootRef.current,
         getTrigger: (tabId: string) => triggerRefs.current.get(tabId) ?? null,
         getPanel: (tabId: string) => panelRefs.current.get(tabId) ?? null,
+        getHeaderShell: () => headerShellRef.current,
+        getHeaderForeground: () => headerForegroundRef.current,
+        getSelectionIndicator: () => selectionIndicatorRef.current,
         getActiveTabId: () => activeTab?.id ?? null,
       }),
       [activeTab?.id]
@@ -67,7 +76,9 @@ vi.mock('@/components/tabs', () => ({
         data-active-tab={activeTab?.id ?? ''}
         className={className}
       >
-        <div className="tabs-strip">
+        <div ref={headerShellRef} data-tabs-header-shell="true" />
+        <div ref={selectionIndicatorRef} data-tabs-selection-indicator="true" />
+        <div ref={headerForegroundRef} data-tabs-header-foreground="true" className="tabs-strip">
           {tabs.map((tab) => (
             <button
               key={tab.id}

--- a/packages/web/src/components/git/git-panel-detail.test.tsx
+++ b/packages/web/src/components/git/git-panel-detail.test.tsx
@@ -367,6 +367,40 @@ const largeDiffPatchFiles = largeDiffFiles.map((file, index) => ({
   ].join('\n'),
 }))
 
+const replayScrollFiles = [
+  {
+    ...baseFile,
+    fileId: 'replay-app-kernel',
+    path: 'packages/app-server/src/app-kernel.ts',
+    displayPath: 'packages/app-server/src/app-kernel.ts',
+  },
+  {
+    ...baseFile,
+    fileId: 'replay-heartbeat-groups',
+    path: 'packages/app-server/src/heartbeat-groups.ts',
+    displayPath: 'packages/app-server/src/heartbeat-groups.ts',
+  },
+  {
+    ...baseFile,
+    fileId: 'replay-session-runtime',
+    path: 'packages/app-server/src/session-runtime.ts',
+    displayPath: 'packages/app-server/src/session-runtime.ts',
+  },
+]
+
+const replayScrollPatchFiles = replayScrollFiles.map((file, index) => ({
+  ...basePatchFile,
+  fileId: file.fileId,
+  path: file.path,
+  displayPath: file.displayPath,
+  patch: [
+    `diff --git a/${file.path} b/${file.path}`,
+    '@@ -1,3 +1,3 @@',
+    `-export const before_${index + 1} = 0`,
+    `+export const after_${index + 1} = 1`,
+  ].join('\n'),
+}))
+
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
@@ -631,6 +665,337 @@ describe('GitEntryDetailPanel', () => {
       await waitFor(() => {
         expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
       })
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        writable: true,
+        value: originalGetBoundingClientRect,
+      })
+    }
+  })
+
+  it('scrolls the outer narrow viewport to the selected diff card after tree navigation', async () => {
+    stubNarrowResizeObserver()
+
+    const targetFile = largeDiffFiles.at(-1)
+    expect(targetFile).toBeTruthy()
+    if (!targetFile) {
+      return
+    }
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      writable: true,
+      value: function mockGetBoundingClientRect(this: HTMLElement) {
+        if (this.dataset.testid === 'scroll-shell') {
+          return {
+            x: 0,
+            y: 40,
+            width: 420,
+            height: 320,
+            top: 40,
+            right: 420,
+            bottom: 360,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        if (this.dataset.testid === 'git-diff-viewport') {
+          return {
+            x: 0,
+            y: 104,
+            width: 420,
+            height: 240,
+            top: 104,
+            right: 420,
+            bottom: 344,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        if (this.tagName === 'SECTION' && this.dataset.fileId === targetFile.fileId) {
+          return {
+            x: 0,
+            y: 860,
+            width: 420,
+            height: 180,
+            top: 860,
+            right: 420,
+            bottom: 1040,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        return originalGetBoundingClientRect.call(this)
+      },
+    })
+
+    try {
+      renderWithQueryClient(
+        <div data-testid="scroll-shell" style={{ height: '320px', overflowY: 'auto' }}>
+          <GitEntryDetailPanel
+            selector={{ type: 'commit', hash: baseEntry.hash }}
+            entry={{
+              ...baseEntry,
+              diff: { files: largeDiffFiles.length, insertions: 56, deletions: 28 },
+            }}
+            files={largeDiffFiles}
+            eagerFiles={largeDiffPatchFiles}
+            isLoading={false}
+            error={null}
+          />
+        </div>
+      )
+
+      const scrollShell = screen.getByTestId('scroll-shell')
+      Object.defineProperty(scrollShell, 'clientHeight', {
+        configurable: true,
+        value: 320,
+      })
+      Object.defineProperty(scrollShell, 'scrollHeight', {
+        configurable: true,
+        value: 4000,
+      })
+
+      const scrollToMock = vi.fn(({ top }: ScrollToOptions) => {
+        Object.defineProperty(scrollShell, 'scrollTop', {
+          configurable: true,
+          value: top ?? 0,
+          writable: true,
+        })
+      })
+      Object.defineProperty(scrollShell, 'scrollTo', {
+        configurable: true,
+        writable: true,
+        value: scrollToMock,
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+      fireEvent.click(screen.getByRole('treeitem', { name: new RegExp(targetFile.displayPath) }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+      })
+
+      await waitFor(() => {
+        expect(scrollToMock).toHaveBeenCalled()
+      })
+
+      expect(scrollToMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          behavior: 'auto',
+          top: expect.any(Number),
+        })
+      )
+      expect(
+        (scrollToMock.mock.lastCall?.[0] as ScrollToOptions | undefined)?.top ?? 0
+      ).toBeGreaterThan(700)
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        writable: true,
+        value: originalGetBoundingClientRect,
+      })
+    }
+  })
+
+  it('retries a tree-selection reveal when another restore rewinds the viewport before verification settles', async () => {
+    stubNarrowResizeObserver()
+
+    const frameQueue: FrameRequestCallback[] = []
+    const flushNextFrame = () => {
+      const callback = frameQueue.shift()
+      callback?.(16)
+    }
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frameQueue.push(callback)
+      return frameQueue.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+    let scrollShell: HTMLElement | null = null
+    const absoluteTopByFileId = new Map([
+      ['replay-app-kernel', 544],
+      ['replay-heartbeat-groups', 744],
+      ['replay-session-runtime', 944],
+    ])
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      writable: true,
+      value: function mockGetBoundingClientRect(this: HTMLElement) {
+        if (this.dataset.testid === 'scroll-shell') {
+          return {
+            x: 0,
+            y: 40,
+            width: 420,
+            height: 320,
+            top: 40,
+            right: 420,
+            bottom: 360,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        if (this.dataset.testid === 'git-diff-viewport') {
+          return {
+            x: 0,
+            y: 104,
+            width: 420,
+            height: 240,
+            top: 104,
+            right: 420,
+            bottom: 344,
+            left: 0,
+            toJSON: () => ({}),
+          } satisfies DOMRect
+        }
+
+        if (this.tagName === 'SECTION') {
+          const fileId = this.dataset.fileId
+          const absoluteTop = fileId ? absoluteTopByFileId.get(fileId) : null
+          if (absoluteTop != null && scrollShell) {
+            const top = absoluteTop - scrollShell.scrollTop
+            return {
+              x: 0,
+              y: top,
+              width: 420,
+              height: 180,
+              top,
+              right: 420,
+              bottom: top + 180,
+              left: 0,
+              toJSON: () => ({}),
+            } satisfies DOMRect
+          }
+        }
+
+        return originalGetBoundingClientRect.call(this)
+      },
+    })
+
+    try {
+      renderWithQueryClient(
+        <div data-testid="scroll-shell" style={{ height: '320px', overflowY: 'auto' }}>
+          <GitEntryDetailPanel
+            selector={{ type: 'commit', hash: baseEntry.hash }}
+            entry={{
+              ...baseEntry,
+              diff: { files: replayScrollFiles.length, insertions: 9, deletions: 3 },
+            }}
+            files={replayScrollFiles}
+            eagerFiles={replayScrollPatchFiles}
+            isLoading={false}
+            error={null}
+          />
+        </div>
+      )
+
+      scrollShell = screen.getByTestId('scroll-shell')
+      Object.defineProperty(scrollShell, 'clientHeight', {
+        configurable: true,
+        value: 320,
+      })
+      Object.defineProperty(scrollShell, 'scrollHeight', {
+        configurable: true,
+        value: 4000,
+      })
+      Object.defineProperty(scrollShell, 'scrollTop', {
+        configurable: true,
+        value: 0,
+        writable: true,
+      })
+
+      const scrollToMock = vi.fn(({ top }: ScrollToOptions) => {
+        Object.defineProperty(scrollShell, 'scrollTop', {
+          configurable: true,
+          value: top ?? 0,
+          writable: true,
+        })
+      })
+      Object.defineProperty(scrollShell, 'scrollTo', {
+        configurable: true,
+        writable: true,
+        value: scrollToMock,
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'files')
+      })
+
+      fireEvent.click(
+        screen.getByRole('treeitem', { name: /packages\/app-server\/src\/session-runtime\.ts/i })
+      )
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+      })
+
+      await act(async () => {
+        flushNextFrame()
+        flushNextFrame()
+      })
+
+      const sessionRuntimeTop =
+        (scrollToMock.mock.lastCall?.[0] as ScrollToOptions | undefined)?.top ?? null
+      expect(sessionRuntimeTop).toEqual(expect.any(Number))
+      expect(sessionRuntimeTop).toBeGreaterThan(0)
+      expect(scrollShell.scrollTop).toBe(sessionRuntimeTop)
+
+      scrollToMock.mockClear()
+
+      fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'files')
+      })
+
+      fireEvent.click(
+        screen.getByRole('treeitem', { name: /packages\/app-server\/src\/app-kernel\.ts/i })
+      )
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+      })
+
+      await act(async () => {
+        flushNextFrame()
+      })
+
+      const appKernelTop =
+        (scrollToMock.mock.lastCall?.[0] as ScrollToOptions | undefined)?.top ?? null
+      expect(appKernelTop).toEqual(expect.any(Number))
+      expect(appKernelTop).toBeLessThan(sessionRuntimeTop ?? Number.POSITIVE_INFINITY)
+      expect(scrollShell.scrollTop).toBe(appKernelTop)
+
+      Object.defineProperty(scrollShell, 'scrollTop', {
+        configurable: true,
+        value: sessionRuntimeTop,
+        writable: true,
+      })
+
+      await act(async () => {
+        flushNextFrame()
+        flushNextFrame()
+      })
+
+      const scrollTargets = scrollToMock.mock.calls.map(
+        ([options]) => (options as ScrollToOptions | undefined)?.top ?? null
+      )
+      expect(scrollTargets.filter((top) => top === appKernelTop).length).toBeGreaterThanOrEqual(2)
+      expect(scrollShell.scrollTop).toBe(appKernelTop)
     } finally {
       Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
         configurable: true,

--- a/packages/web/src/components/git/git-panel-detail.test.tsx
+++ b/packages/web/src/components/git/git-panel-detail.test.tsx
@@ -494,6 +494,73 @@ describe('GitEntryDetailPanel', () => {
     expect(frameStates.every((state) => state === 'diff')).toBe(true)
   })
 
+  it('does not replay a completed tree-selection diff scroll on later tab activations', async () => {
+    const frameQueue: FrameRequestCallback[] = []
+    const frameStates: string[] = []
+
+    const flushFrames = (limit = 8) => {
+      for (let index = 0; index < limit && frameQueue.length > 0; index += 1) {
+        const callback = frameQueue.shift()
+        callback?.((index + 1) * 16)
+      }
+    }
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frameStates.push(screen.getByTestId('tabs').getAttribute('data-active-tab') ?? '')
+      frameQueue.push(callback)
+      return frameQueue.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    renderWithQueryClient(
+      <GitEntryDetailPanel
+        selector={{ type: 'commit', hash: baseEntry.hash }}
+        entry={baseEntry}
+        files={[baseFile]}
+        eagerFiles={[basePatchFile]}
+        isLoading={false}
+        error={null}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'files')
+    })
+
+    fireEvent.click(screen.getByRole('treeitem', { name: /src\/git-panel\.ts/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+    })
+
+    await act(async () => {
+      flushFrames()
+    })
+
+    expect(frameStates.length).toBeGreaterThan(0)
+    expect(frameStates.every((state) => state === 'diff')).toBe(true)
+
+    const initialFrameCount = frameStates.length
+
+    fireEvent.click(screen.getByRole('button', { name: /File Tree/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'files')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Diff Stream/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('tabs')).toHaveAttribute('data-active-tab', 'diff')
+    })
+
+    await act(async () => {
+      flushFrames()
+    })
+
+    expect(frameStates).toHaveLength(initialFrameCount)
+  })
+
   it('renders full large narrow diff lists and switches back to diff after tree selection', async () => {
     stubNarrowResizeObserver()
     const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect

--- a/packages/web/src/components/git/git-panel-detail.tsx
+++ b/packages/web/src/components/git/git-panel-detail.tsx
@@ -45,6 +45,14 @@ interface GitEntryPatchResponse {
   file: GitEntryFilePatch | null
 }
 
+interface PendingDiffScrollCommand {
+  deadline: number
+  fileId: string
+  lastAttemptVersion: string | null
+  phase: 'queued' | 'verifying' | 'await-layout'
+  token: number
+}
+
 type GitPatchLoader = (options: {
   selector: GitEntrySelector
   fileId: string
@@ -220,7 +228,7 @@ export function GitEntryDetailPanel({
     queryKey: 'gitPane',
     tabs: paneTabs,
     initialTab: 'diff',
-    viewportSelector: '.main-content, .bottom-area',
+    viewportSelector: ['.main-content', '.bottom-area'],
   })
   const eagerFileIdSet = useMemo(() => new Set(eagerFiles.map((file) => file.fileId)), [eagerFiles])
   const [requestedFileIds, setRequestedFileIds] = useState<string[]>([])
@@ -229,13 +237,14 @@ export function GitEntryDetailPanel({
   const [diffViewportNode, setDiffViewportNode] = useState<HTMLDivElement | null>(null)
   const [treeRevealRequest, setTreeRevealRequest] = useState<GitFileTreeRevealRequest | null>(null)
   const cardNodesRef = useRef(new Map<string, HTMLElement>())
-  const pendingScrollFileIdRef = useRef<string | null>(null)
-  const pendingScrollDeadlineRef = useRef(0)
+  const pendingDiffScrollCommandRef = useRef<PendingDiffScrollCommand | null>(null)
+  const pendingDiffScrollTokenRef = useRef(0)
   const pendingScrollFrameRef = useRef<number | null>(null)
   const schedulePendingScrollRef = useRef<() => void>(() => {})
   const tabsRootRef = useRef<HTMLDivElement | null>(null)
   const treeRevealNonceRef = useRef(0)
   const revealNavigationSourceRef = useRef<'diff' | 'tree' | null>(null)
+  const didInitializeSelectorRef = useRef(false)
   const [wideTreeViewportNode, setWideTreeViewportNode] = useState<HTMLDivElement | null>(null)
   const wideTreeHeight = useViewportConstrainedHeight({
     target: wideTreeViewportNode,
@@ -249,6 +258,37 @@ export function GitEntryDetailPanel({
   const markDiffNavigation = useCallback(() => {
     revealNavigationSourceRef.current = 'diff'
   }, [])
+
+  const clearPendingDiffScroll = useCallback((token?: number) => {
+    const currentCommand = pendingDiffScrollCommandRef.current
+    if (!currentCommand) {
+      return
+    }
+
+    if (token != null && currentCommand.token !== token) {
+      return
+    }
+
+    pendingDiffScrollCommandRef.current = null
+  }, [])
+
+  const cancelPendingDiffScroll = useCallback(() => {
+    clearPendingDiffScroll()
+  }, [clearPendingDiffScroll])
+
+  const handleDiffUserScrollIntent = useCallback(() => {
+    markDiffNavigation()
+    cancelPendingDiffScroll()
+  }, [cancelPendingDiffScroll, markDiffNavigation])
+
+  const handleDiffKeyDownCapture = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (isScrollIntentEventKey(event)) {
+        handleDiffUserScrollIntent()
+      }
+    },
+    [handleDiffUserScrollIntent]
+  )
 
   const requestPatch = useCallback(
     (fileId: string) => {
@@ -279,13 +319,19 @@ export function GitEntryDetailPanel({
   )
 
   useEffect(() => {
-    setSelectedTab('diff')
+    if (didInitializeSelectorRef.current) {
+      queueMicrotask(() => {
+        setSelectedTab('diff')
+      })
+    } else {
+      didInitializeSelectorRef.current = true
+    }
+
     setRequestedFileIds([])
     setTreeRevealRequest(null)
     revealNavigationSourceRef.current = null
     cardNodesRef.current.clear()
-    pendingScrollFileIdRef.current = null
-    pendingScrollDeadlineRef.current = 0
+    pendingDiffScrollCommandRef.current = null
     if (pendingScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(pendingScrollFrameRef.current)
       pendingScrollFrameRef.current = null
@@ -376,6 +422,10 @@ export function GitEntryDetailPanel({
           .join('|'),
       ].join('|'),
     [eagerFiles, patchQueries]
+  )
+  const diffContentVersion = useMemo(
+    () => [files.map((file) => file.fileId).join('|'), patchLayoutVersion].join('::'),
+    [files, patchLayoutVersion]
   )
   const treeFiles = useMemo(
     () =>
@@ -498,33 +548,57 @@ export function GitEntryDetailPanel({
       return
     }
 
-    const fileId = pendingScrollFileIdRef.current
-    if (!fileId) {
+    const command = pendingDiffScrollCommandRef.current
+    if (!command) {
       return
     }
 
-    if (
-      pendingScrollDeadlineRef.current > 0 &&
-      window.performance.now() > pendingScrollDeadlineRef.current
-    ) {
-      pendingScrollFileIdRef.current = null
-      pendingScrollDeadlineRef.current = 0
+    if (window.performance.now() > command.deadline) {
+      clearPendingDiffScroll(command.token)
       return
     }
 
-    const node = cardNodesRef.current.get(fileId)
+    const node = cardNodesRef.current.get(command.fileId)
     if (!node) {
+      pendingDiffScrollCommandRef.current = {
+        ...command,
+        lastAttemptVersion: diffContentVersion,
+        phase: 'await-layout',
+      }
       return
     }
 
     if (isCardAligned(node, diffViewportNode, diffScrollOffset)) {
-      pendingScrollFileIdRef.current = null
-      pendingScrollDeadlineRef.current = 0
+      clearPendingDiffScroll(command.token)
+      return
+    }
+
+    if (command.phase === 'verifying') {
+      pendingDiffScrollCommandRef.current = {
+        ...command,
+        lastAttemptVersion: diffContentVersion,
+        phase: 'await-layout',
+      }
       return
     }
 
     scrollCardIntoView(node, diffViewportNode, diffScrollOffset)
-  }, [activePane, diffScrollOffset, diffViewportNode, wide])
+    if (pendingDiffScrollCommandRef.current?.token === command.token) {
+      pendingDiffScrollCommandRef.current = {
+        ...command,
+        lastAttemptVersion: diffContentVersion,
+        phase: 'verifying',
+      }
+      schedulePendingScrollRef.current()
+    }
+  }, [
+    activePane,
+    clearPendingDiffScroll,
+    diffContentVersion,
+    diffScrollOffset,
+    diffViewportNode,
+    wide,
+  ])
 
   const schedulePendingScroll = useCallback(() => {
     if (pendingScrollFrameRef.current !== null) {
@@ -540,8 +614,13 @@ export function GitEntryDetailPanel({
 
   const queueScrollToFile = useCallback(
     (fileId: string) => {
-      pendingScrollFileIdRef.current = fileId
-      pendingScrollDeadlineRef.current = window.performance.now() + DIFF_SCROLL_DEADLINE_MS
+      pendingDiffScrollCommandRef.current = {
+        deadline: window.performance.now() + DIFF_SCROLL_DEADLINE_MS,
+        fileId,
+        lastAttemptVersion: null,
+        phase: 'queued',
+        token: ++pendingDiffScrollTokenRef.current,
+      }
 
       if (!wide && activePane !== 'diff') {
         return
@@ -553,10 +632,31 @@ export function GitEntryDetailPanel({
   )
 
   useEffect(() => {
-    if ((!wide && activePane !== 'diff') || pendingScrollFileIdRef.current === null) return
+    const command = pendingDiffScrollCommandRef.current
+    if ((!wide && activePane !== 'diff') || !command) return
+
+    if (command.phase === 'queued') {
+      schedulePendingScroll()
+      return
+    }
+
+    if (command.phase === 'await-layout' && command.lastAttemptVersion !== diffContentVersion) {
+      pendingDiffScrollCommandRef.current = {
+        ...command,
+        phase: 'queued',
+      }
+      schedulePendingScroll()
+    }
+  }, [activePane, diffContentVersion, schedulePendingScroll, wide])
+
+  useEffect(() => {
+    const command = pendingDiffScrollCommandRef.current
+    if (!command || command.phase !== 'verifying') {
+      return
+    }
 
     schedulePendingScroll()
-  }, [activePane, files, patchLayoutVersion, schedulePendingScroll, wide])
+  }, [diffContentVersion, schedulePendingScroll])
 
   useEffect(
     () => () => {
@@ -777,14 +877,10 @@ export function GitEntryDetailPanel({
           </section>
           <section
             className="min-w-0 space-y-2"
-            onKeyDownCapture={(event) => {
-              if (isScrollIntentEventKey(event)) {
-                markDiffNavigation()
-              }
-            }}
-            onPointerDownCapture={markDiffNavigation}
-            onTouchMoveCapture={markDiffNavigation}
-            onWheelCapture={markDiffNavigation}
+            onKeyDownCapture={handleDiffKeyDownCapture}
+            onPointerDownCapture={handleDiffUserScrollIntent}
+            onTouchMoveCapture={handleDiffUserScrollIntent}
+            onWheelCapture={handleDiffUserScrollIntent}
           >
             <div className="flex items-center gap-2 text-sm font-medium">
               <Files className="h-4 w-4 shrink-0" />
@@ -817,6 +913,10 @@ export function GitEntryDetailPanel({
                     data-testid="git-diff-viewport"
                     className="pt-3"
                     style={diffViewportStyle}
+                    onKeyDownCapture={handleDiffKeyDownCapture}
+                    onPointerDownCapture={handleDiffUserScrollIntent}
+                    onTouchMoveCapture={handleDiffUserScrollIntent}
+                    onWheelCapture={handleDiffUserScrollIntent}
                   >
                     {diffStreamContent}
                   </div>

--- a/packages/web/src/components/git/git-panel-detail.tsx
+++ b/packages/web/src/components/git/git-panel-detail.tsx
@@ -48,8 +48,9 @@ interface GitEntryPatchResponse {
 interface PendingDiffScrollCommand {
   deadline: number
   fileId: string
+  lastAppliedContainerScrollTop: number | null
   lastAttemptVersion: string | null
-  phase: 'queued' | 'verifying' | 'await-layout'
+  phase: 'queued' | 'verifying' | 'settling' | 'await-layout'
   token: number
 }
 
@@ -117,43 +118,66 @@ function scrollCardIntoView(
   node: HTMLElement,
   fallbackRoot: HTMLElement | null,
   topOffset: number
-): void {
+): {
+  appliedTop: number
+  requestedTop: number
+  wasClamped: boolean
+} | null {
   const scrollContainer =
     findVerticalScrollContainer(node, { allowNonScrollable: true }) ??
     findVerticalScrollContainer(fallbackRoot, { allowNonScrollable: true })
 
   if (!scrollContainer) {
     node.scrollIntoView({ block: 'start', behavior: 'auto' })
-    return
+    return null
   }
 
   const nodeRect = node.getBoundingClientRect()
   const containerRect = scrollContainer.getBoundingClientRect()
-  const nextTop = scrollContainer.scrollTop + nodeRect.top - containerRect.top - topOffset
+  const requestedTop = Math.max(
+    scrollContainer.scrollTop + nodeRect.top - containerRect.top - topOffset,
+    0
+  )
 
   scrollContainer.scrollTo({
-    top: Math.max(nextTop, 0),
+    top: requestedTop,
     behavior: 'auto',
   })
+
+  const appliedTop = scrollContainer.scrollTop
+  return {
+    appliedTop,
+    requestedTop,
+    wasClamped: appliedTop + 1 < requestedTop,
+  }
 }
 
 function isCardAligned(
   node: HTMLElement,
   fallbackRoot: HTMLElement | null,
   topOffset: number
-): boolean {
+): {
+  aligned: boolean
+  containerScrollTop: number | null
+} {
   const scrollContainer =
     findVerticalScrollContainer(node, { allowNonScrollable: true }) ??
     findVerticalScrollContainer(fallbackRoot, { allowNonScrollable: true })
   const nodeRect = node.getBoundingClientRect()
 
   if (!scrollContainer) {
-    return Math.abs(nodeRect.top - topOffset) <= DIFF_SCROLL_ALIGNMENT_TOLERANCE
+    return {
+      aligned: Math.abs(nodeRect.top - topOffset) <= DIFF_SCROLL_ALIGNMENT_TOLERANCE,
+      containerScrollTop: null,
+    }
   }
 
   const containerRect = scrollContainer.getBoundingClientRect()
   const targetTop = containerRect.top + topOffset
-  return Math.abs(nodeRect.top - targetTop) <= DIFF_SCROLL_ALIGNMENT_TOLERANCE
+  return {
+    aligned: Math.abs(nodeRect.top - targetTop) <= DIFF_SCROLL_ALIGNMENT_TOLERANCE,
+    containerScrollTop: scrollContainer.scrollTop,
+  }
 }
 
 function entryIcon(entry: DashboardGitEntry) {
@@ -330,7 +354,6 @@ export function GitEntryDetailPanel({
     setRequestedFileIds([])
     setTreeRevealRequest(null)
     revealNavigationSourceRef.current = null
-    cardNodesRef.current.clear()
     pendingDiffScrollCommandRef.current = null
     if (pendingScrollFrameRef.current !== null) {
       window.cancelAnimationFrame(pendingScrollFrameRef.current)
@@ -558,6 +581,16 @@ export function GitEntryDetailPanel({
       return
     }
 
+    const targetPatchStatus = patchStateByFileId.get(command.fileId)?.status ?? 'idle'
+    if (!wide && targetPatchStatus !== 'ready') {
+      pendingDiffScrollCommandRef.current = {
+        ...command,
+        lastAttemptVersion: diffContentVersion,
+        phase: 'await-layout',
+      }
+      return
+    }
+
     const node = cardNodesRef.current.get(command.fileId)
     if (!node) {
       pendingDiffScrollCommandRef.current = {
@@ -568,24 +601,63 @@ export function GitEntryDetailPanel({
       return
     }
 
-    if (isCardAligned(node, diffViewportNode, diffScrollOffset)) {
+    const alignment = isCardAligned(node, diffViewportNode, diffScrollOffset)
+    const scrollWasExternallyRestored =
+      alignment.containerScrollTop != null &&
+      command.lastAppliedContainerScrollTop != null &&
+      Math.abs(alignment.containerScrollTop - command.lastAppliedContainerScrollTop) > 1
+
+    if (alignment.aligned) {
+      if (command.phase === 'verifying') {
+        pendingDiffScrollCommandRef.current = {
+          ...command,
+          lastAttemptVersion: diffContentVersion,
+          phase: 'settling',
+        }
+        schedulePendingScrollRef.current()
+        return
+      }
+
       clearPendingDiffScroll(command.token)
       return
     }
 
-    if (command.phase === 'verifying') {
+    if (command.phase === 'verifying' || command.phase === 'settling') {
+      if (scrollWasExternallyRestored) {
+        pendingDiffScrollCommandRef.current = {
+          ...command,
+          lastAppliedContainerScrollTop: null,
+          lastAttemptVersion: diffContentVersion,
+          phase: 'queued',
+        }
+        schedulePendingScrollRef.current()
+        return
+      }
+
       pendingDiffScrollCommandRef.current = {
         ...command,
+        lastAppliedContainerScrollTop: null,
         lastAttemptVersion: diffContentVersion,
         phase: 'await-layout',
       }
       return
     }
 
-    scrollCardIntoView(node, diffViewportNode, diffScrollOffset)
+    const scrollAttempt = scrollCardIntoView(node, diffViewportNode, diffScrollOffset)
     if (pendingDiffScrollCommandRef.current?.token === command.token) {
+      if (scrollAttempt?.wasClamped) {
+        pendingDiffScrollCommandRef.current = {
+          ...command,
+          lastAppliedContainerScrollTop: scrollAttempt.appliedTop,
+          lastAttemptVersion: diffContentVersion,
+          phase: 'await-layout',
+        }
+        return
+      }
+
       pendingDiffScrollCommandRef.current = {
         ...command,
+        lastAppliedContainerScrollTop: scrollAttempt?.appliedTop ?? null,
         lastAttemptVersion: diffContentVersion,
         phase: 'verifying',
       }
@@ -597,6 +669,7 @@ export function GitEntryDetailPanel({
     diffContentVersion,
     diffScrollOffset,
     diffViewportNode,
+    patchStateByFileId,
     wide,
   ])
 
@@ -617,6 +690,7 @@ export function GitEntryDetailPanel({
       pendingDiffScrollCommandRef.current = {
         deadline: window.performance.now() + DIFF_SCROLL_DEADLINE_MS,
         fileId,
+        lastAppliedContainerScrollTop: null,
         lastAttemptVersion: null,
         phase: 'queued',
         token: ++pendingDiffScrollTokenRef.current,
@@ -672,7 +746,7 @@ export function GitEntryDetailPanel({
       requestPatch(fileId)
       queueScrollToFile(fileId)
       if (!wide) {
-        setSelectedTab('diff')
+        setSelectedTab('diff', { transferScroll: false })
       }
     },
     [queueScrollToFile, requestPatch, setSelectedTab, wide]
@@ -693,6 +767,10 @@ export function GitEntryDetailPanel({
         (currentRoot) =>
           currentRoot ?? findVerticalScrollContainer(node, { allowNonScrollable: true })
       )
+
+      if (pendingDiffScrollCommandRef.current?.fileId === fileId) {
+        schedulePendingScrollRef.current()
+      }
     },
     [setPrefetchObservedNode, setVisibleObservedNode]
   )

--- a/packages/web/src/components/tabs.test.tsx
+++ b/packages/web/src/components/tabs.test.tsx
@@ -1,7 +1,7 @@
 import { createEvent, fireEvent, render, within } from '@testing-library/react'
-import { useEffect } from 'react'
+import { createRef, useEffect } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { Tabs, type Tab } from './tabs'
+import { Tabs, type Tab, type TabsHandle } from './tabs'
 
 const tabs: Tab[] = [
   { id: 'a', label: 'A', content: <div>A content</div> },
@@ -73,20 +73,88 @@ describe('Tabs double-click behavior', () => {
 
     const actions = container.querySelector('[data-tabs-actions="true"]')
     expect(actions?.className).toContain('bg-terminal')
+    expect(container.querySelector('[data-tabs-selection-indicator="true"]')).toBeNull()
   })
 
   it('renders the default variant with a surfaced header background', () => {
     const { container } = render(<Tabs tabs={tabs} selectedTab="a" actions={<button>x</button>} />)
 
     const header = container.querySelector('.tabs-header')
-    expect(header?.className).toContain('bg-card/95')
-    expect(header?.className).toContain('rounded-md')
+    expect(header?.className).toContain('sticky')
 
-    const selected = within(container).getByRole('button', { name: 'A' })
-    expect(selected.className).toContain('bg-background/70')
+    const headerShell = container.querySelector('[data-tabs-header-shell="true"]')
+    expect(headerShell?.className).toContain('bg-card/95')
+    expect(headerShell?.className).toContain('rounded-md')
+
+    const indicator = container.querySelector('[data-tabs-selection-indicator="true"]')
+    expect(indicator).not.toBeNull()
 
     const actions = container.querySelector('[data-tabs-actions="true"]')
-    expect(actions?.className).toContain('bg-card/95')
+    expect(actions?.className).toContain('border-l')
+  })
+
+  it('exposes default VT layer handles and syncs the selection indicator to the active tab', () => {
+    const handleRef = createRef<TabsHandle>()
+    const rect = (left: number, top: number, width: number, height: number) =>
+      ({
+        x: left,
+        y: top,
+        left,
+        top,
+        width,
+        height,
+        right: left + width,
+        bottom: top + height,
+        toJSON: () => ({}),
+      }) satisfies DOMRect
+
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: function mockGetBoundingClientRect(this: HTMLElement) {
+        if (this.classList.contains('tabs-header')) {
+          return rect(20, 40, 320, 44)
+        }
+
+        if (this.dataset.tabId === 'a') {
+          return rect(36, 40, 80, 36)
+        }
+
+        if (this.dataset.tabId === 'b') {
+          return rect(128, 40, 96, 36)
+        }
+
+        return originalGetBoundingClientRect.call(this)
+      },
+    })
+
+    try {
+      const { container, rerender } = render(
+        <Tabs ref={handleRef} tabs={tabs} selectedTab="a" actions={<button>x</button>} />
+      )
+
+      const indicator = handleRef.current?.getSelectionIndicator()
+      expect(handleRef.current?.getHeaderShell()).toBe(
+        container.querySelector('[data-tabs-header-shell="true"]')
+      )
+      expect(handleRef.current?.getHeaderForeground()).toBe(
+        container.querySelector('[data-tabs-header-foreground="true"]')
+      )
+      expect(indicator?.style.transform).toBe('translate(16px, 0px)')
+      expect(indicator?.style.width).toBe('80px')
+      expect(indicator?.style.height).toBe('36px')
+
+      rerender(<Tabs ref={handleRef} tabs={tabs} selectedTab="b" actions={<button>x</button>} />)
+
+      expect(indicator?.style.transform).toBe('translate(108px, 0px)')
+      expect(indicator?.style.width).toBe('96px')
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: originalGetBoundingClientRect,
+      })
+    }
   })
 
   it('mounts tab styles in document head instead of rendering style text in the body', () => {

--- a/packages/web/src/components/tabs.tsx
+++ b/packages/web/src/components/tabs.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useId,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -51,6 +52,9 @@ export interface TabsHandle {
   root: HTMLElement | null
   getTrigger: (tabId: string) => HTMLElement | null
   getPanel: (tabId: string) => HTMLElement | null
+  getHeaderShell: () => HTMLElement | null
+  getHeaderForeground: () => HTMLElement | null
+  getSelectionIndicator: () => HTMLElement | null
   getActiveTabId: () => string | null
 }
 
@@ -103,16 +107,6 @@ const tabsStyleText = (id: string) => {
       content: '►';
       left: calc(anchor(right) - 0.5rem);
       transform: scaleX(0.5);
-    }
-
-    #${id}[data-tabs-variant='default'] .tabs-button > button.tab-selected {
-      background-image: linear-gradient(
-        to bottom,
-        transparent,
-        transparent calc(100% - 2px),
-        var(--primary) calc(100% - 2px),
-        var(--primary)
-      );
     }
 
     #${id} .tabs-strip {
@@ -182,11 +176,17 @@ function TabsImpl(
   const dropIndicatorRef = useRef<DropIndicator | null>(null)
   const contentOrderRef = useRef<string[]>(tabs.map((tab) => tab.id))
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const headerRef = useRef<HTMLDivElement | null>(null)
+  const headerShellRef = useRef<HTMLDivElement | null>(null)
+  const headerForegroundRef = useRef<HTMLDivElement | null>(null)
+  const selectionIndicatorRef = useRef<HTMLDivElement | null>(null)
+  const tabsButtonRef = useRef<HTMLDivElement | null>(null)
   const triggerRefs = useRef(new Map<string, HTMLButtonElement | null>())
   const panelRefs = useRef(new Map<string, HTMLDivElement | null>())
   const activeTab = controlled ?? uncontrolled
   const reorderable = typeof onTabOrderChange === 'function' && tabs.length > 1
   const tabIds = tabs.map((tab) => tab.id)
+  const tabLayoutSignature = tabIds.join('|')
   const tabsById = useMemo(() => new Map(tabs.map((tab) => [tab.id, tab] as const)), [tabs])
   const contentTabIds = useMemo(() => {
     const nextOrder = buildStableContentTabIds(contentOrderRef.current, tabIds)
@@ -212,12 +212,95 @@ function TabsImpl(
       getPanel(tabId: string) {
         return panelRefs.current.get(tabId) ?? null
       },
+      getHeaderShell() {
+        return headerShellRef.current
+      },
+      getHeaderForeground() {
+        return headerForegroundRef.current
+      },
+      getSelectionIndicator() {
+        return selectionIndicatorRef.current
+      },
       getActiveTabId() {
         return activeTab || null
       },
     }),
     [activeTab]
   )
+
+  const syncSelectionIndicator = useCallback(() => {
+    const indicator = selectionIndicatorRef.current
+    const header = headerRef.current
+    const activeTrigger = activeTab ? triggerRefs.current.get(activeTab) : null
+
+    if (!indicator) {
+      return
+    }
+
+    if (variant !== 'default' || !header || !activeTrigger) {
+      indicator.style.opacity = '0'
+      indicator.style.width = '0px'
+      indicator.style.height = '0px'
+      indicator.style.transform = 'translate(0px, 0px)'
+      return
+    }
+
+    const headerRect = header.getBoundingClientRect()
+    const triggerRect = activeTrigger.getBoundingClientRect()
+
+    indicator.style.opacity = '1'
+    indicator.style.width = `${triggerRect.width}px`
+    indicator.style.height = `${triggerRect.height}px`
+    indicator.style.transform = `translate(${triggerRect.left - headerRect.left}px, ${
+      triggerRect.top - headerRect.top
+    }px)`
+  }, [activeTab, variant])
+
+  useLayoutEffect(() => {
+    syncSelectionIndicator()
+  }, [syncSelectionIndicator, tabLayoutSignature])
+
+  useLayoutEffect(() => {
+    if (variant !== 'default') {
+      return
+    }
+
+    const tabsButton = tabsButtonRef.current
+    if (!tabsButton) {
+      return
+    }
+
+    const handleScroll = () => {
+      syncSelectionIndicator()
+    }
+
+    tabsButton.addEventListener('scroll', handleScroll, { passive: true })
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {
+        tabsButton.removeEventListener('scroll', handleScroll)
+      }
+    }
+
+    const observer = new ResizeObserver(() => {
+      syncSelectionIndicator()
+    })
+
+    observer.observe(tabsButton)
+    if (headerRef.current) {
+      observer.observe(headerRef.current)
+    }
+
+    const activeTrigger = activeTab ? triggerRefs.current.get(activeTab) : null
+    if (activeTrigger) {
+      observer.observe(activeTrigger)
+    }
+
+    return () => {
+      tabsButton.removeEventListener('scroll', handleScroll)
+      observer.disconnect()
+    }
+  }, [activeTab, syncSelectionIndicator, tabLayoutSignature, variant])
 
   const handleChange = (id: string) => {
     if (!controlled) {
@@ -342,24 +425,24 @@ function TabsImpl(
   const headerClassName =
     variant === 'terminal'
       ? 'tabs-header bg-terminal text-terminal-foreground sticky top-0 z-20 flex min-w-0 items-stretch'
-      : 'tabs-header bg-card/95 sticky top-0 z-20 flex min-w-0 items-stretch rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm'
+      : 'tabs-header relative sticky top-0 z-20 min-w-0'
 
   const stripClassName =
     variant === 'terminal'
       ? 'tabs-strip min-w-0 flex-1 bg-terminal px-4'
-      : 'tabs-strip bg-card/95 min-w-0 flex-1 rounded-l-md px-4'
+      : 'tabs-strip min-w-0 flex-1 rounded-l-md px-4'
 
   const listClassName =
     variant === 'terminal'
       ? 'tabs-button scrollbar-none flex min-w-0 gap-1 overflow-x-auto pt-2'
       : 'tabs-button scrollbar-none flex min-w-0 gap-1 overflow-x-auto'
 
-  const buttonBaseClassName = `group relative m-0 flex h-full shrink-0 items-center gap-2 px-2 text-sm font-medium transition-colors ${variant === 'terminal' ? 'rounded-t-[8px] py-1' : 'py-2'}`
+  const buttonBaseClassName = `group relative z-10 m-0 flex h-full shrink-0 items-center gap-2 px-2 text-sm font-medium transition-colors ${variant === 'terminal' ? 'rounded-t-[8px] py-1' : 'py-2'}`
 
   const activeButtonClassName =
     variant === 'terminal'
       ? 'tab-selected bg-background text-foreground'
-      : 'tab-selected bg-background/70 text-foreground'
+      : 'tab-selected text-foreground'
 
   const inactiveButtonClassName =
     variant === 'terminal'
@@ -369,13 +452,73 @@ function TabsImpl(
   const actionsClassName =
     variant === 'terminal'
       ? 'tabs-actions border-border bg-terminal text-terminal-foreground flex shrink-0 items-center border-b px-1'
-      : 'tabs-actions bg-card/95 border-zinc-500/15 flex shrink-0 items-center rounded-r-md border-l px-1'
+      : 'tabs-actions border-zinc-500/15 flex shrink-0 items-center rounded-r-md border-l px-1'
 
   const handleTabBarDoubleClick = (event: ReactMouseEvent<HTMLDivElement>) => {
     if (!onTabBarDoubleClick) return
     if ((event.target as HTMLElement).closest('[data-tab-item="true"]')) return
     onTabBarDoubleClick()
   }
+
+  const tabButtons = tabs.map((tab) => {
+    const dragIndicatorStyle: CSSProperties | undefined =
+      dropIndicator?.tabId === tab.id
+        ? {
+            boxShadow:
+              dropIndicator.position === 'before'
+                ? 'inset 2px 0 0 var(--border)'
+                : 'inset -2px 0 0 var(--border)',
+          }
+        : undefined
+
+    return (
+      <button
+        key={tab.id}
+        ref={(element) => {
+          triggerRefs.current.set(tab.id, element)
+        }}
+        data-tab-item="true"
+        data-tab-id={tab.id}
+        draggable={reorderable}
+        onClick={() => handleChange(tab.id)}
+        onDragStart={(event) => handleDragStart(event, tab.id)}
+        onDragEnd={handleDragEnd}
+        onDragOver={(event) => handleItemDragOver(event, tab.id)}
+        onDrop={(event) => handleItemDrop(event, tab.id)}
+        className={`${buttonBaseClassName} ${
+          activeTab === tab.id ? activeButtonClassName : inactiveButtonClassName
+        } ${reorderable ? 'cursor-grab active:cursor-grabbing' : ''}`}
+        style={dragIndicatorStyle}
+      >
+        {tab.icon}
+        {tab.label}
+        {tab.closable && onTabClose && (
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(event) => {
+              event.stopPropagation()
+              onTabClose(tab.id)
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.stopPropagation()
+                onTabClose(tab.id)
+              }
+            }}
+            draggable={false}
+            className={`hover:text-foreground -mr-1 rounded p-0.5 transition ${
+              tab.closeButtonVisibility === 'always'
+                ? 'opacity-100'
+                : 'opacity-0 group-hover:opacity-100 [button:hover>&]:opacity-100'
+            } ${activeTab === tab.id ? 'text-current/80' : 'text-muted-foreground'}`}
+          >
+            <X className="h-3 w-3" />
+          </span>
+        )}
+      </button>
+    )
+  })
 
   return (
     <div
@@ -384,79 +527,64 @@ function TabsImpl(
       data-tabs-variant={variant}
       className={`relative isolate flex min-h-0 min-w-0 flex-1 flex-col ${className}`}
     >
-      <div className={headerClassName}>
-        <div className={stripClassName}>
-          <div
-            className={listClassName}
-            onDoubleClick={handleTabBarDoubleClick}
-            onDragOver={handleListDragOver}
-            onDrop={handleListDrop}
-          >
-            {tabs.map((tab) => {
-              const dragIndicatorStyle: CSSProperties | undefined =
-                dropIndicator?.tabId === tab.id
-                  ? {
-                      boxShadow:
-                        dropIndicator.position === 'before'
-                          ? 'inset 2px 0 0 var(--border)'
-                          : 'inset -2px 0 0 var(--border)',
-                    }
-                  : undefined
-
-              return (
-                <button
-                  key={tab.id}
-                  ref={(element) => {
-                    triggerRefs.current.set(tab.id, element)
-                  }}
-                  data-tab-item="true"
-                  data-tab-id={tab.id}
-                  draggable={reorderable}
-                  onClick={() => handleChange(tab.id)}
-                  onDragStart={(event) => handleDragStart(event, tab.id)}
-                  onDragEnd={handleDragEnd}
-                  onDragOver={(event) => handleItemDragOver(event, tab.id)}
-                  onDrop={(event) => handleItemDrop(event, tab.id)}
-                  className={`${buttonBaseClassName} ${
-                    activeTab === tab.id ? activeButtonClassName : inactiveButtonClassName
-                  } ${reorderable ? 'cursor-grab active:cursor-grabbing' : ''}`}
-                  style={dragIndicatorStyle}
+      <div ref={headerRef} className={headerClassName}>
+        {variant === 'default' ? (
+          <>
+            <div
+              ref={headerShellRef}
+              data-tabs-header-shell="true"
+              className="tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm"
+            />
+            <div className="pointer-events-none absolute inset-0 z-10">
+              <div
+                ref={selectionIndicatorRef}
+                data-tabs-selection-indicator="true"
+                aria-hidden="true"
+                className="tabs-selection-indicator border-primary bg-background/70 duration-280 absolute left-0 top-0 rounded-md border-b-2 opacity-0 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] transition-[transform,width,height,opacity] ease-[cubic-bezier(0.22,1,0.36,1)]"
+              />
+            </div>
+            <div
+              ref={headerForegroundRef}
+              data-tabs-header-foreground="true"
+              className="tabs-header-foreground relative z-20 flex min-w-0 items-stretch"
+            >
+              <div className={stripClassName}>
+                <div
+                  ref={tabsButtonRef}
+                  className={listClassName}
+                  onDoubleClick={handleTabBarDoubleClick}
+                  onDragOver={handleListDragOver}
+                  onDrop={handleListDrop}
                 >
-                  {tab.icon}
-                  {tab.label}
-                  {tab.closable && onTabClose && (
-                    <span
-                      role="button"
-                      tabIndex={0}
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        onTabClose(tab.id)
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter' || event.key === ' ') {
-                          event.stopPropagation()
-                          onTabClose(tab.id)
-                        }
-                      }}
-                      draggable={false}
-                      className={`hover:text-foreground -mr-1 rounded p-0.5 transition ${
-                        tab.closeButtonVisibility === 'always'
-                          ? 'opacity-100'
-                          : 'opacity-0 group-hover:opacity-100 [button:hover>&]:opacity-100'
-                      } ${activeTab === tab.id ? 'text-current/80' : 'text-muted-foreground'}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-        {actions && (
-          <div data-tabs-actions="true" className={actionsClassName}>
-            {actions}
-          </div>
+                  {tabButtons}
+                </div>
+              </div>
+              {actions && (
+                <div data-tabs-actions="true" className={actionsClassName}>
+                  {actions}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={stripClassName}>
+              <div
+                ref={tabsButtonRef}
+                className={listClassName}
+                onDoubleClick={handleTabBarDoubleClick}
+                onDragOver={handleListDragOver}
+                onDrop={handleListDrop}
+              >
+                {tabButtons}
+              </div>
+            </div>
+            {actions && (
+              <div data-tabs-actions="true" className={actionsClassName}>
+                {actions}
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -463,6 +463,24 @@ html[data-vt-kind='route-detail'] .vt-detail-content {
   }
 }
 
+@keyframes vt-tab-layer-new {
+  from {
+    opacity: 0.78;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes vt-tab-layer-old {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0.72;
+  }
+}
+
 ::view-transition-group(root) {
   animation-duration: 1ms;
 }
@@ -578,12 +596,26 @@ html[data-vt-kind='tab-carousel'] [data-tabs-selection-indicator] {
 
 html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-header-shell) {
   z-index: 2;
-  animation-duration: 1ms;
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  isolation: isolate;
+  overflow: clip;
 }
 
 html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-shell),
 html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-shell) {
-  animation: none;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  mix-blend-mode: normal;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-shell) {
+  animation: vt-tab-layer-old 160ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-shell) {
+  animation: vt-tab-layer-new 220ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
   mix-blend-mode: normal;
 }
 
@@ -614,12 +646,26 @@ html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-edge) {
 
 html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-header-foreground) {
   z-index: 4;
-  animation-duration: 1ms;
+  animation-duration: 240ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  isolation: isolate;
+  overflow: clip;
 }
 
 html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-foreground),
 html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-foreground) {
-  animation: none;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  mix-blend-mode: normal;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-foreground) {
+  animation: vt-tab-layer-old 160ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-foreground) {
+  animation: vt-tab-layer-new 220ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
   mix-blend-mode: normal;
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -255,6 +255,18 @@
   view-transition-class: vt-tab-panel;
 }
 
+[data-tabs-header-shell] {
+  view-transition-class: vt-tab-header-shell;
+}
+
+[data-tabs-header-foreground] {
+  view-transition-class: vt-tab-header-foreground;
+}
+
+[data-tabs-selection-indicator] {
+  view-transition-class: vt-tab-edge;
+}
+
 html[data-vt-kind='route-detail'] .vt-detail-content.route-loading {
   view-transition-name: vt-detail-content;
 }
@@ -429,6 +441,28 @@ html[data-vt-kind='route-detail'] .vt-detail-content {
   }
 }
 
+@keyframes vt-tab-edge-new {
+  from {
+    opacity: 0.72;
+    filter: saturate(0.9);
+  }
+  to {
+    opacity: 1;
+    filter: saturate(1);
+  }
+}
+
+@keyframes vt-tab-edge-old {
+  from {
+    opacity: 1;
+    filter: saturate(1);
+  }
+  to {
+    opacity: 0.72;
+    filter: saturate(0.94);
+  }
+}
+
 ::view-transition-group(root) {
   animation-duration: 1ms;
 }
@@ -538,7 +572,59 @@ html[data-vt-kind='route-detail']::view-transition-new(vt-detail-content) {
   mix-blend-mode: normal;
 }
 
+html[data-vt-kind='tab-carousel'] [data-tabs-selection-indicator] {
+  transition: none;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-header-shell) {
+  z-index: 2;
+  animation-duration: 1ms;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-shell),
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-shell) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-edge) {
+  z-index: 3;
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  isolation: isolate;
+  overflow: clip;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-edge),
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-edge) {
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-edge) {
+  animation: vt-tab-edge-old 180ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  mix-blend-mode: normal;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-edge) {
+  animation: vt-tab-edge-new 260ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  mix-blend-mode: normal;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-header-foreground) {
+  z-index: 4;
+  animation-duration: 1ms;
+}
+
+html[data-vt-kind='tab-carousel']::view-transition-old(.vt-tab-header-foreground),
+html[data-vt-kind='tab-carousel']::view-transition-new(.vt-tab-header-foreground) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
 html[data-vt-kind='tab-carousel']::view-transition-group(.vt-tab-panel) {
+  z-index: 1;
   animation-duration: 280ms;
   animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   isolation: isolate;
@@ -592,6 +678,12 @@ html[data-vt-kind='tab-carousel'][data-vt-direction='backward']::view-transition
   ::view-transition-new(.vt-shared-title),
   ::view-transition-old(vt-detail-content),
   ::view-transition-new(vt-detail-content),
+  ::view-transition-old(.vt-tab-header-shell),
+  ::view-transition-new(.vt-tab-header-shell),
+  ::view-transition-old(.vt-tab-edge),
+  ::view-transition-new(.vt-tab-edge),
+  ::view-transition-old(.vt-tab-header-foreground),
+  ::view-transition-new(.vt-tab-header-foreground),
   ::view-transition-old(.vt-tab-panel),
   ::view-transition-new(.vt-tab-panel) {
     animation: none;

--- a/packages/web/src/lib/view-transitions/runtime.test.ts
+++ b/packages/web/src/lib/view-transitions/runtime.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { setTemporaryViewTransitionNamesMock } = vi.hoisted(() => ({
+  setTemporaryViewTransitionNamesMock: vi.fn(async () => {}),
+}))
+
 vi.mock('react-dom', () => ({
   flushSync(callback: () => void) {
     callback()
@@ -17,7 +21,7 @@ vi.mock('view-transitions-toolkit/track-active-view-transition', () => ({
 }))
 
 vi.mock('view-transitions-toolkit/misc', () => ({
-  setTemporaryViewTransitionNames: vi.fn(async () => {}),
+  setTemporaryViewTransitionNames: setTemporaryViewTransitionNamesMock,
 }))
 
 import { runViewTransition } from './runtime'
@@ -41,6 +45,7 @@ describe('runViewTransition', () => {
     const doc = document as TestViewTransitionDocument
     doc.activeViewTransition = null
     delete doc.startViewTransition
+    setTemporaryViewTransitionNamesMock.mockClear()
   })
 
   it('clears previous names before collecting the next snapshot entries', async () => {
@@ -183,5 +188,40 @@ describe('runViewTransition', () => {
 
     expect(document.querySelector('[data-vt-ready-indicator]')).toBeNull()
     expect(document.documentElement.dataset.vtKind).toBeUndefined()
+  })
+
+  it('reuses the same tab-carousel element as both old and new shared entry', async () => {
+    const sharedElement = document.createElement('div')
+    document.body.append(sharedElement)
+
+    let nameDuringAfterCollection = '__unset__'
+    let nameAfterAfterCollection = '__unset__'
+
+    ;(document as TestViewTransitionDocument).startViewTransition = (update) => {
+      const pending = Promise.resolve(update()).then(() => {
+        nameAfterAfterCollection = sharedElement.style.viewTransitionName
+      })
+      return {
+        finished: pending.then(() => undefined),
+      }
+    }
+
+    await runViewTransition({
+      intent: {
+        area: 'main',
+        kind: 'tab-carousel',
+        direction: 'forward',
+      },
+      collectBeforeEntries: () => [[sharedElement, 'vt-tab-edge']],
+      collectAfterEntries: () => {
+        nameDuringAfterCollection = sharedElement.style.viewTransitionName
+        return [[sharedElement, 'vt-tab-edge']]
+      },
+      update: () => {},
+    })
+
+    expect(nameDuringAfterCollection).toBe('')
+    expect(nameAfterAfterCollection).toBe('vt-tab-edge')
+    expect(setTemporaryViewTransitionNamesMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/web/src/lib/view-transitions/runtime.ts
+++ b/packages/web/src/lib/view-transitions/runtime.ts
@@ -85,11 +85,15 @@ function waitForDomCommit(): Promise<void> {
   })
 }
 
-function filterDistinctEntries(
+function filterAfterEntries(
   entries: NamedElementEntry[],
-  beforeEntries: NamedElementEntry[]
+  beforeEntries: NamedElementEntry[],
+  intent: VTIntent
 ): NamedElementEntry[] {
   if (beforeEntries.length === 0) return entries
+  if (intent.kind === 'tab-carousel') {
+    return entries
+  }
   const beforeElements = new Set(beforeEntries.map(([element]) => element))
   return entries.filter(([element]) => !beforeElements.has(element))
 }
@@ -104,12 +108,12 @@ async function collectSettledAfterEntries(
   if (intent.kind === 'route-detail' && beforeEntries.length > 0) {
     return waitForNamedEntriesReady({
       expectedNames: beforeEntries.map(([, name]) => name),
-      collectEntries: () => filterDistinctEntries(collectAfterEntries(), beforeEntries),
+      collectEntries: () => filterAfterEntries(collectAfterEntries(), beforeEntries, intent),
     })
   }
 
   for (let attempt = 0; attempt < 4; attempt += 1) {
-    const entries = filterDistinctEntries(collectAfterEntries(), beforeEntries)
+    const entries = filterAfterEntries(collectAfterEntries(), beforeEntries, intent)
     if (entries.length > 0 || beforeEntries.length === 0) {
       return entries
     }
@@ -118,7 +122,7 @@ async function collectSettledAfterEntries(
     await waitForDomCommit()
   }
 
-  return filterDistinctEntries(collectAfterEntries(), beforeEntries)
+  return filterAfterEntries(collectAfterEntries(), beforeEntries, intent)
 }
 
 function setIntentDataset(intent: VTIntent): () => void {

--- a/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
+++ b/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
@@ -3,6 +3,9 @@ import type { TabsHandle } from '@/components/tabs'
 const DATA_VISIBLE_HEIGHT = 'tabVisibleHeight'
 const DATA_TOP_INSET = 'tabTopInset'
 const DATA_SCROLL_OFFSET = 'tabScrollOffset'
+const DATA_LAYOUT_BRIDGE = 'tabLayoutBridge'
+const DATA_LAYOUT_BRIDGE_BASE_PADDING = 'tabLayoutBridgeBasePadding'
+const DATA_LAYOUT_BRIDGE_INLINE_PADDING = 'tabLayoutBridgeInlinePadding'
 const TAB_SCROLL_ROOT_SELECTOR = '[data-tab-scroll-root="true"]'
 
 export interface TabScrollMemory {
@@ -10,9 +13,13 @@ export interface TabScrollMemory {
   contentScrollTop: number
   topInset: number
   visibleHeight: number
+  viewportScrollTop: number
 }
 
 export interface FrozenTabState {
+  contentScrollRoot: HTMLElement | null
+  contentScrollTop: number
+  finalViewportScrollTop: number
   panel: HTMLElement
   previousStyles: {
     height: string
@@ -29,6 +36,8 @@ interface ResolvedTabScrollElements {
   viewport: HTMLElement
 }
 
+export type ViewportSelector = string | readonly string[]
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
@@ -39,6 +48,67 @@ function maxViewportScroll(viewport: HTMLElement): number {
 
 function maxPanelScroll(panel: HTMLElement, visibleHeight: number): number {
   return Math.max(panel.scrollHeight - visibleHeight, 0)
+}
+
+function readPanelLayoutBridge(panel: HTMLElement): number {
+  return Number(panel.dataset[DATA_LAYOUT_BRIDGE] ?? '0') || 0
+}
+
+function ensurePanelLayoutBridgeState(panel: HTMLElement): void {
+  panel.dataset[DATA_LAYOUT_BRIDGE_BASE_PADDING] ||= window.getComputedStyle(panel).paddingBottom
+  panel.dataset[DATA_LAYOUT_BRIDGE_INLINE_PADDING] ||= panel.style.paddingBottom
+}
+
+function setPanelLayoutBridge(panel: HTMLElement, extraHeight: number): void {
+  ensurePanelLayoutBridgeState(panel)
+
+  const normalizedHeight = Math.max(Math.ceil(extraHeight), 0)
+  panel.dataset[DATA_LAYOUT_BRIDGE] = String(normalizedHeight)
+
+  if (normalizedHeight <= 0) {
+    panel.style.paddingBottom = panel.dataset[DATA_LAYOUT_BRIDGE_INLINE_PADDING] ?? ''
+    return
+  }
+
+  const basePadding = panel.dataset[DATA_LAYOUT_BRIDGE_BASE_PADDING] ?? '0px'
+  panel.style.paddingBottom = `calc(${basePadding} + ${normalizedHeight}px)`
+}
+
+function restoreViewportScroll(
+  viewport: HTMLElement,
+  panel: HTMLElement,
+  targetScrollTop: number
+): void {
+  const applyScrollTop = () => {
+    if (!viewport.isConnected || !panel.isConnected) {
+      return true
+    }
+
+    const existingBridge = readPanelLayoutBridge(panel)
+    const baseMaxViewportScroll = Math.max(maxViewportScroll(viewport) - existingBridge, 0)
+    const requiredBridge = Math.max(targetScrollTop - baseMaxViewportScroll, 0)
+
+    setPanelLayoutBridge(panel, requiredBridge)
+    const nextScrollTop = clamp(targetScrollTop, 0, maxViewportScroll(viewport))
+    viewport.scrollTop = nextScrollTop
+    return viewport.scrollTop === nextScrollTop
+  }
+
+  if (applyScrollTop() || typeof requestAnimationFrame !== 'function') {
+    return
+  }
+
+  let retriesRemaining = 10
+  const retry = () => {
+    if (applyScrollTop() || retriesRemaining <= 0) {
+      return
+    }
+
+    retriesRemaining -= 1
+    requestAnimationFrame(retry)
+  }
+
+  requestAnimationFrame(retry)
 }
 
 function hasVerticalScrollBehavior(overflowY: string): boolean {
@@ -71,8 +141,9 @@ function findScrollableDescendant(panel: HTMLElement): HTMLElement | null {
 }
 
 function resolveContentScrollRoot(panel: HTMLElement): HTMLElement | null {
-  const markedRoot =
-    panel.matches(TAB_SCROLL_ROOT_SELECTOR) ? panel : panel.querySelector<HTMLElement>(TAB_SCROLL_ROOT_SELECTOR)
+  const markedRoot = panel.matches(TAB_SCROLL_ROOT_SELECTOR)
+    ? panel
+    : panel.querySelector<HTMLElement>(TAB_SCROLL_ROOT_SELECTOR)
 
   if (markedRoot) {
     return markedRoot
@@ -157,10 +228,71 @@ function restoreContentScrollRoot(element: HTMLElement | null, targetScrollTop: 
   requestAnimationFrame(retry)
 }
 
+function normalizeViewportSelectors(viewportSelector: ViewportSelector): string[] {
+  return typeof viewportSelector === 'string'
+    ? viewportSelector.split(',').map((selector: string) => selector.trim())
+    : [...viewportSelector]
+}
+
+function resolveViewportBoundary(
+  panel: HTMLElement,
+  viewportSelector: ViewportSelector
+): HTMLElement | null {
+  const selectors = normalizeViewportSelectors(viewportSelector)
+
+  for (const selector of selectors) {
+    if (!selector) {
+      continue
+    }
+
+    try {
+      const match = panel.closest(selector)
+      if (match instanceof HTMLElement) {
+        return match
+      }
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+function resolveScrollViewport(
+  panel: HTMLElement,
+  boundary: HTMLElement | null
+): HTMLElement | null {
+  let current: HTMLElement | null = panel.parentElement
+
+  while (current) {
+    const style = window.getComputedStyle(current)
+    if (hasVerticalScrollBehavior(style.overflowY) && current.scrollHeight > current.clientHeight) {
+      return current
+    }
+
+    if (boundary && current === boundary) {
+      break
+    }
+
+    current = current.parentElement
+  }
+
+  if (!boundary) {
+    return null
+  }
+
+  const boundaryStyle = window.getComputedStyle(boundary)
+  if (hasVerticalScrollBehavior(boundaryStyle.overflowY)) {
+    return boundary
+  }
+
+  return null
+}
+
 export function resolveTabScrollElements(
   handle: TabsHandle | null,
   tabId: string,
-  viewportSelector?: string
+  viewportSelector?: ViewportSelector
 ): ResolvedTabScrollElements | null {
   if (!viewportSelector) return null
   const panel = handle?.getPanel(tabId)
@@ -168,12 +300,8 @@ export function resolveTabScrollElements(
     return null
   }
 
-  let viewport: Element | null = null
-  try {
-    viewport = panel.closest(viewportSelector)
-  } catch {
-    return null
-  }
+  const boundary = resolveViewportBoundary(panel, viewportSelector)
+  const viewport = resolveScrollViewport(panel, boundary)
   if (!(viewport instanceof HTMLElement)) {
     return null
   }
@@ -197,6 +325,23 @@ export function restorePanelContentScroll(
   if (contentScrollRoot && contentScrollRoot !== panel) {
     restoreContentScrollRoot(contentScrollRoot, snapshot.contentScrollTop)
   }
+}
+
+export function restorePanelViewportScroll(
+  panel: HTMLElement | null,
+  viewport: HTMLElement | null,
+  snapshot: TabScrollMemory | null | undefined
+): void {
+  if (!(panel instanceof HTMLElement) || !(viewport instanceof HTMLElement)) {
+    return
+  }
+
+  if (!snapshot) {
+    setPanelLayoutBridge(panel, 0)
+    return
+  }
+
+  restoreViewportScroll(viewport, panel, snapshot.viewportScrollTop)
 }
 
 export function captureTabScrollMemory(
@@ -228,6 +373,7 @@ export function captureTabScrollMemory(
     innerScrollTop,
     topInset,
     visibleHeight,
+    viewportScrollTop: viewport.scrollTop,
   }
 }
 
@@ -251,6 +397,12 @@ export function freezeOutgoingTab(
   }
 
   return {
+    contentScrollRoot:
+      elements.contentScrollRoot && elements.contentScrollRoot !== elements.panel
+        ? elements.contentScrollRoot
+        : null,
+    contentScrollTop: snapshot.contentScrollTop,
+    finalViewportScrollTop: snapshot.viewportScrollTop,
     panel: elements.panel,
     previousStyles,
     viewport: elements.viewport,
@@ -269,6 +421,7 @@ export function freezeIncomingTab(
     topInset: clamp(snapshot.topInset, 0, elements.viewport.clientHeight),
     visibleHeight: clamp(snapshot.visibleHeight, 1, elements.viewport.clientHeight),
     innerScrollTop: 0,
+    viewportScrollTop: snapshot.viewportScrollTop,
   }
 
   normalizedSnapshot.innerScrollTop = clamp(
@@ -292,6 +445,12 @@ export function freezeIncomingTab(
   elements.panel.scrollTop = normalizedSnapshot.innerScrollTop
 
   return {
+    contentScrollRoot:
+      elements.contentScrollRoot && elements.contentScrollRoot !== elements.panel
+        ? elements.contentScrollRoot
+        : null,
+    contentScrollTop: normalizedSnapshot.contentScrollTop,
+    finalViewportScrollTop: snapshot.viewportScrollTop,
     panel: elements.panel,
     previousStyles,
     viewport: elements.viewport,
@@ -299,23 +458,11 @@ export function freezeIncomingTab(
 }
 
 export function finalizeFrozenIncomingTab(state: FrozenTabState): void {
-  const transferScrollTop = state.panel.scrollTop
-  const contentScrollRoot =
-    state.panel.matches(TAB_SCROLL_ROOT_SELECTOR)
-      ? state.panel
-      : state.panel.querySelector<HTMLElement>(TAB_SCROLL_ROOT_SELECTOR) ??
-        findScrollableDescendant(state.panel)
-  const contentScrollTop =
-    contentScrollRoot && contentScrollRoot !== state.panel ? contentScrollRoot.scrollTop : 0
   restorePanel(state.panel, state.previousStyles)
-  state.viewport.scrollTop = clamp(
-    state.viewport.scrollTop + transferScrollTop,
-    0,
-    maxViewportScroll(state.viewport)
-  )
+  restoreViewportScroll(state.viewport, state.panel, state.finalViewportScrollTop)
   state.panel.scrollTop = 0
-  if (contentScrollRoot && contentScrollRoot !== state.panel) {
-    restoreContentScrollRoot(contentScrollRoot, contentScrollTop)
+  if (state.contentScrollRoot) {
+    restoreContentScrollRoot(state.contentScrollRoot, state.contentScrollTop)
   }
 }
 

--- a/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
+++ b/packages/web/src/lib/view-transitions/tab-scroll-freeze.ts
@@ -3,9 +3,11 @@ import type { TabsHandle } from '@/components/tabs'
 const DATA_VISIBLE_HEIGHT = 'tabVisibleHeight'
 const DATA_TOP_INSET = 'tabTopInset'
 const DATA_SCROLL_OFFSET = 'tabScrollOffset'
+const TAB_SCROLL_ROOT_SELECTOR = '[data-tab-scroll-root="true"]'
 
 export interface TabScrollMemory {
   innerScrollTop: number
+  contentScrollTop: number
   topInset: number
   visibleHeight: number
 }
@@ -23,6 +25,7 @@ export interface FrozenTabState {
 
 interface ResolvedTabScrollElements {
   panel: HTMLElement
+  contentScrollRoot: HTMLElement | null
   viewport: HTMLElement
 }
 
@@ -36,6 +39,46 @@ function maxViewportScroll(viewport: HTMLElement): number {
 
 function maxPanelScroll(panel: HTMLElement, visibleHeight: number): number {
   return Math.max(panel.scrollHeight - visibleHeight, 0)
+}
+
+function hasVerticalScrollBehavior(overflowY: string): boolean {
+  return overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
+}
+
+function findScrollableDescendant(panel: HTMLElement): HTMLElement | null {
+  const walker = document.createTreeWalker(panel, NodeFilter.SHOW_ELEMENT)
+  let candidate: HTMLElement | null = null
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode
+    if (!(node instanceof HTMLElement)) {
+      continue
+    }
+
+    const style = window.getComputedStyle(node)
+    if (!hasVerticalScrollBehavior(style.overflowY) || node.scrollHeight <= node.clientHeight) {
+      continue
+    }
+
+    if (node.scrollTop > 0) {
+      return node
+    }
+
+    candidate ??= node
+  }
+
+  return candidate
+}
+
+function resolveContentScrollRoot(panel: HTMLElement): HTMLElement | null {
+  const markedRoot =
+    panel.matches(TAB_SCROLL_ROOT_SELECTOR) ? panel : panel.querySelector<HTMLElement>(TAB_SCROLL_ROOT_SELECTOR)
+
+  if (markedRoot) {
+    return markedRoot
+  }
+
+  return findScrollableDescendant(panel)
 }
 
 function panelDocumentTop(panel: HTMLElement, viewport: HTMLElement): number {
@@ -83,6 +126,37 @@ function restorePanel(panel: HTMLElement, previousStyles: FrozenTabState['previo
   clearFrozenMetrics(panel)
 }
 
+function restoreContentScrollRoot(element: HTMLElement | null, targetScrollTop: number): void {
+  if (!element) {
+    return
+  }
+
+  const applyScrollTop = () => {
+    if (!element.isConnected) {
+      return true
+    }
+
+    element.scrollTop = targetScrollTop
+    return element.scrollTop === targetScrollTop
+  }
+
+  if (applyScrollTop() || typeof requestAnimationFrame !== 'function') {
+    return
+  }
+
+  let retriesRemaining = 10
+  const retry = () => {
+    if (applyScrollTop() || retriesRemaining <= 0) {
+      return
+    }
+
+    retriesRemaining -= 1
+    requestAnimationFrame(retry)
+  }
+
+  requestAnimationFrame(retry)
+}
+
 export function resolveTabScrollElements(
   handle: TabsHandle | null,
   tabId: string,
@@ -104,13 +178,31 @@ export function resolveTabScrollElements(
     return null
   }
 
-  return { panel, viewport }
+  return {
+    panel,
+    contentScrollRoot: resolveContentScrollRoot(panel),
+    viewport,
+  }
+}
+
+export function restorePanelContentScroll(
+  panel: HTMLElement | null,
+  snapshot: TabScrollMemory | null | undefined
+): void {
+  if (!(panel instanceof HTMLElement) || !snapshot) {
+    return
+  }
+
+  const contentScrollRoot = resolveContentScrollRoot(panel)
+  if (contentScrollRoot && contentScrollRoot !== panel) {
+    restoreContentScrollRoot(contentScrollRoot, snapshot.contentScrollTop)
+  }
 }
 
 export function captureTabScrollMemory(
   elements: ResolvedTabScrollElements
 ): TabScrollMemory | null {
-  const { panel, viewport } = elements
+  const { panel, contentScrollRoot, viewport } = elements
   const panelRect = panel.getBoundingClientRect()
   const viewportRect = viewport.getBoundingClientRect()
   const visibleHeight = clamp(
@@ -131,6 +223,8 @@ export function captureTabScrollMemory(
   )
 
   return {
+    contentScrollTop:
+      contentScrollRoot && contentScrollRoot !== panel ? contentScrollRoot.scrollTop : 0,
     innerScrollTop,
     topInset,
     visibleHeight,
@@ -142,6 +236,10 @@ export function freezeOutgoingTab(
   snapshot: TabScrollMemory
 ): FrozenTabState {
   const previousStyles = applyFrozenStyles(elements.panel, snapshot)
+
+  if (elements.contentScrollRoot && elements.contentScrollRoot !== elements.panel) {
+    restoreContentScrollRoot(elements.contentScrollRoot, snapshot.contentScrollTop)
+  }
 
   elements.panel.scrollTop = snapshot.innerScrollTop
   if (snapshot.innerScrollTop > 0) {
@@ -164,6 +262,10 @@ export function freezeIncomingTab(
   snapshot: TabScrollMemory
 ): FrozenTabState {
   const normalizedSnapshot: TabScrollMemory = {
+    contentScrollTop:
+      elements.contentScrollRoot && elements.contentScrollRoot !== elements.panel
+        ? snapshot.contentScrollTop
+        : 0,
     topInset: clamp(snapshot.topInset, 0, elements.viewport.clientHeight),
     visibleHeight: clamp(snapshot.visibleHeight, 1, elements.viewport.clientHeight),
     innerScrollTop: 0,
@@ -184,6 +286,9 @@ export function freezeIncomingTab(
   const previousStyles = applyFrozenStyles(elements.panel, normalizedSnapshot)
 
   elements.viewport.scrollTop = nextViewportScrollTop
+  if (elements.contentScrollRoot && elements.contentScrollRoot !== elements.panel) {
+    restoreContentScrollRoot(elements.contentScrollRoot, normalizedSnapshot.contentScrollTop)
+  }
   elements.panel.scrollTop = normalizedSnapshot.innerScrollTop
 
   return {
@@ -195,6 +300,13 @@ export function freezeIncomingTab(
 
 export function finalizeFrozenIncomingTab(state: FrozenTabState): void {
   const transferScrollTop = state.panel.scrollTop
+  const contentScrollRoot =
+    state.panel.matches(TAB_SCROLL_ROOT_SELECTOR)
+      ? state.panel
+      : state.panel.querySelector<HTMLElement>(TAB_SCROLL_ROOT_SELECTOR) ??
+        findScrollableDescendant(state.panel)
+  const contentScrollTop =
+    contentScrollRoot && contentScrollRoot !== state.panel ? contentScrollRoot.scrollTop : 0
   restorePanel(state.panel, state.previousStyles)
   state.viewport.scrollTop = clamp(
     state.viewport.scrollTop + transferScrollTop,
@@ -202,6 +314,9 @@ export function finalizeFrozenIncomingTab(state: FrozenTabState): void {
     maxViewportScroll(state.viewport)
   )
   state.panel.scrollTop = 0
+  if (contentScrollRoot && contentScrollRoot !== state.panel) {
+    restoreContentScrollRoot(contentScrollRoot, contentScrollTop)
+  }
 }
 
 export function cleanupFrozenTab(state: FrozenTabState): void {

--- a/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
@@ -1,0 +1,172 @@
+import { Tabs, type Tab } from '@/components/tabs'
+import { isStaticMode, setStaticMode } from '@/lib/static-mode'
+import { getRouterContext } from '@tanstack/react-router'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useEffect, useMemo, useRef, type ReactNode } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useRoutedCarouselTabs } from './tabs'
+
+function RoutedTabsTestRouter({ children }: { children: ReactNode }) {
+  const RouterContext = getRouterContext()
+  const listenersRef = useRef(new Set<() => void>())
+  const storeStateRef = useRef({
+    location: {
+      pathname: '/browser-test',
+      searchStr: '?gitPane=diff',
+      hash: '',
+      state: undefined as unknown,
+    },
+  })
+
+  const router = useMemo(
+    () => ({
+      __store: {
+        state: storeStateRef.current,
+        subscribe(listener: () => void) {
+          listenersRef.current.add(listener)
+          return () => {
+            listenersRef.current.delete(listener)
+          }
+        },
+      },
+      navigate({ href, state }: { href: string; replace?: boolean; state?: unknown }) {
+        const url = new URL(href, 'http://browser.test')
+        storeStateRef.current.location = {
+          pathname: url.pathname,
+          searchStr: url.search,
+          hash: url.hash,
+          state,
+        }
+
+        for (const listener of listenersRef.current) {
+          listener()
+        }
+      },
+    }),
+    []
+  )
+
+  return <RouterContext.Provider value={router as never}>{children}</RouterContext.Provider>
+}
+
+function RoutedTabsBrowserHarness() {
+  const previousStaticModeRef = useRef(isStaticMode())
+
+  useEffect(() => {
+    setStaticMode(true)
+    return () => {
+      setStaticMode(previousStaticModeRef.current)
+    }
+  }, [])
+
+  const routedTabs = useMemo(
+    () =>
+      [{ id: 'diff' as const }, { id: 'files' as const }] satisfies Array<{
+        id: 'diff' | 'files'
+      }>,
+    []
+  )
+  const { onTabChange, selectedTab, tabsRef } = useRoutedCarouselTabs({
+    queryKey: 'gitPane',
+    tabs: routedTabs,
+    initialTab: 'diff',
+    viewportSelector: '.main-content',
+  })
+
+  const tabs = useMemo<Tab[]>(
+    () => [
+      {
+        id: 'diff',
+        label: 'Diff',
+        content: (
+          <div className="space-y-2 py-4">
+            {Array.from({ length: 24 }, (_, index) => (
+              <div
+                key={`diff-row-${index + 1}`}
+                className="rounded-md border border-zinc-500/15 px-3 py-2 text-sm"
+              >
+                Diff row {index + 1}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+      {
+        id: 'files',
+        label: 'Files',
+        unmountOnHide: true,
+        content: (
+          <div className="py-4">
+            <div
+              data-tab-scroll-root="true"
+              data-testid="files-scroll-root"
+              className="rounded-md border border-zinc-500/15"
+              style={{ height: '160px', overflowY: 'auto' }}
+            >
+              <div className="space-y-1 p-2">
+                {Array.from({ length: 40 }, (_, index) => (
+                  <div
+                    key={`file-row-${index + 1}`}
+                    className="rounded-md border border-zinc-500/10 px-2 py-1 text-sm"
+                  >
+                    File row {index + 1}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ),
+      },
+    ],
+    []
+  )
+
+  return (
+    <div
+      className="main-content"
+      style={{ width: '480px', height: '320px', overflowY: 'auto', padding: '16px' }}
+    >
+      <div style={{ height: '72px' }} />
+      <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
+      <div style={{ height: '240px' }} />
+    </div>
+  )
+}
+
+describe('useRoutedCarouselTabs browser', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('restores marked inner scroll roots after a remount in a real browser', async () => {
+    render(
+      <RoutedTabsTestRouter>
+        <RoutedTabsBrowserHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Files' }))
+
+    const firstScrollRoot = await screen.findByTestId('files-scroll-root')
+    firstScrollRoot.scrollTop = 240
+    firstScrollRoot.dispatchEvent(new Event('scroll', { bubbles: true }))
+    expect(firstScrollRoot.scrollTop).toBe(240)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('files-scroll-root')).toBeNull()
+    })
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 360)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('files-scroll-root').scrollTop).toBe(240)
+    })
+  })
+})

--- a/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
@@ -1,5 +1,13 @@
+import { GitEntryDetailPanel } from '@/components/git/git-panel-detail'
 import { Tabs, type Tab } from '@/components/tabs'
 import { isStaticMode, setStaticMode } from '@/lib/static-mode'
+import type {
+  DashboardGitEntry,
+  GitEntryFilePatch,
+  GitEntryFileSummary,
+  GitEntrySelector,
+} from '@openspecui/core'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { getRouterContext } from '@tanstack/react-router'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useEffect, useMemo, useRef, type ReactNode } from 'react'
@@ -7,13 +15,19 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { useRoutedCarouselTabs } from './tabs'
 
-function RoutedTabsTestRouter({ children }: { children: ReactNode }) {
+function RoutedTabsTestRouter({
+  children,
+  initialSearch = '?gitPane=diff',
+}: {
+  children: ReactNode
+  initialSearch?: string
+}) {
   const RouterContext = getRouterContext()
   const listenersRef = useRef(new Set<() => void>())
   const storeStateRef = useRef({
     location: {
       pathname: '/browser-test',
-      searchStr: '?gitPane=diff',
+      searchStr: initialSearch,
       hash: '',
       state: undefined as unknown,
     },
@@ -134,6 +148,188 @@ function RoutedTabsBrowserHarness() {
   )
 }
 
+function RoutedTabsViewportScrollHarness() {
+  const previousStaticModeRef = useRef(isStaticMode())
+
+  useEffect(() => {
+    setStaticMode(true)
+    return () => {
+      setStaticMode(previousStaticModeRef.current)
+    }
+  }, [])
+
+  const routedTabs = useMemo(
+    () =>
+      [{ id: 'diff' as const }, { id: 'files' as const }] satisfies Array<{
+        id: 'diff' | 'files'
+      }>,
+    []
+  )
+  const { onTabChange, selectedTab, tabsRef } = useRoutedCarouselTabs({
+    queryKey: 'gitPane',
+    tabs: routedTabs,
+    initialTab: 'diff',
+    viewportSelector: '.main-content',
+  })
+
+  const tabs = useMemo<Tab[]>(
+    () => [
+      {
+        id: 'diff',
+        label: 'Diff',
+        content: (
+          <div>
+            {Array.from({ length: 500 }, (_, index) => (
+              <div
+                key={`diff-row-${index + 1}`}
+                style={{ height: '20px', borderBottom: '1px solid transparent' }}
+              >
+                Diff row {index + 1}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+      {
+        id: 'files',
+        label: 'Files',
+        content: (
+          <div>
+            {Array.from({ length: 100 }, (_, index) => (
+              <div
+                key={`file-row-${index + 1}`}
+                style={{ height: '30px', borderBottom: '1px solid transparent' }}
+              >
+                File row {index + 1}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+    ],
+    []
+  )
+
+  return (
+    <div
+      className="main-content"
+      data-testid="viewport-scroll-root"
+      style={{ width: '480px', height: '320px', overflowY: 'auto', padding: '16px' }}
+    >
+      <div style={{ height: '72px' }} />
+      <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
+      <div style={{ height: '240px' }} />
+    </div>
+  )
+}
+
+const commitDetailEntry: DashboardGitEntry = {
+  type: 'commit',
+  hash: 'abc12345',
+  title: 'feat: preserve commit detail tab scroll',
+  committedAt: Date.UTC(2026, 3, 14),
+  relatedChanges: ['commit-detail-vt-scroll'],
+  diff: {
+    files: 24,
+    insertions: 168,
+    deletions: 42,
+  },
+}
+
+const commitDetailSelector: GitEntrySelector = {
+  type: 'commit',
+  hash: commitDetailEntry.hash,
+}
+
+const commitDetailFiles: GitEntryFileSummary[] = Array.from({ length: 24 }, (_, index) => ({
+  fileId: `commit-detail-file-${index + 1}`,
+  source: 'tracked',
+  path: `src/features/group-${Math.floor(index / 4) + 1}/file-${index + 1}.tsx`,
+  displayPath: `src/features/group-${Math.floor(index / 4) + 1}/file-${index + 1}.tsx`,
+  previousPath: null,
+  changeType:
+    index % 4 === 0
+      ? 'added'
+      : index % 4 === 1
+        ? 'modified'
+        : index % 4 === 2
+          ? 'deleted'
+          : 'renamed',
+  diff: {
+    state: 'ready',
+    files: 1,
+    insertions: 4 + index,
+    deletions: index % 3,
+  },
+}))
+
+const commitDetailPatches: GitEntryFilePatch[] = commitDetailFiles.map((file, index) => ({
+  ...file,
+  state: 'available',
+  patch: [
+    `diff --git a/${file.path} b/${file.path}`,
+    'index 0000000..1111111 100644',
+    `--- a/${file.path}`,
+    `+++ b/${file.path}`,
+    '@@ -1,6 +1,6 @@',
+    ...Array.from(
+      { length: 8 + (index % 5) * 4 },
+      (_, lineIndex) =>
+        `${lineIndex % 2 === 0 ? '+' : '-'} line ${lineIndex + 1} for ${file.fileId}`
+    ),
+  ].join('\n'),
+}))
+
+function RoutedCommitDetailBrowserHarness() {
+  const previousStaticModeRef = useRef(isStaticMode())
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            staleTime: Number.POSITIVE_INFINITY,
+          },
+        },
+      }),
+    []
+  )
+
+  useEffect(() => {
+    setStaticMode(true)
+    return () => {
+      setStaticMode(previousStaticModeRef.current)
+    }
+  }, [])
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div style={{ width: '480px', height: '320px' }}>
+        <div className="bottom-area min-h-0 shrink-0 overflow-auto">
+          <div
+            data-testid="commit-detail-scroll-root"
+            className="scrollbar-thin scrollbar-track-transparent flex h-full min-h-0 flex-col overflow-auto"
+            style={{ height: '300px' }}
+          >
+            <div className="flex flex-col gap-4 p-4">
+              <div className="vt-detail-content">
+                <GitEntryDetailPanel
+                  selector={commitDetailSelector}
+                  entry={commitDetailEntry}
+                  files={commitDetailFiles}
+                  eagerFiles={commitDetailPatches}
+                  isLoading={false}
+                  error={null}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </QueryClientProvider>
+  )
+}
+
 describe('useRoutedCarouselTabs browser', () => {
   afterEach(() => {
     document.body.innerHTML = ''
@@ -167,6 +363,136 @@ describe('useRoutedCarouselTabs browser', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('files-scroll-root').scrollTop).toBe(240)
+    })
+  })
+
+  it('preserves per-tab viewport scroll positions across 10 animated switches in a real browser', async () => {
+    render(
+      <RoutedTabsTestRouter>
+        <RoutedTabsViewportScrollHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('viewport-scroll-root')
+    const diffScrollSequence = [180, 840, 1280, 1960, 2480, 3120, 3880, 4520, 5160, 5880]
+    const fileScrollSequence = [120, 260, 420, 760, 980, 1240, 1480, 1720, 1960, 2280]
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    viewport.scrollTop = diffScrollSequence[0]
+    expect(viewport.scrollTop).toBe(diffScrollSequence[0])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Files' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+    })
+
+    viewport.scrollTop = fileScrollSequence[0]
+    expect(viewport.scrollTop).toBe(fileScrollSequence[0])
+
+    for (let iteration = 0; iteration < 10; iteration += 1) {
+      fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+      await waitFor(() => {
+        expect(getActivePanel()).toBe('diff')
+        expect(viewport.scrollTop).toBe(diffScrollSequence[iteration])
+      })
+
+      viewport.scrollTop = diffScrollSequence[(iteration + 1) % diffScrollSequence.length]
+      expect(viewport.scrollTop).toBe(
+        diffScrollSequence[(iteration + 1) % diffScrollSequence.length]
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      await waitFor(() => {
+        expect(getActivePanel()).toBe('files')
+        expect(viewport.scrollTop).toBe(fileScrollSequence[iteration])
+      })
+
+      viewport.scrollTop = fileScrollSequence[(iteration + 1) % fileScrollSequence.length]
+      expect(viewport.scrollTop).toBe(
+        fileScrollSequence[(iteration + 1) % fileScrollSequence.length]
+      )
+    }
+  })
+
+  it('preserves per-tab viewport scroll positions for commit detail in a real browser', async () => {
+    render(
+      <RoutedTabsTestRouter>
+        <RoutedCommitDetailBrowserHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('commit-detail-scroll-root')
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    viewport.scrollTop = 1400
+    expect(viewport.scrollTop).toBe(1400)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'File Tree' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBe(1400)
+    })
+
+    viewport.scrollTop = 300
+    expect(viewport.scrollTop).toBe(300)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Stream' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('diff')
+      expect(viewport.scrollTop).toBe(1400)
+    })
+
+    viewport.scrollTop = 1700
+    expect(viewport.scrollTop).toBe(1700)
+
+    fireEvent.click(screen.getByRole('button', { name: 'File Tree' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBe(300)
+    })
+  })
+
+  it('preserves commit detail viewport scroll when the route starts on file tree', async () => {
+    render(
+      <RoutedTabsTestRouter initialSearch="?gitPane=files">
+        <RoutedCommitDetailBrowserHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('commit-detail-scroll-root')
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+    })
+
+    viewport.scrollTop = 300
+    expect(viewport.scrollTop).toBe(300)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff Stream' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('diff')
+      expect(viewport.scrollTop).toBe(300)
+    })
+
+    viewport.scrollTop = 1200
+    expect(viewport.scrollTop).toBe(1200)
+
+    fireEvent.click(screen.getByRole('button', { name: 'File Tree' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBe(300)
     })
   })
 })

--- a/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.browser.test.tsx
@@ -10,7 +10,7 @@ import type {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { getRouterContext } from '@tanstack/react-router'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { useEffect, useMemo, useRef, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { useRoutedCarouselTabs } from './tabs'
@@ -216,6 +216,86 @@ function RoutedTabsViewportScrollHarness() {
       data-testid="viewport-scroll-root"
       style={{ width: '480px', height: '320px', overflowY: 'auto', padding: '16px' }}
     >
+      <div style={{ height: '72px' }} />
+      <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
+      <div style={{ height: '240px' }} />
+    </div>
+  )
+}
+
+function RoutedTabsUnstableViewportSelectorHarness() {
+  const previousStaticModeRef = useRef(isStaticMode())
+  const [rerenderCount, setRerenderCount] = useState(0)
+
+  useEffect(() => {
+    setStaticMode(true)
+    return () => {
+      setStaticMode(previousStaticModeRef.current)
+    }
+  }, [])
+
+  const routedTabs = useMemo(
+    () =>
+      [{ id: 'diff' as const }, { id: 'files' as const }] satisfies Array<{
+        id: 'diff' | 'files'
+      }>,
+    []
+  )
+  const viewportSelector = rerenderCount % 2 === 0 ? ['.main-content'] : ['.main-content']
+  const { onTabChange, selectedTab, tabsRef } = useRoutedCarouselTabs({
+    queryKey: 'gitPane',
+    tabs: routedTabs,
+    initialTab: 'diff',
+    viewportSelector,
+  })
+
+  const tabs = useMemo<Tab[]>(
+    () => [
+      {
+        id: 'diff',
+        label: 'Diff',
+        content: (
+          <div>
+            {Array.from({ length: 500 }, (_, index) => (
+              <div
+                key={`unstable-diff-row-${index + 1}`}
+                style={{ height: '20px', borderBottom: '1px solid transparent' }}
+              >
+                Diff row {index + 1}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+      {
+        id: 'files',
+        label: 'Files',
+        content: (
+          <div>
+            {Array.from({ length: 100 }, (_, index) => (
+              <div
+                key={`unstable-file-row-${index + 1}`}
+                style={{ height: '30px', borderBottom: '1px solid transparent' }}
+              >
+                File row {index + 1}
+              </div>
+            ))}
+          </div>
+        ),
+      },
+    ],
+    []
+  )
+
+  return (
+    <div
+      className="main-content"
+      data-testid="unstable-selector-viewport-scroll-root"
+      style={{ width: '480px', height: '320px', overflowY: 'auto', padding: '16px' }}
+    >
+      <button type="button" onClick={() => setRerenderCount((current) => current + 1)}>
+        Rerender
+      </button>
       <div style={{ height: '72px' }} />
       <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
       <div style={{ height: '240px' }} />
@@ -494,5 +574,141 @@ describe('useRoutedCarouselTabs browser', () => {
       expect(getActivePanel()).toBe('files')
       expect(viewport.scrollTop).toBe(300)
     })
+  })
+
+  it('keeps commit detail viewport user-scrollable after tree-to-diff reveal in a real browser', async () => {
+    render(
+      <RoutedTabsTestRouter initialSearch="?gitPane=files">
+        <RoutedCommitDetailBrowserHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('commit-detail-scroll-root')
+    const targetFile = commitDetailFiles.at(-1)
+    expect(targetFile).toBeTruthy()
+    if (!targetFile) {
+      return
+    }
+
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+    })
+
+    fireEvent.click(screen.getByRole('treeitem', { name: targetFile.displayPath }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('diff')
+      expect(viewport.scrollTop).toBeGreaterThan(400)
+    })
+
+    const revealedScrollTop = viewport.scrollTop
+    const nextScrollTop = revealedScrollTop + 180
+    viewport.scrollTop = nextScrollTop
+    viewport.dispatchEvent(new Event('scroll', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(viewport.scrollTop).toBe(nextScrollTop)
+    })
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 360)
+    })
+
+    expect(viewport.scrollTop).toBe(nextScrollTop)
+  })
+
+  it('does not restore stale viewport scroll when selector arrays rerender with the same values', async () => {
+    render(
+      <RoutedTabsTestRouter>
+        <RoutedTabsUnstableViewportSelectorHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('unstable-selector-viewport-scroll-root')
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    viewport.scrollTop = 880
+    expect(viewport.scrollTop).toBe(880)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Files' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBe(880)
+    })
+
+    viewport.scrollTop = 260
+    expect(viewport.scrollTop).toBe(260)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('diff')
+      expect(viewport.scrollTop).toBe(880)
+    })
+
+    const nextScrollTop = 1120
+    viewport.scrollTop = nextScrollTop
+    expect(viewport.scrollTop).toBe(nextScrollTop)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rerender' }))
+
+    await waitFor(() => {
+      expect(viewport.scrollTop).toBe(nextScrollTop)
+    })
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 360)
+    })
+
+    expect(viewport.scrollTop).toBe(nextScrollTop)
+  })
+
+  it('restores the file tree viewport after returning from a tree-to-diff reveal', async () => {
+    render(
+      <RoutedTabsTestRouter initialSearch="?gitPane=files">
+        <RoutedCommitDetailBrowserHarness />
+      </RoutedTabsTestRouter>
+    )
+
+    const viewport = await screen.findByTestId('commit-detail-scroll-root')
+    const targetFile = commitDetailFiles.at(-1)
+    expect(targetFile).toBeTruthy()
+    if (!targetFile) {
+      return
+    }
+
+    const getActivePanel = () =>
+      viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')?.dataset.tabPanel
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBe(0)
+    })
+
+    fireEvent.click(screen.getByRole('treeitem', { name: targetFile.displayPath }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('diff')
+      expect(viewport.scrollTop).toBeGreaterThan(400)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'File Tree' }))
+
+    await waitFor(() => {
+      expect(getActivePanel()).toBe('files')
+      expect(viewport.scrollTop).toBeLessThan(80)
+    })
+
+    const treeRoot = await screen.findByRole('tree', { name: 'Changed files' })
+    const treeRect = treeRoot.getBoundingClientRect()
+    const viewportRect = viewport.getBoundingClientRect()
+
+    expect(treeRect.bottom).toBeGreaterThan(viewportRect.top + 20)
+    expect(treeRect.top).toBeLessThan(viewportRect.bottom - 20)
   })
 })

--- a/packages/web/src/lib/view-transitions/tabs.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.test.tsx
@@ -1,4 +1,12 @@
+import { GitEntryDetailPanel } from '@/components/git/git-panel-detail'
 import { Tabs, type Tab } from '@/components/tabs'
+import type {
+  DashboardGitEntry,
+  GitEntryFilePatch,
+  GitEntryFileSummary,
+  GitEntrySelector,
+} from '@openspecui/core'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useEffect, useMemo } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,7 +15,7 @@ import { useRoutedCarouselTabs } from './tabs'
 
 const { runViewTransitionMock } = vi.hoisted(() => ({
   runViewTransitionMock: vi.fn(
-    ({
+    async ({
       collectAfterEntries,
       collectBeforeEntries,
       update,
@@ -18,8 +26,8 @@ const { runViewTransitionMock } = vi.hoisted(() => ({
     }) => {
       collectBeforeEntries?.()
       update()
+      await Promise.resolve()
       collectAfterEntries?.()
-      return Promise.resolve()
     }
   ),
 }))
@@ -148,14 +156,114 @@ function RoutedTabsInnerScrollHarness() {
   )
 }
 
-function installScrollableTabLayoutMocks() {
+const commitDetailEntry: DashboardGitEntry = {
+  type: 'commit',
+  hash: 'abc12345',
+  title: 'feat: preserve commit detail tab scroll',
+  committedAt: Date.UTC(2026, 3, 14),
+  relatedChanges: ['commit-detail-vt-scroll'],
+  diff: {
+    files: 24,
+    insertions: 168,
+    deletions: 42,
+  },
+}
+
+const commitDetailSelector: GitEntrySelector = {
+  type: 'commit',
+  hash: commitDetailEntry.hash,
+}
+
+const commitDetailFiles: GitEntryFileSummary[] = Array.from({ length: 24 }, (_, index) => ({
+  fileId: `commit-detail-file-${index + 1}`,
+  source: 'tracked',
+  path: `src/features/group-${Math.floor(index / 4) + 1}/file-${index + 1}.tsx`,
+  displayPath: `src/features/group-${Math.floor(index / 4) + 1}/file-${index + 1}.tsx`,
+  previousPath: null,
+  changeType:
+    index % 4 === 0
+      ? 'added'
+      : index % 4 === 1
+        ? 'modified'
+        : index % 4 === 2
+          ? 'deleted'
+          : 'renamed',
+  diff: {
+    state: 'ready',
+    files: 1,
+    insertions: 4 + index,
+    deletions: index % 3,
+  },
+}))
+
+const commitDetailPatches: GitEntryFilePatch[] = commitDetailFiles.map((file, index) => ({
+  ...file,
+  state: 'available',
+  patch: [
+    `diff --git a/${file.path} b/${file.path}`,
+    'index 0000000..1111111 100644',
+    `--- a/${file.path}`,
+    `+++ b/${file.path}`,
+    '@@ -1,6 +1,6 @@',
+    ...Array.from(
+      { length: 8 + (index % 5) * 4 },
+      (_, lineIndex) =>
+        `${lineIndex % 2 === 0 ? '+' : '-'} line ${lineIndex + 1} for ${file.fileId}`
+    ),
+  ].join('\n'),
+}))
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+    },
+  })
+}
+
+function RoutedCommitDetailHarness() {
+  const queryClient = useMemo(() => createQueryClient(), [])
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div
+        className="main-content"
+        data-testid="viewport"
+        style={{ width: 480, height: 320, overflowY: 'auto', padding: '16px' }}
+      >
+        <div style={{ height: 72 }} />
+        <GitEntryDetailPanel
+          selector={commitDetailSelector}
+          entry={commitDetailEntry}
+          files={commitDetailFiles}
+          eagerFiles={commitDetailPatches}
+          isLoading={false}
+          error={null}
+        />
+        <div style={{ height: 160 }} />
+      </div>
+    </QueryClientProvider>
+  )
+}
+
+function installScrollableTabLayoutMocks(
+  options: {
+    panelHeights?: Partial<Record<'diff' | 'files', number>>
+    baseOffset?: number
+    viewportHeight?: number
+  } = {}
+) {
   const viewport = screen.getByTestId('viewport')
   const panelHeights: Record<'diff' | 'files', number> = {
     diff: 1400,
     files: 900,
+    ...options.panelHeights,
   }
-  const baseOffset = 168
-  const viewportHeight = 240
+  const baseOffset = options.baseOffset ?? 168
+  const viewportHeight = options.viewportHeight ?? 240
   let viewportScrollTop = 0
 
   const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
@@ -252,6 +360,9 @@ function installScrollableTabLayoutMocks() {
 
   return {
     viewport,
+    getActivePanel() {
+      return viewport.querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+    },
     restore() {
       Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
         configurable: true,
@@ -483,6 +594,118 @@ describe('useRoutedCarouselTabs', () => {
       })
     } finally {
       restore()
+    }
+  })
+
+  it('preserves per-tab viewport scroll memory across repeated animated switches', async () => {
+    render(<RoutedTabsScrollHarness />)
+    const { restore, viewport, getActivePanel } = installScrollableTabLayoutMocks({
+      panelHeights: {
+        diff: 500 * 20,
+        files: 100 * 30,
+      },
+    })
+
+    const diffScrollSequence = [180, 840, 1280, 1960, 2480, 3120, 3880, 4520, 5160, 5880]
+    const fileScrollSequence = [120, 260, 420, 760, 980, 1240, 1480, 1720, 1960, 2280]
+
+    try {
+      viewport.scrollTop = diffScrollSequence[0]
+
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      await waitFor(() => {
+        expect(getActivePanel()?.dataset.tabPanel).toBe('files')
+      })
+
+      viewport.scrollTop = fileScrollSequence[0]
+
+      for (let iteration = 0; iteration < 10; iteration += 1) {
+        fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+        await waitFor(() => {
+          expect(getActivePanel()?.dataset.tabPanel).toBe('diff')
+          expect(viewport.scrollTop).toBe(diffScrollSequence[iteration])
+        })
+
+        const nextDiffScrollTop = diffScrollSequence[(iteration + 1) % diffScrollSequence.length]
+        viewport.scrollTop = nextDiffScrollTop
+
+        fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+        await waitFor(() => {
+          expect(getActivePanel()?.dataset.tabPanel).toBe('files')
+          expect(viewport.scrollTop).toBe(fileScrollSequence[iteration])
+        })
+
+        const nextFileScrollTop = fileScrollSequence[(iteration + 1) % fileScrollSequence.length]
+        viewport.scrollTop = nextFileScrollTop
+      }
+    } finally {
+      restore()
+    }
+  })
+
+  it('preserves commit-detail diff scroll after VT finalization even if the frozen panel loses scrollTop', async () => {
+    const defaultImplementation = runViewTransitionMock.getMockImplementation()
+    runViewTransitionMock.mockImplementation(
+      async ({
+        collectAfterEntries,
+        collectBeforeEntries,
+        update,
+      }: {
+        collectAfterEntries?: () => unknown
+        collectBeforeEntries?: () => unknown
+        update: () => void
+      }) => {
+        collectBeforeEntries?.()
+        update()
+        await Promise.resolve()
+        collectAfterEntries?.()
+
+        const activePanel = document.querySelector<HTMLElement>('[data-tab-panel-state="active"]')
+        if (activePanel?.dataset.tabPanel === 'diff') {
+          activePanel.scrollTop = 0
+        }
+      }
+    )
+
+    render(<RoutedCommitDetailHarness />)
+    const { restore, viewport, getActivePanel } = installScrollableTabLayoutMocks({
+      panelHeights: {
+        diff: 500 * 20,
+        files: 100 * 30,
+      },
+      baseOffset: 196,
+      viewportHeight: 320,
+    })
+
+    try {
+      viewport.scrollTop = 2480
+
+      fireEvent.click(screen.getByRole('button', { name: 'File Tree' }))
+
+      await waitFor(() => {
+        expect(getActivePanel()?.dataset.tabPanel).toBe('files')
+      })
+
+      viewport.scrollTop = 760
+
+      fireEvent.click(screen.getByRole('button', { name: 'Diff Stream' }))
+
+      await waitFor(() => {
+        expect(getActivePanel()?.dataset.tabPanel).toBe('diff')
+        expect(viewport.scrollTop).toBe(2480)
+      })
+
+      await waitFor(() => {
+        expect(viewport.scrollTop).toBe(2480)
+      })
+    } finally {
+      restore()
+      if (defaultImplementation) {
+        runViewTransitionMock.mockImplementation(defaultImplementation)
+      }
     }
   })
 

--- a/packages/web/src/lib/view-transitions/tabs.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.test.tsx
@@ -243,6 +243,51 @@ describe('useRoutedCarouselTabs', () => {
     expect(runViewTransitionMock).toHaveBeenCalledTimes(1)
   })
 
+  it('collects default header VT layers together with the active panel', async () => {
+    runViewTransitionMock.mockImplementationOnce(
+      ({
+        collectAfterEntries,
+        collectBeforeEntries,
+        update,
+      }: {
+        collectAfterEntries?: () => unknown
+        collectBeforeEntries?: () => unknown
+        update: () => void
+      }) => {
+        const beforeNames = ((collectBeforeEntries?.() ?? []) as Array<[HTMLElement, string]>)
+          .map(([, name]) => name)
+          .sort()
+        update()
+        const afterNames = ((collectAfterEntries?.() ?? []) as Array<[HTMLElement, string]>)
+          .map(([, name]) => name)
+          .sort()
+
+        expect(beforeNames).toEqual([
+          'vt-tab-edge',
+          'vt-tab-header-foreground',
+          'vt-tab-header-shell',
+          'vt-tab-panel',
+        ])
+        expect(afterNames).toEqual([
+          'vt-tab-edge',
+          'vt-tab-header-foreground',
+          'vt-tab-header-shell',
+          'vt-tab-panel',
+        ])
+
+        return Promise.resolve()
+      }
+    )
+
+    render(<RoutedTabsScrollHarness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+    await waitFor(() => {
+      expect(runViewTransitionMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('restores page scroll after animated tab switches when viewportSelector is provided', async () => {
     render(<RoutedTabsScrollHarness />)
     const { restore, viewport } = installScrollableTabLayoutMocks()

--- a/packages/web/src/lib/view-transitions/tabs.test.tsx
+++ b/packages/web/src/lib/view-transitions/tabs.test.tsx
@@ -106,6 +106,48 @@ function RoutedTabsScrollHarness() {
   )
 }
 
+function RoutedTabsInnerScrollHarness() {
+  const tabs = useMemo<Tab[]>(
+    () => [
+      {
+        id: 'diff',
+        label: 'Diff',
+        content: <div data-testid="diff-content" style={{ height: 320 }} />,
+      },
+      {
+        id: 'files',
+        label: 'Files',
+        unmountOnHide: true,
+        content: (
+          <div className="py-3">
+            <div
+              data-tab-scroll-root="true"
+              data-testid="files-scroll-root"
+              style={{ height: 160, overflowY: 'auto' }}
+            >
+              <div style={{ height: 720 }} />
+            </div>
+          </div>
+        ),
+      },
+    ],
+    []
+  )
+  const { tabsRef, selectedTab, onTabChange } = useRoutedCarouselTabs({
+    queryKey: 'gitPane',
+    tabs,
+    initialTab: 'diff',
+    viewportSelector: '.main-content',
+  })
+
+  return (
+    <div className="main-content" data-testid="viewport" style={{ height: 240, overflowY: 'auto' }}>
+      <div style={{ height: 96 }} />
+      <Tabs ref={tabsRef} tabs={tabs} selectedTab={selectedTab} onTabChange={onTabChange} />
+    </div>
+  )
+}
+
 function installScrollableTabLayoutMocks() {
   const viewport = screen.getByTestId('viewport')
   const panelHeights: Record<'diff' | 'files', number> = {
@@ -210,6 +252,94 @@ function installScrollableTabLayoutMocks() {
 
   return {
     viewport,
+    restore() {
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        writable: true,
+        value: originalGetBoundingClientRect,
+      })
+    },
+  }
+}
+
+function installInnerScrollTabLayoutMocks() {
+  const viewport = screen.getByTestId('viewport')
+  const viewportHeight = 240
+  const baseOffset = 96
+  let viewportScrollTop = 0
+  const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    writable: true,
+    value: function mockGetBoundingClientRect(this: HTMLElement) {
+      if (this.dataset.testid === 'viewport') {
+        return {
+          x: 0,
+          y: 0,
+          width: 320,
+          height: viewportHeight,
+          top: 0,
+          right: 320,
+          bottom: viewportHeight,
+          left: 0,
+          toJSON: () => ({}),
+        } satisfies DOMRect
+      }
+
+      if (this.dataset.tabPanel === 'diff') {
+        const top = baseOffset - viewportScrollTop
+        return {
+          x: 0,
+          y: top,
+          width: 320,
+          height: 320,
+          top,
+          right: 320,
+          bottom: top + 320,
+          left: 0,
+          toJSON: () => ({}),
+        } satisfies DOMRect
+      }
+
+      if (this.dataset.tabPanel === 'files') {
+        const top = baseOffset - viewportScrollTop
+        return {
+          x: 0,
+          y: top,
+          width: 320,
+          height: 184,
+          top,
+          right: 320,
+          bottom: top + 184,
+          left: 0,
+          toJSON: () => ({}),
+        } satisfies DOMRect
+      }
+
+      return originalGetBoundingClientRect.call(this)
+    },
+  })
+
+  Object.defineProperty(viewport, 'clientHeight', {
+    configurable: true,
+    get: () => viewportHeight,
+  })
+
+  Object.defineProperty(viewport, 'scrollHeight', {
+    configurable: true,
+    get: () => 640,
+  })
+
+  Object.defineProperty(viewport, 'scrollTop', {
+    configurable: true,
+    get: () => viewportScrollTop,
+    set: (value: number) => {
+      viewportScrollTop = value
+    },
+  })
+
+  return {
     restore() {
       Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
         configurable: true,
@@ -350,6 +480,81 @@ describe('useRoutedCarouselTabs', () => {
           .querySelector<HTMLElement>('[data-tab-panel-state="active"]')
         expect(activePanel?.dataset.tabPanel).toBe('diff')
         expect(viewport.scrollTop).toBe(420)
+      })
+    } finally {
+      restore()
+    }
+  })
+
+  it('restores marked inner scroll roots when the tab panel remounts', async () => {
+    render(<RoutedTabsInnerScrollHarness />)
+    const { restore } = installInnerScrollTabLayoutMocks()
+
+    try {
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      const firstScrollRoot = await screen.findByTestId('files-scroll-root')
+      firstScrollRoot.scrollTop = 240
+
+      fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('files-scroll-root')).toBeNull()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('files-scroll-root').scrollTop).toBe(240)
+      })
+    } finally {
+      restore()
+    }
+  })
+
+  it('ignores stale transition cleanup when a tab is reopened before the prior VT finishes', async () => {
+    let resolveFirstTransition: () => void = () => {}
+    runViewTransitionMock.mockImplementationOnce(
+      ({
+        collectAfterEntries,
+        collectBeforeEntries,
+        update,
+      }: {
+        collectAfterEntries?: () => unknown
+        collectBeforeEntries?: () => unknown
+        update: () => void
+      }) => {
+        collectBeforeEntries?.()
+        update()
+        collectAfterEntries?.()
+
+        return new Promise<void>((resolve) => {
+          resolveFirstTransition = resolve
+        })
+      }
+    )
+
+    render(<RoutedTabsInnerScrollHarness />)
+    const { restore } = installInnerScrollTabLayoutMocks()
+
+    try {
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      const firstScrollRoot = await screen.findByTestId('files-scroll-root')
+      firstScrollRoot.scrollTop = 240
+
+      fireEvent.click(screen.getByRole('button', { name: 'Diff' }))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('files-scroll-root')).toBeNull()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Files' }))
+
+      resolveFirstTransition()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('files-scroll-root').scrollTop).toBe(240)
       })
     } finally {
       restore()

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -115,6 +115,22 @@ function resolveTabArea(pathname: string, area?: VTArea): VTArea {
   return isStaticMode() ? 'main' : navController.getAreaForPath(pathname)
 }
 
+function normalizeViewportSelectorOption(
+  viewportSelector?: ViewportSelector
+): readonly string[] | undefined {
+  if (!viewportSelector) {
+    return undefined
+  }
+
+  const selectors =
+    typeof viewportSelector === 'string' ? viewportSelector.split(',') : [...viewportSelector]
+  const normalized = selectors
+    .map((selector) => selector.trim())
+    .filter((selector) => selector.length > 0)
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
 function readWindowLocation(): RoutedTabsLocation {
   if (typeof window === 'undefined') return SERVER_LOCATION
   return {
@@ -233,9 +249,14 @@ export function useRoutedCarouselTabs<TTabId extends string>({
 }: UseRoutedCarouselTabsOptions<TTabId>) {
   const { location, router } = useRoutedTabsLocation()
   const tabsRef = useRef<TabsHandle | null>(null)
+  const viewportSelectorValue = useMemo(
+    () => normalizeViewportSelectorOption(viewportSelector),
+    [typeof viewportSelector === 'string' ? viewportSelector : (viewportSelector ?? []).join('\0')]
+  )
   const scrollMemoryByTabRef = useRef(new Map<string, TabScrollMemory>())
   const frozenTabsRef = useRef(new Map<string, FrozenTabEntry>())
   const frozenTabTokenRef = useRef(0)
+  const skipNextRestoreTabRef = useRef<string | null>(null)
   const selectedFromLocation = useMemo(
     () =>
       resolveSelectedTab({
@@ -258,7 +279,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     selectedFromLocation,
     selectedTab,
     tabs,
-    viewportSelector,
+    viewportSelector: viewportSelectorValue,
   })
 
   latestRef.current = {
@@ -271,7 +292,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     selectedFromLocation,
     selectedTab,
     tabs,
-    viewportSelector,
+    viewportSelector: viewportSelectorValue,
   }
 
   const cleanupFrozenTabById = useCallback((tabId: string, token?: number) => {
@@ -381,15 +402,20 @@ export function useRoutedCarouselTabs<TTabId extends string>({
   }, [selectedFromLocation])
 
   useLayoutEffect(() => {
+    if (skipNextRestoreTabRef.current === selectedTab) {
+      skipNextRestoreTabRef.current = null
+      return
+    }
+
     const snapshot = scrollMemoryByTabRef.current.get(selectedTab)
-    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelector)
+    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelectorValue)
     const panel = elements?.panel ?? tabsRef.current?.getPanel(selectedTab) ?? null
     restorePanelContentScroll(panel, snapshot)
     restorePanelViewportScroll(panel, elements?.viewport ?? null, snapshot)
-  }, [selectedTab, viewportSelector])
+  }, [selectedTab, viewportSelectorValue])
 
   useEffect(() => {
-    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelector)
+    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelectorValue)
     const contentScrollRoot = elements?.contentScrollRoot
     if (!elements || !contentScrollRoot || contentScrollRoot === elements.panel) {
       return
@@ -413,7 +439,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     return () => {
       contentScrollRoot.removeEventListener('scroll', rememberContentScroll)
     }
-  }, [selectedTab, viewportSelector])
+  }, [selectedTab, viewportSelectorValue])
 
   useEffect(() => {
     const validIds = new Set(tabs.map((tab) => tab.id))
@@ -449,6 +475,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       options?: {
         animate?: boolean
         history?: 'replace' | 'push'
+        transferScroll?: boolean
       }
     ) => {
       const {
@@ -468,6 +495,7 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       if (!validIds.has(nextTabId) && !allowUnknown) return
 
       const nextHistory = options?.history ?? defaultHistory
+      const transferScroll = options?.transferScroll ?? true
       if (currentTab === nextTabId && latestSelectedFromLocation === nextTabId) {
         return
       }
@@ -502,6 +530,31 @@ export function useRoutedCarouselTabs<TTabId extends string>({
           return
         }
         navController.push(nextArea, href, latestLocation.state)
+      }
+
+      if (!transferScroll) {
+        const outgoingSnapshot = captureTabSnapshot(currentTab, latestViewportSelector)
+        if (outgoingSnapshot) {
+          scrollMemoryByTabRef.current.set(currentTab, outgoingSnapshot)
+        }
+        skipNextRestoreTabRef.current = nextTabId
+
+        if (!options?.animate || currentTab === nextTabId) {
+          commitSelection()
+          return
+        }
+
+        void runViewTransition({
+          intent: {
+            area: resolveTabArea(latestLocation.pathname, latestArea),
+            kind: 'tab-carousel',
+            direction: 'forward',
+          },
+          collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
+          collectAfterEntries: () => collectTabEntries(tabsRef.current, nextTabId),
+          update: commitSelection,
+        })
+        return
       }
 
       const runSelectionWithScrollTransfer = (animated: boolean) => {

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -6,6 +6,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -20,10 +21,16 @@ import {
   finalizeFrozenIncomingTab,
   freezeIncomingTab,
   freezeOutgoingTab,
+  restorePanelContentScroll,
   resolveTabScrollElements,
   type FrozenTabState,
   type TabScrollMemory,
 } from './tab-scroll-freeze'
+
+interface FrozenTabEntry {
+  state: FrozenTabState
+  token: number
+}
 
 export interface UseRoutedCarouselTabsOptions<TTabId extends string> {
   queryKey: string
@@ -225,7 +232,8 @@ export function useRoutedCarouselTabs<TTabId extends string>({
   const { location, router } = useRoutedTabsLocation()
   const tabsRef = useRef<TabsHandle | null>(null)
   const scrollMemoryByTabRef = useRef(new Map<string, TabScrollMemory>())
-  const frozenTabsRef = useRef(new Map<string, FrozenTabState>())
+  const frozenTabsRef = useRef(new Map<string, FrozenTabEntry>())
+  const frozenTabTokenRef = useRef(0)
   const selectedFromLocation = useMemo(
     () =>
       resolveSelectedTab({
@@ -264,19 +272,19 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     viewportSelector,
   }
 
-  const cleanupFrozenTabById = useCallback((tabId: string) => {
-    const frozenState = frozenTabsRef.current.get(tabId)
-    if (!frozenState) {
+  const cleanupFrozenTabById = useCallback((tabId: string, token?: number) => {
+    const frozenEntry = frozenTabsRef.current.get(tabId)
+    if (!frozenEntry || (token != null && frozenEntry.token !== token)) {
       return
     }
 
-    cleanupFrozenTab(frozenState)
+    cleanupFrozenTab(frozenEntry.state)
     frozenTabsRef.current.delete(tabId)
   }, [])
 
   const cleanupAllFrozenTabs = useCallback(() => {
-    for (const frozenState of frozenTabsRef.current.values()) {
-      cleanupFrozenTab(frozenState)
+    for (const frozenEntry of frozenTabsRef.current.values()) {
+      cleanupFrozenTab(frozenEntry.state)
     }
     frozenTabsRef.current.clear()
   }, [])
@@ -295,7 +303,12 @@ export function useRoutedCarouselTabs<TTabId extends string>({
 
       scrollMemoryByTabRef.current.set(tabId, snapshot)
       cleanupFrozenTabById(tabId)
-      frozenTabsRef.current.set(tabId, freezeOutgoingTab(elements, snapshot))
+      const token = ++frozenTabTokenRef.current
+      frozenTabsRef.current.set(tabId, {
+        token,
+        state: freezeOutgoingTab(elements, snapshot),
+      })
+      return token
     },
     [cleanupFrozenTabById]
   )
@@ -304,28 +317,32 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     (tabId: string, nextViewportSelector?: string) => {
       const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
       if (!elements) {
-        return false
+        return null
       }
 
       const snapshot = scrollMemoryByTabRef.current.get(tabId) ?? captureTabScrollMemory(elements)
       if (!snapshot) {
-        return false
+        return null
       }
 
       cleanupFrozenTabById(tabId)
-      frozenTabsRef.current.set(tabId, freezeIncomingTab(elements, snapshot))
-      return true
+      const token = ++frozenTabTokenRef.current
+      frozenTabsRef.current.set(tabId, {
+        token,
+        state: freezeIncomingTab(elements, snapshot),
+      })
+      return token
     },
     [cleanupFrozenTabById]
   )
 
-  const finalizeIncomingTab = useCallback((tabId: string) => {
-    const frozenState = frozenTabsRef.current.get(tabId)
-    if (!frozenState) {
+  const finalizeIncomingTab = useCallback((tabId: string, token?: number) => {
+    const frozenEntry = frozenTabsRef.current.get(tabId)
+    if (!frozenEntry || (token != null && frozenEntry.token !== token)) {
       return
     }
 
-    finalizeFrozenIncomingTab(frozenState)
+    finalizeFrozenIncomingTab(frozenEntry.state)
     frozenTabsRef.current.delete(tabId)
   }, [])
 
@@ -334,6 +351,40 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       current === selectedFromLocation ? current : selectedFromLocation
     )
   }, [selectedFromLocation])
+
+  useLayoutEffect(() => {
+    const snapshot = scrollMemoryByTabRef.current.get(selectedTab)
+    const panel = tabsRef.current?.getPanel(selectedTab) ?? null
+    restorePanelContentScroll(panel, snapshot)
+  }, [selectedTab])
+
+  useEffect(() => {
+    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelector)
+    const contentScrollRoot = elements?.contentScrollRoot
+    if (!elements || !contentScrollRoot || contentScrollRoot === elements.panel) {
+      return
+    }
+
+    const rememberContentScroll = () => {
+      const nextSnapshot =
+        captureTabScrollMemory(elements) ?? scrollMemoryByTabRef.current.get(selectedTab)
+      if (!nextSnapshot) {
+        return
+      }
+
+      scrollMemoryByTabRef.current.set(selectedTab, {
+        ...nextSnapshot,
+        contentScrollTop: contentScrollRoot.scrollTop,
+      })
+    }
+
+    rememberContentScroll()
+    contentScrollRoot.addEventListener('scroll', rememberContentScroll, { passive: true })
+
+    return () => {
+      contentScrollRoot.removeEventListener('scroll', rememberContentScroll)
+    }
+  }, [selectedTab, viewportSelector])
 
   useEffect(() => {
     const validIds = new Set(tabs.map((tab) => tab.id))
@@ -425,19 +476,23 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       }
 
       const runSelectionWithScrollTransfer = (animated: boolean) => {
-        captureOutgoingTab(currentTab, latestViewportSelector)
+        const outgoingToken = captureOutgoingTab(currentTab, latestViewportSelector)
 
         if (!animated) {
           flushSync(() => {
             commitSelection()
           })
-          prepareIncomingTab(nextTabId, latestViewportSelector)
-          finalizeIncomingTab(nextTabId)
-          cleanupFrozenTabById(currentTab)
+          const incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
+          if (incomingToken != null) {
+            finalizeIncomingTab(nextTabId, incomingToken)
+          }
+          if (outgoingToken != null) {
+            cleanupFrozenTabById(currentTab, outgoingToken)
+          }
           return
         }
 
-        let hasPreparedIncoming = false
+        let incomingToken: number | null = null
         void runViewTransition({
           intent: {
             area: resolveTabArea(latestLocation.pathname, latestArea),
@@ -446,18 +501,22 @@ export function useRoutedCarouselTabs<TTabId extends string>({
           },
           collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
           collectAfterEntries: () => {
-            if (!hasPreparedIncoming) {
-              hasPreparedIncoming = prepareIncomingTab(nextTabId, latestViewportSelector)
+            if (incomingToken == null) {
+              incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
             }
             return collectTabEntries(tabsRef.current, nextTabId)
           },
           update: commitSelection,
         }).finally(() => {
-          if (!hasPreparedIncoming) {
-            prepareIncomingTab(nextTabId, latestViewportSelector)
+          if (incomingToken == null) {
+            incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
           }
-          finalizeIncomingTab(nextTabId)
-          cleanupFrozenTabById(currentTab)
+          if (incomingToken != null) {
+            finalizeIncomingTab(nextTabId, incomingToken)
+          }
+          if (outgoingToken != null) {
+            cleanupFrozenTabById(currentTab, outgoingToken)
+          }
         })
       }
 

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -191,6 +191,21 @@ function collectTabEntries(handle: TabsHandle | null, tabId: string): Array<[HTM
   if (!handle) return []
 
   const entries: Array<[HTMLElement, string]> = []
+  const headerShell = handle.getHeaderShell()
+  if (headerShell) {
+    entries.push([headerShell, 'vt-tab-header-shell'])
+  }
+
+  const selectionIndicator = handle.getSelectionIndicator()
+  if (selectionIndicator) {
+    entries.push([selectionIndicator, 'vt-tab-edge'])
+  }
+
+  const headerForeground = handle.getHeaderForeground()
+  if (headerForeground) {
+    entries.push([headerForeground, 'vt-tab-header-foreground'])
+  }
+
   const panel = handle.getPanel(tabId)
   if (panel) {
     entries.push([panel, 'vt-tab-panel'])

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -21,10 +21,12 @@ import {
   finalizeFrozenIncomingTab,
   freezeIncomingTab,
   freezeOutgoingTab,
-  restorePanelContentScroll,
   resolveTabScrollElements,
+  restorePanelContentScroll,
+  restorePanelViewportScroll,
   type FrozenTabState,
   type TabScrollMemory,
+  type ViewportSelector,
 } from './tab-scroll-freeze'
 
 interface FrozenTabEntry {
@@ -39,7 +41,7 @@ export interface UseRoutedCarouselTabsOptions<TTabId extends string> {
   area?: VTArea
   history?: 'replace' | 'push'
   allowUnknownSelection?: boolean
-  viewportSelector?: string
+  viewportSelector?: string | readonly string[]
 }
 
 interface RoutedTabsLocation {
@@ -289,14 +291,30 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     frozenTabsRef.current.clear()
   }, [])
 
+  const captureTabSnapshot = useCallback(
+    (tabId: string, nextViewportSelector?: ViewportSelector) => {
+      const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
+      if (!elements) {
+        return null
+      }
+
+      return captureTabScrollMemory(elements)
+    },
+    []
+  )
+
   const captureOutgoingTab = useCallback(
-    (tabId: string, nextViewportSelector?: string) => {
+    (
+      tabId: string,
+      nextViewportSelector?: ViewportSelector,
+      snapshotOverride?: TabScrollMemory | null
+    ) => {
       const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
       if (!elements) {
         return
       }
 
-      const snapshot = captureTabScrollMemory(elements)
+      const snapshot = snapshotOverride ?? captureTabScrollMemory(elements)
       if (!snapshot) {
         return
       }
@@ -314,17 +332,27 @@ export function useRoutedCarouselTabs<TTabId extends string>({
   )
 
   const prepareIncomingTab = useCallback(
-    (tabId: string, nextViewportSelector?: string) => {
+    (
+      tabId: string,
+      nextViewportSelector?: ViewportSelector,
+      fallbackSnapshot?: TabScrollMemory | null
+    ) => {
       const elements = resolveTabScrollElements(tabsRef.current, tabId, nextViewportSelector)
       if (!elements) {
         return null
       }
 
-      const snapshot = scrollMemoryByTabRef.current.get(tabId) ?? captureTabScrollMemory(elements)
+      const snapshot =
+        scrollMemoryByTabRef.current.get(tabId) ??
+        fallbackSnapshot ??
+        captureTabScrollMemory(elements)
       if (!snapshot) {
         return null
       }
 
+      if (!scrollMemoryByTabRef.current.has(tabId)) {
+        scrollMemoryByTabRef.current.set(tabId, snapshot)
+      }
       cleanupFrozenTabById(tabId)
       const token = ++frozenTabTokenRef.current
       frozenTabsRef.current.set(tabId, {
@@ -354,9 +382,11 @@ export function useRoutedCarouselTabs<TTabId extends string>({
 
   useLayoutEffect(() => {
     const snapshot = scrollMemoryByTabRef.current.get(selectedTab)
-    const panel = tabsRef.current?.getPanel(selectedTab) ?? null
+    const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelector)
+    const panel = elements?.panel ?? tabsRef.current?.getPanel(selectedTab) ?? null
     restorePanelContentScroll(panel, snapshot)
-  }, [selectedTab])
+    restorePanelViewportScroll(panel, elements?.viewport ?? null, snapshot)
+  }, [selectedTab, viewportSelector])
 
   useEffect(() => {
     const elements = resolveTabScrollElements(tabsRef.current, selectedTab, viewportSelector)
@@ -366,14 +396,13 @@ export function useRoutedCarouselTabs<TTabId extends string>({
     }
 
     const rememberContentScroll = () => {
-      const nextSnapshot =
-        captureTabScrollMemory(elements) ?? scrollMemoryByTabRef.current.get(selectedTab)
-      if (!nextSnapshot) {
+      const existingSnapshot = scrollMemoryByTabRef.current.get(selectedTab)
+      if (!existingSnapshot) {
         return
       }
 
       scrollMemoryByTabRef.current.set(selectedTab, {
-        ...nextSnapshot,
+        ...existingSnapshot,
         contentScrollTop: contentScrollRoot.scrollTop,
       })
     }
@@ -476,13 +505,26 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       }
 
       const runSelectionWithScrollTransfer = (animated: boolean) => {
-        const outgoingToken = captureOutgoingTab(currentTab, latestViewportSelector)
+        const outgoingSnapshot = captureTabSnapshot(currentTab, latestViewportSelector)
+        const incomingSeedSnapshot =
+          scrollMemoryByTabRef.current.get(nextTabId) ??
+          outgoingSnapshot ??
+          captureTabSnapshot(nextTabId, latestViewportSelector)
+        const outgoingToken = captureOutgoingTab(
+          currentTab,
+          latestViewportSelector,
+          outgoingSnapshot
+        )
 
         if (!animated) {
           flushSync(() => {
             commitSelection()
           })
-          const incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
+          const incomingToken = prepareIncomingTab(
+            nextTabId,
+            latestViewportSelector,
+            incomingSeedSnapshot
+          )
           if (incomingToken != null) {
             finalizeIncomingTab(nextTabId, incomingToken)
           }
@@ -502,14 +544,22 @@ export function useRoutedCarouselTabs<TTabId extends string>({
           collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
           collectAfterEntries: () => {
             if (incomingToken == null) {
-              incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
+              incomingToken = prepareIncomingTab(
+                nextTabId,
+                latestViewportSelector,
+                incomingSeedSnapshot
+              )
             }
             return collectTabEntries(tabsRef.current, nextTabId)
           },
           update: commitSelection,
         }).finally(() => {
           if (incomingToken == null) {
-            incomingToken = prepareIncomingTab(nextTabId, latestViewportSelector)
+            incomingToken = prepareIncomingTab(
+              nextTabId,
+              latestViewportSelector,
+              incomingSeedSnapshot
+            )
           }
           if (incomingToken != null) {
             finalizeIncomingTab(nextTabId, incomingToken)
@@ -534,7 +584,13 @@ export function useRoutedCarouselTabs<TTabId extends string>({
       const direction = nextIndex >= currentIndex ? 'forward' : 'backward'
       runSelectionWithScrollTransfer(true)
     },
-    [captureOutgoingTab, cleanupFrozenTabById, finalizeIncomingTab, prepareIncomingTab]
+    [
+      captureOutgoingTab,
+      captureTabSnapshot,
+      cleanupFrozenTabById,
+      finalizeIncomingTab,
+      prepareIncomingTab,
+    ]
   )
 
   return {

--- a/packages/web/src/test/browser.setup.ts
+++ b/packages/web/src/test/browser.setup.ts
@@ -1,0 +1,2 @@
+import './setup'
+import '../index.css'

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(({ isSsrBuild }) => {
             environment: 'jsdom',
             setupFiles: './src/test/setup.ts',
             include: ['src/**/*.test.{ts,tsx}'],
+            exclude: ['src/**/*.browser.test.{ts,tsx}'],
           },
         },
         './vitest.storybook.config.ts',

--- a/packages/web/vitest.browser.config.ts
+++ b/packages/web/vitest.browser.config.ts
@@ -1,0 +1,35 @@
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { playwright } from '@vitest/browser-playwright'
+import { resolve } from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+const alias = {
+  '@': resolve(__dirname, './src'),
+  '@openspecui/core': resolve(__dirname, '../core/src'),
+  '@openspecui/core/dashboard-display': resolve(__dirname, '../core/src/dashboard-display.ts'),
+  '@openspecui/core/hosted-app': resolve(__dirname, '../core/src/hosted-app.ts'),
+  '@openspecui/core/opsx-display-path': resolve(__dirname, '../core/src/opsx-display-path.ts'),
+  '@openspecui/core/pty-protocol': resolve(__dirname, '../core/src/pty-protocol.ts'),
+  '@openspecui/search': resolve(__dirname, '../search/src'),
+  '@openspecui/search/node': resolve(__dirname, '../search/src/node.ts'),
+  '@openspecui/server': resolve(__dirname, '../server/src'),
+}
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias,
+  },
+  test: {
+    name: 'browser',
+    include: ['src/**/*.browser.test.{ts,tsx}'],
+    setupFiles: './src/test/browser.setup.ts',
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      headless: true,
+      instances: [{ browser: 'chromium' }],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- preserve commit detail diff reveal scroll across narrow routed tab roundtrips
- stop Safari/WebKit tab rerenders from replaying stale viewport restores when `viewportSelector` is passed as a new array with the same values
- exclude `*.browser.test.tsx` from the jsdom unit project so `pnpm --filter @openspecui/web test` matches the intended Vitest split

## Validation
- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm changeset:check`
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm test:browser:ci`
