### PR TITLE
Improve responsive shell navigation

### DIFF
--- a/.changeset/responsive-shell-navigation.md
+++ b/.changeset/responsive-shell-navigation.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Improve Git worktree switch responsiveness and add collapsible desktop sidebar navigation.

--- a/openspec/changes/improve-responsive-shell-navigation/.openspec.yaml
+++ b/openspec/changes/improve-responsive-shell-navigation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-05-06

--- a/openspec/changes/improve-responsive-shell-navigation/loop/checkpoints.md
+++ b/openspec/changes/improve-responsive-shell-navigation/loop/checkpoints.md
@@ -18,7 +18,7 @@
 - [x] 3.1 Changeset included for release-impacting package changes
 - [x] 3.2 CI-equivalent local checks passed
 - [x] 3.3 Real browser acceptance passed locally
-- [ ] 3.4 PR checks passed
+- [x] 3.4 PR checks passed
 - [ ] 3.5 Release automation published a new version
 - [ ] 3.6 Newly published package acceptance passed
 

--- a/openspec/changes/improve-responsive-shell-navigation/loop/checkpoints.md
+++ b/openspec/changes/improve-responsive-shell-navigation/loop/checkpoints.md
@@ -1,0 +1,28 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively
+- [x] 1.2 Research facts recorded
+- [x] 1.3 Plan reviewed and approved
+
+## 2. Implementation
+
+- [x] 2.1 Implementation started from approved plan
+- [x] 2.2 Progress synchronized with implementation artifact
+- [x] 2.3 Unexpected issues loop back to intake/research-plan
+- [x] 2.4 Git worktree responsive switch UI implemented
+- [x] 2.5 Desktop sidebar collapse UI implemented
+- [x] 2.6 Focused tests updated
+
+## 3. PR and Release Gates
+
+- [x] 3.1 Changeset included for release-impacting package changes
+- [x] 3.2 CI-equivalent local checks passed
+- [x] 3.3 Real browser acceptance passed locally
+- [ ] 3.4 PR checks passed
+- [ ] 3.5 Release automation published a new version
+- [ ] 3.6 Newly published package acceptance passed
+
+## 4. Merge Readiness
+
+- [ ] 4.1 OpenSpec archive flow completed
+- [ ] 4.2 PR merge approved

--- a/openspec/changes/improve-responsive-shell-navigation/loop/implementation.md
+++ b/openspec/changes/improve-responsive-shell-navigation/loop/implementation.md
@@ -1,0 +1,24 @@
+## Implementation State
+
+- Loop initialized for Git worktree responsive switch controls and desktop sidebar collapse behavior.
+- Git page "Other Worktrees" now uses responsive worktree cards that preserve branch/path content and compact icon-only switch controls.
+- Desktop sidebar now supports persisted collapse/expand behavior with icon-only collapsed navigation.
+- Main `opsx-ui-views` spec now records desktop navigation collapse and Git worktree responsive action requirements.
+- Focused unit tests, full local CI-equivalent checks, and local real-browser acceptance pass.
+
+## Decisions Taken
+
+- Sidebar collapse is a local shell presentation preference, not a `navController` layout mutation.
+- Git worktree switching will continue to use the existing `git.switchWorktree` mutation and server handoff path.
+- Collapsed `AreaNav` disables drag/drop at the component boundary and hides grip handles without changing tab topology.
+- Collapsed icon-only controls keep accessible names and tooltips while removing visible text labels.
+- Worktree responsive behavior is card-based because wrapping full branch/path content is a requirement; truncation is only acceptable for the unchanged current-worktree summary row.
+
+## Divergence Notes
+
+- User clarified that responsiveness must not sacrifice content. The implementation looped from compact rows to dedicated worktree cards so long worktree paths remain visible and wrap instead of being omitted.
+
+## Loopback Triggers
+
+- If sidebar collapse requires changing tab topology or backend state synchronization, return to research-plan before continuing.
+- If Git worktree switch action cannot remain outside `WorktreeRow` without layout issues, return to research-plan before introducing a new shared worktree action contract.

--- a/openspec/changes/improve-responsive-shell-navigation/loop/intake.md
+++ b/openspec/changes/improve-responsive-shell-navigation/loop/intake.md
@@ -1,0 +1,37 @@
+## User Input
+
+- 改进一些前端：
+  1. git 页面没有做好响应式的支持，底部的git worktree的switch这里太宽了。需要自动适应自动换行。并且switch按钮不用那么大，只需要做成一个icon-button即可
+  2. 侧边栏需要提供一个收起展开的功能：把这个按钮放在顶部OPENSPEC这个logo的右侧。收起后，OPENSPEC这个LOGO隐藏起来，然后其它全部只留下icon即可（拖动的功能也隐藏起来）。
+- Implement the plan.
+- 完成 Git Worktree 响应式与侧边栏收起的任务，完成真实浏览器走查。并发布一个新版本，并使用新版本进行再次走查，确保符合预期
+- worktree自适应的前提并不是牺牲内容，请你考虑一下卡片化。我让你把内容换行，不是把内容省略掉。
+
+## Objective Scope
+
+- Improve the live Git page "Other Worktrees" area so worktree summaries and switch actions adapt to narrow widths without horizontal overflow.
+- Preserve full Git worktree branch/path content in responsive layouts; wrapping/cardification is preferred over truncation or omission.
+- Replace the text-heavy worktree switch action with a compact accessible icon button while preserving existing backend handoff behavior.
+- Add desktop sidebar collapse/expand behavior from the top logo row.
+- In collapsed desktop sidebar mode, hide the OpenSpec logo, hide text labels, keep icon-only navigation/search controls accessible, and hide drag affordances/drag behavior.
+- Update OpenSpec artifacts and release metadata required for the publishable web package behavior change.
+- Complete local verification, real-browser acceptance, release a new version, and re-run acceptance against the newly published version.
+
+## Non-Goals
+
+- Do not change Git worktree switching backend semantics, stale worktree handling, child instance handoff, or recovery routing.
+- Do not redesign the mobile header/tab bar.
+- Do not change nav tab placement/persistence rules beyond the sidebar collapsed presentation preference.
+- Do not include the unrelated `upgrade-vite-8` active change in this loop.
+
+## Acceptance Boundary
+
+- The Git page worktree switch action is icon-only and remains accessible by name/tooltip.
+- The Git page "Other Worktrees" area wraps/adapts at narrow widths without horizontal overflow and without omitting branch/path content.
+- The desktop sidebar can collapse and expand from the logo row.
+- Collapsed desktop sidebar hides the logo and all nav/search labels while preserving icons and accessible labels.
+- Collapsed desktop sidebar hides drag handles and disables drag/drop navigation interactions.
+- Relevant unit/type/browser checks pass or any unrelated known failures are explicitly separated with evidence.
+- A real browser walk confirms the local implementation behavior.
+- A new package version is released through the repository release workflow.
+- The same behavior is validated again using the newly published package version.

--- a/openspec/changes/improve-responsive-shell-navigation/loop/research-plan.md
+++ b/openspec/changes/improve-responsive-shell-navigation/loop/research-plan.md
@@ -1,0 +1,49 @@
+## Research Findings
+
+- `packages/web/src/routes/git.tsx` owns the live Git page and renders "Other Worktrees" as a two-column large-screen grid with a text `Switch worktree` button below each `WorktreeRow`.
+- `WorktreeRow` in `packages/web/src/components/git/git-shared.tsx` already has compact path, copy, remove, diff, and ahead/behind controls; the switch action is intentionally outside the row.
+- `packages/web/src/components/layout/desktop-sidebar.tsx` owns desktop sidebar rendering for both static and live IDE modes.
+- `AreaNav` owns draggable main/bottom nav sections. Drag state and drop affordances are local to that component, so collapsed sidebar drag hiding can be expressed as a presentation/interaction prop without changing `navController`.
+- `navController` stores tab topology and locations. Sidebar collapse is a shell preference, not a tab-layout rule, and should not be persisted through remote nav layout KV.
+- The web package already depends on `lucide-react` and has a shared `Tooltip` component, so no new UI dependency is needed.
+
+## Decision & Plan (For Approval)
+
+- Treat this as a front-end shell/UI atom under existing navigation and Git handoff laws.
+- Add a local desktop sidebar collapsed preference, defaulting to expanded and persisted in browser local storage with hosted scoping.
+- Render the desktop sidebar with expanded and collapsed width variants. Collapsed mode hides logo/text labels and uses icon-only controls with `aria-label`/`title`/tooltip.
+- Extend `AreaNav` with `collapsed?: boolean`; when collapsed, render icon-only nav and disable draggable/drop behavior and grip handles.
+- Refactor the Git page other-worktree block so summary/action content wraps naturally and the switch action is a compact icon button.
+- Add focused unit coverage and real-browser acceptance for the changed surfaces.
+- Add a patch changeset for `@openspecui/web` because publishable UI behavior changes.
+
+## Capability Impact
+
+### New or Expanded Behavior
+
+- Desktop users can collapse and expand the sidebar.
+- Collapsed desktop sidebar provides an icon-only navigation rail while preserving accessible names.
+- Git worktree switch action is compact enough for narrow bottom-area layouts.
+
+### Modified Behavior
+
+- Desktop sidebar drag-and-drop nav affordances are hidden and disabled only while the sidebar is collapsed.
+- Other worktree cards in the Git page use more responsive wrapping instead of relying on a wide text switch button.
+
+## Risks and Mitigations
+
+- Risk: collapsed nav becomes inaccessible because visible labels are removed. Mitigation: keep `aria-label`, `title`, and tooltip labels on icon-only controls.
+- Risk: disabling drag in collapsed mode changes tab layout behavior globally. Mitigation: keep the rule in `AreaNav` presentation only and do not mutate `navController`.
+- Risk: Git switch UX regresses even though backend semantics are unchanged. Mitigation: keep the same mutation path and test the icon button click/pending state.
+- Risk: release validation misses hosted/npm behavior. Mitigation: run local browser acceptance before release and repeat against the newly published package.
+
+## Verification Strategy
+
+- Unit tests:
+  - `pnpm --filter @openspecui/web test -- src/routes/git.test.tsx src/components/layout/area-nav.test.tsx src/components/layout/desktop-sidebar.test.tsx`
+- Type/lint/build checks:
+  - `pnpm --filter @openspecui/web typecheck`
+  - Repository CI gates before PR/release: `pnpm format:check`, `pnpm lint:ci`, `pnpm typecheck`, `pnpm test:ci`, `pnpm test:browser:ci`
+- Browser acceptance:
+  - Local dev/build browser walk for `/git` responsive worktree switch and desktop sidebar collapse/expand.
+  - Post-release npm package browser walk using the newly published version.

--- a/openspec/specs/opsx-ui-views/spec.md
+++ b/openspec/specs/opsx-ui-views/spec.md
@@ -156,3 +156,36 @@ The UI SHALL provide a Config view dedicated to OPSX project configuration.
 - **GIVEN** the Schemas tab is open
 - **WHEN** the user is allowed to manage schemas
 - **THEN** the UI SHALL provide Add and Delete actions
+
+### Requirement: Desktop Navigation Collapse
+
+The UI SHALL allow desktop navigation to collapse into an icon-only rail without changing route ownership.
+
+#### Scenario: Collapse desktop sidebar
+
+- **GIVEN** the desktop sidebar is expanded
+- **WHEN** the user activates the sidebar collapse control
+- **THEN** the OpenSpec logo SHALL be hidden
+- **AND** navigation labels SHALL be hidden
+- **AND** navigation icons SHALL remain visible with accessible names
+- **AND** drag handles and drag/drop navigation affordances SHALL be hidden
+
+#### Scenario: Expand desktop sidebar
+
+- **GIVEN** the desktop sidebar is collapsed
+- **WHEN** the user activates the sidebar expand control
+- **THEN** the OpenSpec logo SHALL be visible
+- **AND** navigation labels SHALL be visible
+- **AND** drag/drop navigation affordances SHALL be available again
+
+### Requirement: Git Worktree Responsive Actions
+
+The UI SHALL render Git worktree handoff actions without causing horizontal overflow in narrow layouts.
+
+#### Scenario: Render compact worktree switch action
+
+- **GIVEN** the Git page lists other available worktrees
+- **WHEN** the worktree switch action is rendered
+- **THEN** the action SHALL be an icon-only button with an accessible name
+- **AND** the worktree summary and action SHALL wrap or reflow to fit narrow containers without omitting branch or path content
+- **AND** the action SHALL continue to use the existing worktree handoff behavior

--- a/packages/web/src/components/git/git-worktree-card.test.tsx
+++ b/packages/web/src/components/git/git-worktree-card.test.tsx
@@ -1,0 +1,43 @@
+import type { GitWorktreeSummary } from '@openspecui/core'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { WorktreeCard } from './git-worktree-card'
+
+describe('WorktreeCard', () => {
+  it('preserves long worktree content for wrapping instead of truncating it', () => {
+    const longPath =
+      '/Users/kzf/Dev/GitHub/jixoai-labs/openspecui-feature-with-a-very-long-worktree-path'
+    const worktree: GitWorktreeSummary = {
+      path: longPath,
+      relativePath: '../openspecui-feature-with-a-very-long-worktree-path',
+      pathAvailable: true,
+      branchName: 'feature/responsive-shell-navigation-with-long-branch-name',
+      detached: false,
+      isCurrent: false,
+      ahead: 2,
+      behind: 1,
+      diff: { files: 3, insertions: 12, deletions: 4 },
+    }
+
+    render(
+      <WorktreeCard
+        worktree={worktree}
+        emphasize={false}
+        action={
+          <button type="button" aria-label={`Switch to ${worktree.branchName}`}>
+            switch
+          </button>
+        }
+      />
+    )
+
+    const branchText = screen.getByText(worktree.branchName)
+    const pathText = screen.getByText(longPath)
+
+    expect(branchText.className).toContain('break-words')
+    expect(branchText.className).not.toContain('truncate')
+    expect(pathText.className).toContain('break-all')
+    expect(pathText.className).not.toContain('truncate')
+    expect(screen.getByRole('button', { name: `Switch to ${worktree.branchName}` })).toBeTruthy()
+  })
+})

--- a/packages/web/src/components/git/git-worktree-card.tsx
+++ b/packages/web/src/components/git/git-worktree-card.tsx
@@ -1,0 +1,136 @@
+import type { DashboardGitWorktree, GitWorktreeSummary } from '@openspecui/core'
+import {
+  Check,
+  Copy,
+  FolderOpen,
+  FolderOpenDot,
+  GitBranch,
+  LoaderCircle,
+  Trash2,
+} from 'lucide-react'
+import { useCallback, useState, type ReactNode } from 'react'
+import {
+  copyText,
+  DiffStat,
+  GIT_WORKTREE_BG_CLASS,
+  GIT_WORKTREE_BORDER_CLASS,
+  GitAheadBehindBadge,
+  GitFilesBadge,
+  isHttpUrl,
+} from './git-shared'
+
+export function WorktreeCard<TWorktree extends DashboardGitWorktree | GitWorktreeSummary>({
+  worktree,
+  emphasize,
+  removing = false,
+  action,
+  onRemoveDetachedWorktree,
+}: {
+  worktree: TWorktree
+  emphasize: boolean
+  removing?: boolean
+  action?: ReactNode
+  onRemoveDetachedWorktree?: (worktree: TWorktree) => void | Promise<void>
+}) {
+  const isRemotePath = isHttpUrl(worktree.path)
+  const canToggleRelativePath = !isRemotePath
+  const canRemoveDetached = !isRemotePath && worktree.detached && !worktree.isCurrent
+  const [showRelativePath, setShowRelativePath] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const displayPath = isRemotePath
+    ? worktree.path
+    : showRelativePath
+      ? worktree.relativePath
+      : worktree.path
+
+  const handleCopyPath = useCallback(async () => {
+    try {
+      await copyText(displayPath)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    } catch (error) {
+      console.error('[Git] Failed to copy worktree path:', error)
+    }
+  }, [displayPath])
+
+  return (
+    <article
+      className={`min-w-0 rounded-md border p-3 ${
+        emphasize
+          ? `${GIT_WORKTREE_BORDER_CLASS} ${GIT_WORKTREE_BG_CLASS}`
+          : 'border-border/70 bg-muted/15'
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-start gap-1.5 text-sm font-medium">
+            <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="min-w-0 break-words leading-snug">{worktree.branchName}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
+          {canRemoveDetached ? (
+            <button
+              type="button"
+              onClick={() => {
+                void onRemoveDetachedWorktree?.(worktree)
+              }}
+              disabled={removing}
+              className="text-muted-foreground hover:text-destructive inline-flex h-7 w-7 items-center justify-center rounded border border-transparent disabled:cursor-not-allowed disabled:opacity-60"
+              title="Remove detached worktree"
+              aria-label="Remove detached worktree"
+            >
+              {removing ? (
+                <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+            </button>
+          ) : null}
+          <GitAheadBehindBadge ahead={worktree.ahead} behind={worktree.behind} />
+          <GitFilesBadge files={worktree.diff.files} />
+          <DiffStat diff={worktree.diff} className="justify-end" />
+          {action}
+        </div>
+      </div>
+
+      <div className="bg-muted/25 mt-3 flex min-w-0 items-start gap-2 rounded-md px-2 py-1.5">
+        {canToggleRelativePath ? (
+          <button
+            type="button"
+            onClick={() => setShowRelativePath((current) => !current)}
+            className="text-muted-foreground hover:text-foreground mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded border border-transparent"
+            title={showRelativePath ? 'Show absolute path' : 'Show relative path'}
+            aria-label={showRelativePath ? 'Show absolute path' : 'Show relative path'}
+          >
+            {showRelativePath ? (
+              <FolderOpenDot className="h-3.5 w-3.5" />
+            ) : (
+              <FolderOpen className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => {
+            void handleCopyPath()
+          }}
+          onDoubleClick={() => {
+            if (!canToggleRelativePath) return
+            setShowRelativePath((current) => !current)
+          }}
+          className="text-muted-foreground hover:text-foreground flex min-w-0 flex-1 items-start gap-1 text-left text-xs leading-snug"
+          title={displayPath}
+          aria-label={`Copy ${showRelativePath && canToggleRelativePath ? 'relative' : 'absolute'} path for ${worktree.branchName}`}
+        >
+          <span className="min-w-0 flex-1 whitespace-normal break-all">{displayPath}</span>
+          {copied ? (
+            <Check className="mt-0.5 h-3 w-3 shrink-0" />
+          ) : (
+            <Copy className="mt-0.5 h-3 w-3 shrink-0" />
+          )}
+        </button>
+      </div>
+    </article>
+  )
+}

--- a/packages/web/src/components/layout/area-nav.test.tsx
+++ b/packages/web/src/components/layout/area-nav.test.tsx
@@ -86,4 +86,25 @@ describe('AreaNav drag behavior', () => {
 
     expect(dragStart.defaultPrevented).toBe(true)
   })
+
+  it('renders icon-only non-draggable items when collapsed', () => {
+    const { container } = render(<AreaNav area="main" tabs={['/dashboard', '/config']} collapsed />)
+
+    expect(within(container).getByRole('link', { name: 'Dashboard' })).toBeTruthy()
+    expect(within(container).getByRole('link', { name: 'Config' })).toBeTruthy()
+    expect(container.textContent).not.toContain('Dashboard')
+    expect(container.textContent).not.toContain('Config')
+
+    const listItems = container.querySelectorAll('li')
+    expect(listItems).toHaveLength(2)
+    for (const li of listItems) {
+      expect(li.getAttribute('draggable')).toBe('false')
+    }
+
+    const list = container.querySelector('ul')
+    expect(list).toBeTruthy()
+    const dragOver = createEvent.dragOver(list!)
+    fireEvent(list!, dragOver)
+    expect(dragOver.defaultPrevented).toBe(false)
+  })
 })

--- a/packages/web/src/components/layout/area-nav.tsx
+++ b/packages/web/src/components/layout/area-nav.tsx
@@ -3,6 +3,7 @@ import { useNavLayout } from '@/lib/use-nav-controller'
 import { VTLink, vtNavController } from '@/lib/view-transitions/navigation'
 import { GripVertical } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
+import { Tooltip } from '../tooltip'
 import { allNavItems, type NavItem } from './nav-items'
 
 interface AreaNavProps {
@@ -14,6 +15,8 @@ interface AreaNavProps {
   useLinks?: boolean
   /** Called after an item is clicked/navigated to (e.g. to close mobile menu) */
   onNavigate?: () => void
+  /** Render as icon-only and disable drag/drop affordances */
+  collapsed?: boolean
 }
 
 // Module-level: track which tab is currently being dragged (shared between AreaNav instances)
@@ -23,7 +26,7 @@ let _draggedTabId: TabId | null = null
  * Draggable nav section for an area.
  * Uses HTML5 Drag and Drop to move tabs between areas and reorder within an area.
  */
-export function AreaNav({ area, tabs, className, useLinks, onNavigate }: AreaNavProps) {
+export function AreaNav({ area, tabs, className, useLinks, onNavigate, collapsed }: AreaNavProps) {
   const [dragOverArea, setDragOverArea] = useState(false)
   const [dropIndicator, setDropIndicator] = useState<{
     index: number
@@ -136,13 +139,14 @@ export function AreaNav({ area, tabs, className, useLinks, onNavigate }: AreaNav
     .filter(Boolean) as NavItem[]
 
   const shouldUseLink = area === 'main' || useLinks
+  const iconOnly = collapsed === true
 
   return (
     <ul
       className={`min-h-[2rem] space-y-1 ${dragOverArea ? 'bg-muted/50 rounded-md' : ''} ${className ?? ''}`}
-      onDragOver={handleAreaDragOver}
-      onDragLeave={handleAreaDragLeave}
-      onDrop={handleDrop}
+      onDragOver={iconOnly ? undefined : handleAreaDragOver}
+      onDragLeave={iconOnly ? undefined : handleAreaDragLeave}
+      onDrop={iconOnly ? undefined : handleDrop}
     >
       {items.map((item, index) => {
         const isActiveBottom = area === 'bottom' && item.to === activeBottomTabId
@@ -152,49 +156,67 @@ export function AreaNav({ area, tabs, className, useLinks, onNavigate }: AreaNav
         return (
           <li
             key={item.to}
-            draggable
-            onDragStart={(e) => handleDragStart(e, item.to as TabId)}
-            onDragEnd={handleDragEnd}
-            onDragOver={(e) => handleItemDragOver(e, index)}
-            className="group relative cursor-grab"
+            draggable={!iconOnly}
+            onDragStart={iconOnly ? undefined : (e) => handleDragStart(e, item.to as TabId)}
+            onDragEnd={iconOnly ? undefined : handleDragEnd}
+            onDragOver={iconOnly ? undefined : (e) => handleItemDragOver(e, index)}
+            className={`group relative ${iconOnly ? 'cursor-default' : 'cursor-grab'}`}
           >
-            {showLineBefore && (
+            {!iconOnly && showLineBefore && (
               <div className="bg-border -top-0.25 pointer-events-none absolute left-4 right-4 h-0.5 -translate-y-0.5 rounded" />
             )}
             {shouldUseLink ? (
-              <VTLink
-                to={item.to}
-                draggable={false}
-                onDragStart={(e) => e.preventDefault()}
-                onClick={onNavigate}
-                className="hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md px-3 py-2"
-              >
-                <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
-                <item.icon className="h-4 w-4 shrink-0" />
-                <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
-              </VTLink>
+              <Tooltip content={iconOnly ? item.label : undefined} sideOffset={12}>
+                <VTLink
+                  to={item.to}
+                  draggable={false}
+                  onDragStart={(e) => e.preventDefault()}
+                  onClick={onNavigate}
+                  aria-label={iconOnly ? item.label : undefined}
+                  title={iconOnly ? item.label : undefined}
+                  className={`hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md py-2 ${
+                    iconOnly ? 'justify-center px-2' : 'px-3'
+                  }`}
+                >
+                  {!iconOnly ? (
+                    <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
+                  ) : null}
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  {!iconOnly ? (
+                    <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                  ) : null}
+                </VTLink>
+              </Tooltip>
             ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  if (isActiveBottom) {
-                    vtNavController.deactivateBottom()
-                  } else {
-                    void vtNavController.activateBottom(item.to)
-                  }
-                  onNavigate?.()
-                }}
-                className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-left ${
-                  isActiveBottom ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
-                }`}
-              >
-                <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
-                <item.icon className="h-4 w-4 shrink-0" />
-                <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
-              </button>
+              <Tooltip content={iconOnly ? item.label : undefined} sideOffset={12}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (isActiveBottom) {
+                      vtNavController.deactivateBottom()
+                    } else {
+                      void vtNavController.activateBottom(item.to)
+                    }
+                    onNavigate?.()
+                  }}
+                  aria-label={iconOnly ? item.label : undefined}
+                  title={iconOnly ? item.label : undefined}
+                  className={`flex w-full items-center gap-2 rounded-md py-2 ${
+                    iconOnly ? 'justify-center px-2' : 'px-3 text-left'
+                  } ${isActiveBottom ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
+                >
+                  {!iconOnly ? (
+                    <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
+                  ) : null}
+                  <item.icon className="h-4 w-4 shrink-0" />
+                  {!iconOnly ? (
+                    <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                  ) : null}
+                </button>
+              </Tooltip>
             )}
 
-            {showLineAfter && (
+            {!iconOnly && showLineAfter && (
               <div className="bg-border -bottom-0.25 pointer-events-none absolute left-4 right-4 h-0.5 translate-y-0.5 rounded" />
             )}
           </li>

--- a/packages/web/src/components/layout/desktop-sidebar.test.tsx
+++ b/packages/web/src/components/layout/desktop-sidebar.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DesktopSidebar } from './desktop-sidebar'
+
+const { activatePopMock } = vi.hoisted(() => ({
+  activatePopMock: vi.fn(),
+}))
+
+vi.mock('@/components/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}))
+
+vi.mock('@/lib/static-mode', () => ({
+  getBasePath: () => '/',
+  isStaticMode: () => false,
+}))
+
+vi.mock('@/lib/use-dark-mode', () => ({
+  useDarkMode: () => false,
+}))
+
+vi.mock('@/lib/use-nav-controller', () => ({
+  useNavLayout: () => ({
+    mainTabs: ['/dashboard', '/config', '/settings'],
+    bottomTabs: ['/git', '/terminal'],
+    mainLocation: {
+      href: '/dashboard',
+      pathname: '/dashboard',
+      search: '',
+      hash: '',
+      state: { __TSR_index: 0, key: 'main', __TSR_key: 'main' },
+    },
+    bottomLocation: {
+      href: '/git',
+      pathname: '/git',
+      search: '',
+      hash: '',
+      state: { __TSR_index: 0, key: 'bottom', __TSR_key: 'bottom' },
+    },
+    popLocation: {
+      href: '/',
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: { __TSR_index: 0, key: 'pop', __TSR_key: 'pop' },
+    },
+    bottomActive: true,
+    popActive: false,
+  }),
+}))
+
+vi.mock('@/lib/nav-controller', () => ({
+  navController: {
+    moveTab: vi.fn(),
+    reorder: vi.fn(),
+    mainTabs: ['/dashboard', '/config', '/settings'],
+    bottomTabs: ['/git', '/terminal'],
+  },
+}))
+
+vi.mock('@/lib/view-transitions/navigation', () => ({
+  VTLink: ({
+    to,
+    children,
+    ...props
+  }: { to: string; children?: ReactNode } & Omit<ComponentProps<'a'>, 'href'>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  vtNavController: {
+    activatePop: activatePopMock,
+    activateBottom: vi.fn(),
+    deactivateBottom: vi.fn(),
+  },
+}))
+
+describe('DesktopSidebar', () => {
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('collapses to icon-only navigation and keeps controls accessible', () => {
+    const { container } = render(<DesktopSidebar />)
+
+    expect(screen.getByAltText('OpenSpec')).toBeTruthy()
+    expect(screen.getByText('Search')).toBeTruthy()
+    expect(screen.getByText('Dashboard')).toBeTruthy()
+    expect(screen.getByText('Bottom')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+
+    expect(screen.queryByAltText('OpenSpec')).toBeNull()
+    expect(screen.queryByText('Search')).toBeNull()
+    expect(screen.queryByText('Dashboard')).toBeNull()
+    expect(screen.queryByText('Bottom')).toBeNull()
+
+    expect(screen.getByRole('button', { name: 'Search' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Git' })).toBeTruthy()
+
+    for (const item of container.querySelectorAll('li')) {
+      expect(item.getAttribute('draggable')).toBe('false')
+    }
+  })
+
+  it('keeps search activation available while collapsed', () => {
+    const { container } = render(<DesktopSidebar />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }))
+    fireEvent.click(within(container).getByRole('button', { name: 'Search' }))
+
+    expect(activatePopMock).toHaveBeenCalledWith('/search')
+  })
+})

--- a/packages/web/src/components/layout/desktop-sidebar.tsx
+++ b/packages/web/src/components/layout/desktop-sidebar.tsx
@@ -1,10 +1,30 @@
+import { Tooltip } from '@/components/tooltip'
+import { getHostedScopedStorageKey } from '@/lib/hosted-session'
 import { getBasePath, isStaticMode } from '@/lib/static-mode'
 import { useDarkMode } from '@/lib/use-dark-mode'
 import { useNavLayout } from '@/lib/use-nav-controller'
 import { VTLink, vtNavController } from '@/lib/view-transitions/navigation'
-import { Search } from 'lucide-react'
+import { PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { AreaNav } from './area-nav'
 import { navItems, settingsItem } from './nav-items'
+
+const DESKTOP_SIDEBAR_COLLAPSED_STORAGE_KEY = 'openspecui:desktop-sidebar-collapsed'
+
+function getDesktopSidebarCollapsedStorageKey(): string {
+  if (typeof window === 'undefined') return DESKTOP_SIDEBAR_COLLAPSED_STORAGE_KEY
+  return getHostedScopedStorageKey(DESKTOP_SIDEBAR_COLLAPSED_STORAGE_KEY, window.location)
+}
+
+function readDesktopSidebarCollapsed(): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return localStorage.getItem(getDesktopSidebarCollapsedStorageKey()) === 'true'
+  } catch {
+    return false
+  }
+}
 
 /** Desktop sidebar navigation */
 export function DesktopSidebar() {
@@ -12,27 +32,66 @@ export function DesktopSidebar() {
   const navLayout = useNavLayout()
   const basePath = getBasePath()
   const isStatic = isStaticMode()
+  const [collapsed, setCollapsed] = useState(readDesktopSidebarCollapsed)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(getDesktopSidebarCollapsedStorageKey(), collapsed ? 'true' : 'false')
+    } catch {
+      // ignore persistence failures; the sidebar remains usable for this session
+    }
+  }, [collapsed])
+
+  const collapseLabel = collapsed ? 'Expand sidebar' : 'Collapse sidebar'
 
   return (
-    <nav className="desktop-sidebar border-border bg-muted/30 flex w-64 shrink-0 flex-col border-r p-4">
-      <div className="mb-6">
-        <img
-          src={
-            isDark ? `${basePath}openspec_pixel_dark.svg` : `${basePath}openspec_pixel_light.svg`
-          }
-          alt="OpenSpec"
-          className="h-6"
-        />
+    <nav
+      data-collapsed={collapsed}
+      className="desktop-sidebar border-border bg-muted/30 flex shrink-0 flex-col border-r transition-[width,padding]"
+    >
+      <div
+        className={`mb-6 flex items-center gap-2 ${collapsed ? 'justify-center' : 'justify-between'}`}
+      >
+        {!collapsed ? (
+          <img
+            src={
+              isDark ? `${basePath}openspec_pixel_dark.svg` : `${basePath}openspec_pixel_light.svg`
+            }
+            alt="OpenSpec"
+            className="h-6 min-w-0"
+          />
+        ) : null}
+        <Tooltip content={collapseLabel} sideOffset={12}>
+          <button
+            type="button"
+            onClick={() => setCollapsed((current) => !current)}
+            className="hover:bg-muted text-muted-foreground hover:text-foreground inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md"
+            aria-label={collapseLabel}
+            title={collapseLabel}
+          >
+            {collapsed ? (
+              <PanelLeftOpen className="h-4 w-4" />
+            ) : (
+              <PanelLeftClose className="h-4 w-4" />
+            )}
+          </button>
+        </Tooltip>
       </div>
 
-      <button
-        type="button"
-        onClick={() => vtNavController.activatePop('/search')}
-        className="hover:bg-muted border-primary mb-4 flex items-center gap-2 rounded-md border px-3 py-2 text-left"
-      >
-        <Search className="h-4 w-4 shrink-0" />
-        <span className="font-nav text-base tracking-[0.04em]">Search</span>
-      </button>
+      <Tooltip content={collapsed ? 'Search' : undefined} sideOffset={12}>
+        <button
+          type="button"
+          onClick={() => vtNavController.activatePop('/search')}
+          aria-label={collapsed ? 'Search' : undefined}
+          title={collapsed ? 'Search' : undefined}
+          className={`hover:bg-muted border-primary mb-4 flex items-center rounded-md border py-2 ${
+            collapsed ? 'justify-center px-2' : 'gap-2 px-3 text-left'
+          }`}
+        >
+          <Search className="h-4 w-4 shrink-0" />
+          {!collapsed ? <span className="font-nav text-base tracking-[0.04em]">Search</span> : null}
+        </button>
+      </Tooltip>
 
       {isStatic ? (
         /* Static mode: simple nav list */
@@ -40,24 +99,40 @@ export function DesktopSidebar() {
           <ul className="flex-1 space-y-1">
             {navItems.map((item) => (
               <li key={item.to}>
-                <VTLink
-                  to={item.to}
-                  className="hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md px-3 py-2"
-                >
-                  <item.icon className="h-4 w-4 shrink-0" />
-                  <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
-                </VTLink>
+                <Tooltip content={collapsed ? item.label : undefined} sideOffset={12}>
+                  <VTLink
+                    to={item.to}
+                    aria-label={collapsed ? item.label : undefined}
+                    title={collapsed ? item.label : undefined}
+                    className={`hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md py-2 ${
+                      collapsed ? 'justify-center px-2' : 'px-3'
+                    }`}
+                  >
+                    <item.icon className="h-4 w-4 shrink-0" />
+                    {!collapsed ? (
+                      <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                    ) : null}
+                  </VTLink>
+                </Tooltip>
               </li>
             ))}
           </ul>
           <div className="border-border space-y-1 border-t pt-4">
-            <VTLink
-              to={settingsItem.to}
-              className="hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md px-3 py-2"
-            >
-              <settingsItem.icon className="h-4 w-4 shrink-0" />
-              <span className="font-nav text-base tracking-[0.04em]">{settingsItem.label}</span>
-            </VTLink>
+            <Tooltip content={collapsed ? settingsItem.label : undefined} sideOffset={12}>
+              <VTLink
+                to={settingsItem.to}
+                aria-label={collapsed ? settingsItem.label : undefined}
+                title={collapsed ? settingsItem.label : undefined}
+                className={`hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md py-2 ${
+                  collapsed ? 'justify-center px-2' : 'px-3'
+                }`}
+              >
+                <settingsItem.icon className="h-4 w-4 shrink-0" />
+                {!collapsed ? (
+                  <span className="font-nav text-base tracking-[0.04em]">{settingsItem.label}</span>
+                ) : null}
+              </VTLink>
+            </Tooltip>
           </div>
         </div>
       ) : (
@@ -65,15 +140,22 @@ export function DesktopSidebar() {
         <div className="flex flex-1 flex-col gap-2">
           {/* Main area tabs (including Settings) */}
           <div className="flex-1">
-            <AreaNav area="main" tabs={navLayout.mainTabs} className="h-full" />
+            <AreaNav
+              area="main"
+              tabs={navLayout.mainTabs}
+              className="h-full"
+              collapsed={collapsed}
+            />
           </div>
 
           {/* Bottom area tabs (always rendered as drop target) */}
-          <div className="text-muted-foreground text-[10px] font-medium uppercase tracking-wider">
-            Bottom
-          </div>
+          {!collapsed ? (
+            <div className="text-muted-foreground text-[10px] font-medium uppercase tracking-wider">
+              Bottom
+            </div>
+          ) : null}
           <div className="border-border border-t pt-2">
-            <AreaNav area="bottom" tabs={navLayout.bottomTabs} />
+            <AreaNav area="bottom" tabs={navLayout.bottomTabs} collapsed={collapsed} />
           </div>
         </div>
       )}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -923,6 +923,17 @@ html[data-vt-kind='tab-carousel'][data-vt-direction='backward']::view-transition
 .desktop-status {
   display: none;
 }
+.desktop-sidebar {
+  width: 16rem;
+  min-width: 16rem;
+  padding: 1rem;
+  overflow: hidden;
+}
+.desktop-sidebar[data-collapsed='true'] {
+  width: 3.5rem;
+  min-width: 3.5rem;
+  padding: 0.5rem;
+}
 .mobile-header,
 .mobile-tabbar {
   display: flex;

--- a/packages/web/src/routes/git.test.tsx
+++ b/packages/web/src/routes/git.test.tsx
@@ -22,6 +22,7 @@ const {
   gitTaskStatusMock,
   staticModeMock,
   navPushMock,
+  navigateToServerHandoffMock,
 } = vi.hoisted(() => ({
   overviewQueryMock: vi.fn(),
   listEntriesQueryMock: vi.fn(),
@@ -29,6 +30,7 @@ const {
   gitTaskStatusMock: vi.fn(),
   staticModeMock: vi.fn(() => false),
   navPushMock: vi.fn(),
+  navigateToServerHandoffMock: vi.fn(),
 }))
 
 vi.mock('@/lib/trpc', () => ({
@@ -51,6 +53,10 @@ vi.mock('@/lib/static-mode', () => ({
   isStaticMode: staticModeMock,
 }))
 
+vi.mock('@/lib/server-handoff', () => ({
+  navigateToServerHandoff: navigateToServerHandoffMock,
+}))
+
 vi.mock('@/lib/nav-controller', () => ({
   navController: {
     push: navPushMock,
@@ -64,7 +70,27 @@ vi.mock('@/lib/use-dashboard', () => ({
 }))
 
 vi.mock('@/components/git/git-shared', () => ({
+  GIT_WORKTREE_BG_CLASS: 'bg-worktree-current',
+  GIT_WORKTREE_BORDER_CLASS: 'border-worktree-current',
+  copyText: vi.fn(() => Promise.resolve()),
+  isHttpUrl: (value: string) => /^https?:\/\//.test(value),
+  DiffStat: ({
+    diff,
+    className,
+  }: {
+    diff: { insertions: number; deletions: number }
+    className?: string
+  }) => (
+    <span className={className}>
+      +{diff.insertions}/-{diff.deletions}
+    </span>
+  ),
   GitAutoRefreshPresetIcon: () => <span data-testid="git-refresh-icon">icon</span>,
+  GitAheadBehindBadge: ({ ahead, behind }: { ahead: number; behind: number }) => (
+    <span>
+      ahead {ahead} behind {behind}
+    </span>
+  ),
   getGitEntrySharedDescriptor: (entry: { type: string; hash?: string }) => ({
     family: 'git',
     entityId: entry.type === 'commit' ? (entry.hash ?? 'unknown') : 'uncommitted',
@@ -88,6 +114,7 @@ vi.mock('@/components/git/git-shared', () => ({
       {entry.title}
     </button>
   ),
+  GitFilesBadge: ({ files }: { files: number }) => <span>{files} files</span>,
   WorktreeRow: ({ worktree }: { worktree: { path: string } }) => <div>{worktree.path}</div>,
 }))
 
@@ -238,5 +265,52 @@ describe('GitRoute', () => {
         }),
       })
     )
+  })
+
+  it('uses an accessible icon button for worktree switching', async () => {
+    const handoff = {
+      serverUrl: 'http://127.0.0.1:3200',
+    }
+    switchWorktreeMock.mockResolvedValueOnce(handoff)
+    overviewQueryMock.mockResolvedValueOnce({
+      ...overviewData,
+      otherWorktrees: [
+        {
+          path: '/repo-feature',
+          relativePath: '../repo-feature',
+          pathAvailable: true,
+          branchName: 'feature/responsive-shell',
+          detached: false,
+          isCurrent: false,
+          ahead: 2,
+          behind: 0,
+          diff: { files: 3, insertions: 12, deletions: 4 },
+          entries: [],
+        },
+      ],
+    })
+
+    renderWithQueryClient(<GitRoute />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/repo-feature')).toBeTruthy()
+    })
+
+    const switchButton = screen.getByRole('button', {
+      name: 'Switch to feature/responsive-shell',
+    })
+    expect(switchButton.textContent).toBe('')
+
+    fireEvent.click(switchButton)
+
+    await waitFor(() => {
+      expect(switchWorktreeMock).toHaveBeenCalledWith({ path: '/repo-feature' })
+    })
+    await waitFor(() => {
+      expect(navigateToServerHandoffMock).toHaveBeenCalledWith({
+        handoff,
+        location: window.location,
+      })
+    })
   })
 })

--- a/packages/web/src/routes/git.tsx
+++ b/packages/web/src/routes/git.tsx
@@ -5,7 +5,9 @@ import {
   GitEntryRow,
   WorktreeRow,
 } from '@/components/git/git-shared'
+import { WorktreeCard } from '@/components/git/git-worktree-card'
 import { Select, type SelectOption } from '@/components/select'
+import { Tooltip } from '@/components/tooltip'
 import {
   getDashboardGitAutoRefreshIntervalMs,
   getDashboardGitAutoRefreshProgress,
@@ -27,7 +29,14 @@ import { vtNavController } from '@/lib/view-transitions/navigation'
 import { withSharedElementHandoffState } from '@/lib/view-transitions/shared-elements'
 import type { GitWorktreeSummary } from '@openspecui/core'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { AlertCircle, ArrowRightLeft, FileCode2, GitBranch, RefreshCw } from 'lucide-react'
+import {
+  AlertCircle,
+  ArrowRightLeft,
+  FileCode2,
+  GitBranch,
+  LoaderCircle,
+  RefreshCw,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const GIT_AUTO_REFRESH_OPTIONS: SelectOption<DashboardGitAutoRefreshPreset>[] = [
@@ -510,40 +519,46 @@ export function GitRoute() {
       </section>
 
       {otherWorktrees.length > 0 ? (
-        <section className="space-y-3">
+        <section className="min-w-0 space-y-3">
           <div className="flex items-center gap-2">
             <ArrowRightLeft className="h-4 w-4 shrink-0" />
             <h2 className="font-medium">Other Worktrees</h2>
           </div>
-          <div className="grid gap-3 lg:grid-cols-2">
+          <div className="grid min-w-0 gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(100%,22rem),1fr))]">
             {otherWorktrees.map((worktree) => (
-              <div key={worktree.path} className="space-y-2">
-                <WorktreeRow
-                  worktree={worktree}
-                  emphasize={false}
-                  removing={removingWorktreePath === worktree.path}
-                  onRemoveDetachedWorktree={handleRemoveDetachedWorktree}
-                />
-                <div className="flex justify-end">
-                  {worktree.pathAvailable ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        void handleSwitchWorktree(worktree)
-                      }}
-                      disabled={switchingWorktreePath === worktree.path}
-                      className="bg-primary text-primary-foreground inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-70"
-                    >
-                      <ArrowRightLeft className="h-3.5 w-3.5" />
-                      {switchingWorktreePath === worktree.path ? 'Switching…' : 'Switch worktree'}
-                    </button>
+              <WorktreeCard
+                key={worktree.path}
+                worktree={worktree}
+                emphasize={false}
+                removing={removingWorktreePath === worktree.path}
+                onRemoveDetachedWorktree={handleRemoveDetachedWorktree}
+                action={
+                  worktree.pathAvailable ? (
+                    <Tooltip content={`Switch to ${worktree.branchName}`} sideOffset={8}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void handleSwitchWorktree(worktree)
+                        }}
+                        disabled={switchingWorktreePath === worktree.path}
+                        className="bg-primary text-primary-foreground inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-70"
+                        title={`Switch to ${worktree.branchName}`}
+                        aria-label={`Switch to ${worktree.branchName}`}
+                      >
+                        {switchingWorktreePath === worktree.path ? (
+                          <LoaderCircle className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <ArrowRightLeft className="h-4 w-4" />
+                        )}
+                      </button>
+                    </Tooltip>
                   ) : (
                     <span className="text-muted-foreground rounded-md border border-dashed px-2.5 py-1 text-[11px]">
                       Path missing
                     </span>
-                  )}
-                </div>
-              </div>
+                  )
+                }
+              />
             ))}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add responsive Git worktree cards that keep full branch/path content while using compact icon switch actions
- add persisted desktop sidebar collapse with icon-only navigation and disabled drag affordances
- update OpenSpec artifacts and add a web patch changeset

## Verification
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
- local Chromium acceptance for /dashboard?_b=%2Fgit at 900px viewport