### PR TITLE
Release OpenSpecUI 3.0 for OpenSpec CLI 1.3

### DIFF
--- a/.changeset/wise-rules-sync.md
+++ b/.changeset/wise-rules-sync.md
@@ -1,0 +1,14 @@
+---
+'openspecui': major
+'@openspecui/core': major
+'@openspecui/server': major
+'@openspecui/web': major
+---
+
+Release OpenSpecUI 3.0 aligned with OpenSpec CLI 1.3 workflows.
+
+- Establish OpenSpecUI 3.x as the OpenSpec CLI 1.3.x target line while accepting 1.2.x as legacy-compatible.
+- Block OpenSpec CLI versions outside `>=1.2.0 <1.4.0`.
+- Normalize `openspec instructions apply --json` context files to artifact-to-path-array mappings, matching OpenSpec CLI 1.3 while preserving legacy single-path output.
+- Sync AI tool metadata with OpenSpec CLI 1.3.1, including Bob Shell, ForgeCode, Junie, Lingma, Copilot detection paths, and OpenCode `.opencode/commands/`.
+- Update documentation, specs, and reference checks for the OpenSpec CLI 1.3 line.

--- a/README-1.2.0.md
+++ b/README-1.2.0.md
@@ -1,0 +1,105 @@
+# OpenSpec UI
+
+[English](./README-1.2.0.md) | [中文](./README-zh-1.2.0.md)
+
+OpenSpecUI is a web interface for OpenSpec workflows (live mode + hosted app + static export).
+
+## Version Compatibility
+
+| OpenSpecUI | Required OpenSpec CLI |
+| ---------- | --------------------- |
+| `@^2`      | `>=1.2.0 <1.3.0`      |
+| `@^1`      | `>=1.0.0 <1.2.0`      |
+
+Legacy docs:
+
+- 1.x: [`README-1.x.md`](./README-1.x.md)
+- 0.16: [`README-0.16.0.md`](./README-0.16.0.md)
+
+## Quick Start
+
+```bash
+# Recommended: run without global install
+npx openspecui@^2
+bunx openspecui@^2
+
+# Optional: install globally
+npm install -g openspecui
+openspecui
+```
+
+Default URL: `http://localhost:3100`.
+
+## Common Flows
+
+### Start local live mode
+
+```bash
+openspecui
+openspecui ./my-project
+openspecui --port 3200
+```
+
+### Start with the hosted app
+
+```bash
+openspecui --app
+openspecui --app=https://app.example.com
+```
+
+`--app` still runs the local backend, but launches the hosted app instead of a local web bundle.
+When no explicit URL is passed, OpenSpecUI uses the configured `appBaseUrl` or the official
+`https://app.openspecui.com`.
+
+Launch contract:
+
+- PWA-first when the browser can capture the hosted app URL into an installed PWA from the same
+  deployment scope
+- browser-page fallback when no matching hosted-app PWA is installed, link capture is disabled, or
+  the browser does not support it
+- `--app=https://app.example.com` only works with the PWA installed from that same deployment; an
+  installed `app.openspecui.com` PWA will not capture a different origin
+
+### Static export
+
+```bash
+openspecui export -o ./dist
+openspecui export -o ./dist --base-path /docs --clean
+```
+
+### Nix
+
+```bash
+nix run github:jixoai/openspecui -- --help
+nix develop
+```
+
+## Public Entry Points
+
+- Hosted app: `https://app.openspecui.com`
+- Website: `https://www.openspecui.com`
+- OpenSpec official site: `https://openspec.dev`
+- GitHub: `https://github.com/jixoai/openspecui`
+
+## OpenSpec 1.2 Notes
+
+- OpenSpecUI 2.x requires OpenSpec CLI `>=1.2.0`.
+- If your CLI is older, UI shows `OpenSpec CLI Required` and blocks core interactions until upgraded.
+- Default workflow guidance is now `/opsx:propose` (quick path).
+- OpenSpec profile/workflow sync can be inspected from **Settings → OpenSpec 1.2 Profile & Sync**.
+
+Upgrade CLI:
+
+```bash
+npm install -g @fission-ai/openspec@latest
+```
+
+## Key Features
+
+- Dashboard for specs/changes/tasks status
+- Config/Schema viewers and editors
+- OPSX compose panel for change actions
+- Multi-tab PTY terminal (xterm + ghostty-web)
+- Hosted app shell for shared frontend deployments
+- Search in live mode and static mode
+- Static snapshot export for docs hosting

--- a/README-zh-1.2.0.md
+++ b/README-zh-1.2.0.md
@@ -1,0 +1,104 @@
+# OpenSpec UI
+
+[English](./README-1.2.0.md) | [中文](./README-zh-1.2.0.md)
+
+OpenSpecUI 是 OpenSpec 工作流的可视化 Web 界面（支持实时模式、Hosted App 与静态导出）。
+
+## 版本兼容矩阵
+
+| OpenSpecUI | 需要的 OpenSpec CLI |
+| ---------- | ------------------- |
+| `@^2`      | `>=1.2.0 <1.3.0`    |
+| `@^1`      | `>=1.0.0 <1.2.0`    |
+
+历史文档：
+
+- 1.x：[`README-1.x.md`](./README-1.x.md)
+- 0.16：[`README-0.16.0.md`](./README-0.16.0.md)
+
+## 快速开始
+
+```bash
+# 推荐：不全局安装直接运行
+npx openspecui@^2
+bunx openspecui@^2
+
+# 可选：全局安装
+npm install -g openspecui
+openspecui
+```
+
+默认地址：`http://localhost:3100`。
+
+## 常用流程
+
+### 启动本地实时模式
+
+```bash
+openspecui
+openspecui ./my-project
+openspecui --port 3200
+```
+
+### 使用 Hosted App 启动
+
+```bash
+openspecui --app
+openspecui --app=https://app.example.com
+```
+
+`--app` 仍然会启动本地后端，但发起的是 Hosted App 链接，而不是本地构建出来的 Web
+bundle。
+如果没有显式传入 URL，OpenSpecUI 会优先读取配置中的 `appBaseUrl`，否则使用官方地址
+`https://app.openspecui.com`。
+
+启动契约：
+
+- 若浏览器能把该 Hosted App URL 捕获到同一部署范围内已安装的 PWA，则优先进入 PWA
+- 若没有匹配的 PWA、浏览器关闭了链接捕获，或浏览器本身不支持，则回退到普通网页标签
+- `--app=https://app.example.com` 只能复用从 `https://app.example.com` 这一部署安装的 PWA，
+  不能复用 `app.openspecui.com` 的已安装应用
+
+### 静态导出
+
+```bash
+openspecui export -o ./dist
+openspecui export -o ./dist --base-path /docs --clean
+```
+
+### Nix
+
+```bash
+nix run github:jixoai/openspecui -- --help
+nix develop
+```
+
+## 公开入口
+
+- Hosted app：`https://app.openspecui.com`
+- 官网：`https://www.openspecui.com`
+- OpenSpec 官方站点：`https://openspec.dev`
+- GitHub：`https://github.com/jixoai/openspecui`
+
+## OpenSpec 1.2 说明
+
+- OpenSpecUI 2.x 需要 OpenSpec CLI `>=1.2.0`。
+- 如果本地 CLI 版本过低，界面会显示 `OpenSpec CLI Required` 并阻断核心操作，直到升级。
+- 默认工作流建议为 `/opsx:propose`（快速路径）。
+- 可在 **Settings → OpenSpec 1.2 Profile & Sync** 查看 profile/workflow 同步状态。
+
+升级 CLI：
+
+```bash
+npm install -g @fission-ai/openspec@latest
+```
+
+## 核心能力
+
+- 规格/变更/任务 Dashboard
+- Config/Schema 浏览与编辑
+- Change Action 对应的 OPSX Compose
+- 多标签 PTY 终端（xterm + ghostty-web）
+- 面向共享部署的 Hosted App Shell
+- 动态与静态模式搜索
+- 可部署的静态快照导出

--- a/README-zh.md
+++ b/README-zh.md
@@ -2,18 +2,23 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 
-OpenSpecUI 是 OpenSpec 工作流的可视化 Web 界面（支持实时模式、Hosted App 与静态导出）。
+OpenSpecUI 是 OpenSpec 工作流的 Web 界面（动态模式 + 静态导出）。
 
-## 版本兼容矩阵
+## 版本兼容关系
 
-| OpenSpecUI        | 需要的 OpenSpec CLI |
-| ----------------- | ------------------- |
-| `@latest` / `@^2` | `>=1.2.0 <2`        |
-| `@^1`             | `>=1.0.0 <1.2.0`    |
+| OpenSpecUI        | OpenSpec CLI 线                                |
+| ----------------- | ---------------------------------------------- |
+| `@latest` / `@^3` | 当前：`>=1.3.0 <1.4.0`；接受：`>=1.2.0 <1.4.0` |
+| `@^2`             | `>=1.2.0 <1.3.0`                               |
+| `@^1`             | `>=1.0.0 <1.2.0`                               |
+
+OpenSpecUI 的 major 版本跟随 OpenSpec CLI 的 minor 线。OpenSpecUI 3.x 面向 OpenSpec CLI
+1.3.x，并向后兼容 1.2.x 项目。OpenSpecUI 2.x 不向前兼容 OpenSpec CLI 1.3.x。
 
 历史文档：
 
-- 1.x：[`README-1.x.md`](./README-1.x.md)
+- 1.2：[`README-1.2.0.md`](./README-1.2.0.md)
+- 1.x UI / 1.2 之前 CLI 线：[`README-zh-1.x.md`](./README-zh-1.x.md)
 - 0.16：[`README-0.16.0.md`](./README-0.16.0.md)
 
 ## 快速开始
@@ -30,34 +35,29 @@ openspecui
 
 默认地址：`http://localhost:3100`。
 
-## 常用流程
+## OpenSpec 1.3 说明
 
-### 启动本地实时模式
+- OpenSpecUI 3.x 面向 OpenSpec CLI `>=1.3.0 <1.4.0`。
+- OpenSpec CLI `>=1.2.0 <1.3.0` 在 3.x 中作为 legacy-compatible runtime 被接受。
+- 如果 CLI 不在 `>=1.2.0 <1.4.0` 范围内，界面会显示 `OpenSpec CLI Required` 并阻断核心操作，直到升级。
+- 可在 **Settings → OpenSpec Profile & Sync** 查看 profile/workflow 同步状态。
+- OpenSpec CLI 1.3 新增 Bob Shell、ForgeCode、Junie、Lingma，改进 GitHub Copilot 检测，并把 OpenCode 命令目录切换到 `.opencode/commands/`。
+
+升级 CLI：
+
+```bash
+npm install -g @fission-ai/openspec@latest
+```
+
+## 常见流程
+
+### 启动服务
 
 ```bash
 openspecui
 openspecui ./my-project
 openspecui --port 3200
 ```
-
-### 使用 Hosted App 启动
-
-```bash
-openspecui --app
-openspecui --app=https://app.example.com
-```
-
-`--app` 仍然会启动本地后端，但发起的是 Hosted App 链接，而不是本地构建出来的 Web
-bundle。
-如果没有显式传入 URL，OpenSpecUI 会优先读取配置中的 `appBaseUrl`，否则使用官方地址
-`https://app.openspecui.com`。
-
-启动契约：
-
-- 若浏览器能把该 Hosted App URL 捕获到同一部署范围内已安装的 PWA，则优先进入 PWA
-- 若没有匹配的 PWA、浏览器关闭了链接捕获，或浏览器本身不支持，则回退到普通网页标签
-- `--app=https://app.example.com` 只能复用从 `https://app.example.com` 这一部署安装的 PWA，
-  不能复用 `app.openspecui.com` 的已安装应用
 
 ### 静态导出
 
@@ -73,32 +73,11 @@ nix run github:jixoai/openspecui -- --help
 nix develop
 ```
 
-## 公开入口
-
-- Hosted app：`https://app.openspecui.com`
-- 官网：`https://www.openspecui.com`
-- OpenSpec 官方站点：`https://openspec.dev`
-- GitHub：`https://github.com/jixoai/openspecui`
-
-## OpenSpec 1.2 说明
-
-- OpenSpecUI 2.x 需要 OpenSpec CLI `>=1.2.0`。
-- 如果本地 CLI 版本过低，界面会显示 `OpenSpec CLI Required` 并阻断核心操作，直到升级。
-- 默认工作流建议为 `/opsx:propose`（快速路径）。
-- 可在 **Settings → OpenSpec 1.2 Profile & Sync** 查看 profile/workflow 同步状态。
-
-升级 CLI：
-
-```bash
-npm install -g @fission-ai/openspec@latest
-```
-
 ## 核心能力
 
-- 规格/变更/任务 Dashboard
-- Config/Schema 浏览与编辑
-- Change Action 对应的 OPSX Compose
+- specs/changes/tasks 状态仪表盘
+- Config/Schema 查看与编辑
+- 用于 change action 的 OPSX compose 面板
 - 多标签 PTY 终端（xterm + ghostty-web）
-- 面向共享部署的 Hosted App Shell
-- 动态与静态模式搜索
-- 可部署的静态快照导出
+- 动态模式与静态模式搜索
+- 用于文档托管的静态快照导出

--- a/README.md
+++ b/README.md
@@ -2,18 +2,24 @@
 
 [English](./README.md) | [中文](./README-zh.md)
 
-OpenSpecUI is a web interface for OpenSpec workflows (live mode + hosted app + static export).
+OpenSpecUI is a web interface for OpenSpec workflows (live mode + static export).
 
 ## Version Compatibility
 
-| OpenSpecUI        | Required OpenSpec CLI |
-| ----------------- | --------------------- |
-| `@latest` / `@^2` | `>=1.2.0 <2`          |
-| `@^1`             | `>=1.0.0 <1.2.0`      |
+| OpenSpecUI        | OpenSpec CLI line                                     |
+| ----------------- | ----------------------------------------------------- |
+| `@latest` / `@^3` | current: `>=1.3.0 <1.4.0`; accepted: `>=1.2.0 <1.4.0` |
+| `@^2`             | `>=1.2.0 <1.3.0`                                      |
+| `@^1`             | `>=1.0.0 <1.2.0`                                      |
+
+OpenSpecUI major versions track OpenSpec CLI minor lines. OpenSpecUI 3.x targets OpenSpec CLI
+1.3.x and remains backward-compatible with 1.2.x projects. OpenSpecUI 2.x does not forward-support
+OpenSpec CLI 1.3.x.
 
 Legacy docs:
 
-- 1.x: [`README-1.x.md`](./README-1.x.md)
+- 1.2: [`README-1.2.0.md`](./README-1.2.0.md)
+- 1.x UI / pre-1.2 CLI line: [`README-1.x.md`](./README-1.x.md)
 - 0.16: [`README-0.16.0.md`](./README-0.16.0.md)
 
 ## Quick Start
@@ -30,35 +36,29 @@ openspecui
 
 Default URL: `http://localhost:3100`.
 
+## OpenSpec 1.3 Notes
+
+- OpenSpecUI 3.x targets OpenSpec CLI `>=1.3.0 <1.4.0`.
+- OpenSpec CLI `>=1.2.0 <1.3.0` is accepted as a legacy-compatible runtime for 3.x.
+- If your CLI is outside `>=1.2.0 <1.4.0`, UI shows `OpenSpec CLI Required` and blocks core interactions until upgraded.
+- OpenSpec profile/workflow sync can be inspected from **Settings → OpenSpec Profile & Sync**.
+- OpenSpec CLI 1.3 adds Bob Shell, ForgeCode, Junie, Lingma, refined GitHub Copilot detection, and the OpenCode `.opencode/commands/` command directory.
+
+Upgrade CLI:
+
+```bash
+npm install -g @fission-ai/openspec@latest
+```
+
 ## Common Flows
 
-### Start local live mode
+### Start server
 
 ```bash
 openspecui
 openspecui ./my-project
 openspecui --port 3200
 ```
-
-### Start with the hosted app
-
-```bash
-openspecui --app
-openspecui --app=https://app.example.com
-```
-
-`--app` still runs the local backend, but launches the hosted app instead of a local web bundle.
-When no explicit URL is passed, OpenSpecUI uses the configured `appBaseUrl` or the official
-`https://app.openspecui.com`.
-
-Launch contract:
-
-- PWA-first when the browser can capture the hosted app URL into an installed PWA from the same
-  deployment scope
-- browser-page fallback when no matching hosted-app PWA is installed, link capture is disabled, or
-  the browser does not support it
-- `--app=https://app.example.com` only works with the PWA installed from that same deployment; an
-  installed `app.openspecui.com` PWA will not capture a different origin
 
 ### Static export
 
@@ -74,32 +74,11 @@ nix run github:jixoai/openspecui -- --help
 nix develop
 ```
 
-## Public Entry Points
-
-- Hosted app: `https://app.openspecui.com`
-- Website: `https://www.openspecui.com`
-- OpenSpec official site: `https://openspec.dev`
-- GitHub: `https://github.com/jixoai/openspecui`
-
-## OpenSpec 1.2 Notes
-
-- OpenSpecUI 2.x requires OpenSpec CLI `>=1.2.0`.
-- If your CLI is older, UI shows `OpenSpec CLI Required` and blocks core interactions until upgraded.
-- Default workflow guidance is now `/opsx:propose` (quick path).
-- OpenSpec profile/workflow sync can be inspected from **Settings → OpenSpec 1.2 Profile & Sync**.
-
-Upgrade CLI:
-
-```bash
-npm install -g @fission-ai/openspec@latest
-```
-
 ## Key Features
 
 - Dashboard for specs/changes/tasks status
 - Config/Schema viewers and editors
 - OPSX compose panel for change actions
 - Multi-tab PTY terminal (xterm + ghostty-web)
-- Hosted app shell for shared frontend deployments
 - Search in live mode and static mode
 - Static snapshot export for docs hosting

--- a/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/checkpoints.md
+++ b/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/checkpoints.md
@@ -1,0 +1,31 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively
+- [x] 1.2 Version law investigated and corrected
+- [x] 1.3 Plan reviewed and approved
+
+## 2. Platform Law
+
+- [x] 2.1 Add shared OpenSpec CLI compatibility law for OpenSpecUI 3.x
+- [x] 2.2 Export compatibility law through a browser-safe core subpath
+- [x] 2.3 Update CLI health UI to classify current, legacy-compatible, and blocked versions
+- [x] 2.4 Normalize `instructions apply` context files as artifact-to-path-array mappings
+
+## 3. OpenSpec CLI 1.3 Tool Sync
+
+- [x] 3.1 Sync AI tool metadata with OpenSpec CLI 1.3.1
+- [x] 3.2 Support Copilot detection paths
+- [x] 3.3 Model primary and legacy command artifact paths for init state
+
+## 4. Docs, Specs, and Reference
+
+- [x] 4.1 Archive 1.2 README files and rewrite current README for 3.x/1.3.x
+- [x] 4.2 Update OpenSpec specs with the approved version law
+- [x] 4.3 Update `references/openspec` and reference check to `v1.3.*`
+
+## 5. Release and Verification
+
+- [x] 5.1 Add major changeset for publishable packages
+- [x] 5.2 Add/update targeted tests
+- [x] 5.3 Run targeted verification
+- [x] 5.4 Verify apply-instructions JSON compatibility for OpenSpec CLI 1.3 and legacy output

--- a/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/implementation.md
+++ b/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/implementation.md
@@ -1,0 +1,43 @@
+## Implementation State
+
+- OpenSpec change scaffold created for `support-openspec-cli-1-3`.
+- Intake and research plan capture the manager-approved version law.
+- Added shared OpenSpec CLI compatibility law under `@openspecui/core/openspec-compat`.
+- Updated CLI health UI to treat 1.3.x as current, 1.2.x as legacy-compatible, and versions outside `>=1.2.0 <1.4.0` as blocked.
+- Updated apply-instructions parsing so OpenSpec CLI 1.3 `contextFiles` arrays are the internal law while legacy single-path values normalize to arrays.
+- Synced tool metadata with OpenSpec CLI 1.3.1, including Bob Shell, ForgeCode, Junie, Lingma, Copilot detection paths, and OpenCode primary `.opencode/commands/` plus legacy `.opencode/command/`.
+- Archived current 1.2 README files and rewrote root README files for the 3.x / 1.3.x line.
+- Updated main OpenSpec specs with the approved version law.
+- Updated `references/openspec` to `v1.3.1` and reference check to enforce `v1.3.*`.
+- Added a major changeset for the publishable packages affected by the 3.0 alignment.
+- Local verification passed:
+  - `pnpm openspec:check-reference`
+  - `pnpm --filter @openspecui/core test -- openspec-compat.test.ts tool-config.test.ts tool-init-state.test.ts`
+  - `pnpm --filter @openspecui/core test -- opsx-types.test.ts openspec-compat.test.ts`
+  - `pnpm --filter @openspecui/core typecheck`
+  - parsed real `agenter` OpenSpec CLI 1.3.1 `instructions apply --json` output through `ApplyInstructionsSchema`
+  - smoke-started `pnpm openspecui --dir /Users/kzf/Dev/GitHub/jixoai-labs/agenter --no-open --port 3910` without the prior kernel warmup failure
+  - `pnpm --filter @openspecui/web test -- src/components/cli-health-gate.test.tsx src/routes/settings-init.test.ts`
+  - `pnpm format:check`
+  - `pnpm lint:ci`
+  - `pnpm typecheck`
+  - `pnpm test:ci`
+  - `pnpm test:browser:ci`
+
+## Decisions Taken
+
+- Use a shared compatibility law module as the platform rule for CLI version classification.
+- Keep OpenSpec CLI 1.2.x as backward-compatible for OpenSpecUI 3.x.
+- Do not make OpenSpecUI 2.x forward-compatible with OpenSpec CLI 1.3.x.
+- Treat OpenCode `.opencode/commands/` as the primary 1.3 path and `.opencode/command/` as legacy-compatible.
+
+## Divergence Notes
+
+- The final implementation keeps 1.2.x as a non-blocking legacy-compatible runtime for OpenSpecUI 3.x, but the docs and reference line are anchored on OpenSpec CLI 1.3.x.
+- OpenCode legacy command paths count as initialized for compatibility, while surfacing `legacyCommandWorkflows` for UI/status awareness.
+
+## Loopback Triggers
+
+- If OpenSpec CLI 1.3.1 source metadata differs from the investigated release notes, return to research-plan and update the tool model before continuing.
+- If 1.2.x compatibility requires behavior beyond path/tool detection, return to research-plan and record the additional runtime compatibility rule.
+- If CI reference check cannot enforce `v1.3.*` without broader submodule workflow changes, return to research-plan before modifying CI behavior.

--- a/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/intake.md
+++ b/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/intake.md
@@ -1,0 +1,32 @@
+## User Input
+
+- User requirement: "不论1.3是不是破坏性更新，我们必须准信严格的变更同步规范，openspecui@2._ 对应的就是 openspec@1.2._，所以 openspec@1.3._必须对应的是 openspecui@3._ 。"
+- User requirement: "2._不用兼容1.3，反过来我们的规范是运行 3._ 兼容 1.2。"
+- User request: implement the approved plan for OpenSpecUI 3.x alignment with OpenSpec CLI 1.3.x.
+
+## Objective Scope
+
+- Promote the OpenSpec CLI 1.3.x alignment into an OpenSpecUI 3.x major-release track.
+- Encode the version law in shared implementation, docs, specs, and reference checks:
+  - `openspecui@2.*` corresponds to `openspec@1.2.*`.
+  - `openspecui@3.*` corresponds to `openspec@1.3.*`.
+  - `openspecui@2.*` does not forward-support `openspec@1.3.*`.
+  - `openspecui@3.*` backward-supports `openspec@1.2.*`.
+- Sync OpenSpec CLI 1.3.x tool metadata, detection behavior, and command artifact paths.
+- Add release-impacting changeset coverage for publishable package changes.
+
+## Non-Goals
+
+- Do not retrofit OpenSpec CLI 1.3.x support into `openspecui@2.*`.
+- Do not run the release versioning workflow or publish packages in this implementation pass.
+- Do not archive unrelated active change `upgrade-vite-8`.
+- Do not redesign unrelated Git, dashboard, hosted app, or static export behavior.
+
+## Acceptance Boundary
+
+- Shared compatibility code classifies OpenSpec CLI versions according to the approved law.
+- UI/server/core behavior accepts OpenSpec CLI 1.2.x and 1.3.x for OpenSpecUI 3.x, recommends 1.3.x, and blocks outside the accepted range.
+- Tool detection and init state reflect OpenSpec CLI 1.3.1 tool metadata while preserving 1.2 legacy artifacts where required.
+- README and specs describe the 3.x/1.3.x line and archive the 2.x/1.2.x README.
+- `references/openspec` is updated to OpenSpec CLI 1.3.x and CI reference check enforces `v1.3.*`.
+- Targeted tests pass and a major changeset is present.

--- a/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/research-plan.md
+++ b/openspec/changes/archive/2026-05-07-support-openspec-cli-1-3/loop/research-plan.md
@@ -1,0 +1,63 @@
+## Research Findings
+
+- `CLAUDE.md` defines README versioning by OpenSpec CLI version, not by OpenSpecUI package version.
+- Current docs state `openspecui @latest/@^2` requires OpenSpec CLI `>=1.2.0 <2`, but the manager clarified the stricter project law:
+  - `openspecui@2.*` maps to `openspec@1.2.*`.
+  - `openspecui@3.*` maps to `openspec@1.3.*`.
+  - Compatibility is backward from 3.x to 1.2.x, not forward from 2.x to 1.3.x.
+- Current code has hardcoded 1.2 references in:
+  - Web CLI health gate.
+  - Settings profile/sync copy.
+  - Server comments and profile state APIs.
+  - Main README files.
+  - OpenSpec specs.
+  - `scripts/check-openspec-reference.mjs`.
+- OpenSpec CLI 1.3.1 adds or changes:
+  - New tools: `bob`, `forgecode`, `junie`, `lingma`.
+  - `AIToolOption.detectionPaths` for precise GitHub Copilot auto-detection.
+  - OpenCode command directory moves from `.opencode/command/` to `.opencode/commands/`.
+  - Clean `--json` output and path/telemetry fixes.
+- Current `references/openspec` is pinned around `v1.2.0` and lacks local 1.3 tags until fetched.
+
+## Decision & Plan (Approved)
+
+- Treat this as the implementation basis for OpenSpecUI 3.x, not as an OpenSpecUI 2.x patch.
+- Add a shared compatibility law module with:
+  - target CLI series: `1.3`.
+  - accepted runtime range: `>=1.2.0 <1.4.0`.
+  - recommended/current range: `>=1.3.0 <1.4.0`.
+  - legacy-compatible range: `>=1.2.0 <1.3.0`.
+- Update runtime UI so 1.2.x is accepted with an upgrade recommendation, 1.3.x is current, and unsupported versions are blocked.
+- Sync tool metadata to OpenSpec CLI 1.3.1 and model primary versus legacy command paths instead of adding local special-case glue.
+- Archive 1.2 README content and make root README describe OpenSpecUI 3.x / OpenSpec CLI 1.3.x with 1.2 backward compatibility.
+- Update the reference submodule and reference check to `v1.3.*`.
+
+## Capability Impact
+
+### New or Expanded Behavior
+
+- OpenSpecUI 3.x can run against OpenSpec CLI 1.3.x as the current line and 1.2.x as legacy-compatible.
+- Settings/init tooling can see and repair OpenSpec CLI 1.3.x provider artifacts.
+- Copilot detection becomes path-based instead of treating any `.github/` directory as Copilot.
+
+### Modified Behavior
+
+- OpenCode command artifacts prefer `.opencode/commands/` while recognizing `.opencode/command/` as legacy-compatible.
+- Documentation and specs no longer describe a wide `>=1.2.0 <2` OpenSpec CLI range for OpenSpecUI 2.x.
+- The reference check now enforces the 1.3 reference line.
+
+## Risks and Mitigations
+
+- Risk: Accepting 1.2.x in 3.x could be mistaken for 2.x forward compatibility.
+  - Mitigation: copy and compatibility labels explicitly state 1.2 is legacy-compatible under 3.x only.
+- Risk: OpenCode legacy command paths could be reported as stale errors.
+  - Mitigation: represent legacy command artifacts explicitly in tool init state.
+- Risk: Browser package could import the core root entry at runtime.
+  - Mitigation: expose compatibility helpers through a safe subpath export.
+
+## Verification Strategy
+
+- Add unit tests for compatibility classification.
+- Add unit tests for 1.3 tool metadata, Copilot detection paths, and OpenCode primary/legacy command state.
+- Add web tests for CLI health gate behavior across 1.1.x, 1.2.x, 1.3.x, and 1.4.x.
+- Run targeted core/server/web tests first; run broader CI-equivalent checks if time permits.

--- a/openspec/specs/openspec-cli-integration/spec.md
+++ b/openspec/specs/openspec-cli-integration/spec.md
@@ -2,13 +2,13 @@
 
 ## Purpose
 
-Define how OpenSpecUI integrates with the OpenSpec CLI 1.1.x to execute OPSX workflows and stream command output.
+Define how OpenSpecUI integrates with the OpenSpec CLI to execute OPSX workflows and stream command output across the active version line.
 
 ## Requirements
 
 ### Requirement: CLI Discovery and Version Enforcement
 
-OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce a 1.1.x baseline.
+OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce the OpenSpecUI major-to-OpenSpec CLI minor version law.
 
 #### Scenario: Prefer global openspec
 
@@ -23,12 +23,34 @@ OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enfor
 - **WHEN** OpenSpecUI resolves the CLI command
 - **THEN** the system SHALL use `npx @fission-ai/openspec`
 
-#### Scenario: Enforce 1.1.x baseline
+#### Scenario: Enforce OpenSpecUI 3.x compatibility range
 
-- **GIVEN** the CLI reports a version below 1.1.0
+- **GIVEN** OpenSpecUI 3.x evaluates an OpenSpec CLI version outside `>=1.2.0 <1.4.0`
 - **WHEN** OpenSpecUI initializes
 - **THEN** the UI SHALL block usage
 - **AND** present upgrade instructions
+
+#### Scenario: Accept legacy-compatible 1.2 runtime in 3.x
+
+- **GIVEN** OpenSpecUI 3.x evaluates OpenSpec CLI `>=1.2.0 <1.3.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions
+- **AND** SHALL show that the CLI is legacy-compatible and recommend OpenSpec CLI `>=1.3.0 <1.4.0`
+
+#### Scenario: Treat 1.3 runtime as current in 3.x
+
+- **GIVEN** OpenSpecUI 3.x evaluates OpenSpec CLI `>=1.3.0 <1.4.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions without a compatibility warning
+
+#### Scenario: Preserve release-line directionality
+
+- **GIVEN** OpenSpecUI release-line compatibility is evaluated
+- **WHEN** version support is declared
+- **THEN** OpenSpecUI 2.x SHALL correspond to OpenSpec CLI 1.2.x
+- **AND** OpenSpecUI 3.x SHALL correspond to OpenSpec CLI 1.3.x
+- **AND** OpenSpecUI 2.x SHALL NOT forward-support OpenSpec CLI 1.3.x
+- **AND** OpenSpecUI 3.x SHALL backward-support OpenSpec CLI 1.2.x
 
 ### Requirement: Safe CLI Execution
 
@@ -80,6 +102,13 @@ OpenSpecUI SHALL map UI actions to official OPSX CLI commands.
 - **GIVEN** an artifact is selected
 - **WHEN** the UI requests instructions
 - **THEN** the system SHALL execute `openspec instructions <artifact> --json`
+
+#### Scenario: Execute OPSX apply instructions
+
+- **GIVEN** apply guidance is requested for a change
+- **WHEN** the UI requests apply instructions
+- **THEN** the system SHALL execute `openspec instructions apply --json`
+- **AND** normalize CLI-provided `contextFiles` into artifact-id to file-path-array mappings
 
 ### Requirement: CLI Error Handling
 

--- a/openspec/specs/opsx-ui-views/spec.md
+++ b/openspec/specs/opsx-ui-views/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Define the OpenSpecUI screens and navigation model for OPSX workflows, driven entirely by OpenSpec CLI 1.1.x outputs.
+Define the OpenSpecUI screens and navigation model for OPSX workflows, driven entirely by supported OpenSpec CLI outputs.
 
 ## Requirements
 

--- a/openspec/specs/opsx-workflow-ui/spec.md
+++ b/openspec/specs/opsx-workflow-ui/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Define OpenSpecUI behavior so OPSX workflow UI is kernel-first, CLI-aligned, and strictly reactive for OpenSpec 1.x projects.
+Define OpenSpecUI behavior so OPSX workflow UI is kernel-first, CLI-aligned, and strictly reactive for supported OpenSpec CLI projects.
 
 ## Requirements
 
@@ -58,6 +58,13 @@ OpenSpecUI SHALL obtain artifact instructions exclusively from `openspec instruc
 - **WHEN** the user saves artifact content
 - **THEN** the UI SHALL write to the CLI-provided output path
 - **AND** trigger status refresh
+
+#### Scenario: Load apply instructions with multiple context files
+
+- **GIVEN** OpenSpec CLI reports apply `contextFiles` with one or more paths per artifact id
+- **WHEN** the kernel warms apply instructions
+- **THEN** OpenSpecUI SHALL preserve every CLI-provided context file path
+- **AND** legacy single-path values SHALL be normalized into one-item path arrays
 
 ### Requirement: Config-Centered Schema Metadata
 
@@ -174,12 +181,14 @@ OpenSpecUI SHALL block OPSX usage when required CLI capability is missing.
 - **THEN** UI SHALL present a blocking notice with install/upgrade guidance
 - **AND** prevent OPSX actions until resolved
 
-#### Scenario: Enforce 1.1.x baseline only
+#### Scenario: Enforce OpenSpecUI 3.x CLI compatibility
 
-- **GIVEN** project targets OpenSpec CLI 1.1.x
+- **GIVEN** OpenSpecUI 3.x evaluates a project runtime
 - **WHEN** compatibility is evaluated
-- **THEN** UI SHALL require CLI 1.1.x or newer
-- **AND** SHALL NOT implement backward compatibility for pre-1.1.x releases
+- **THEN** UI SHALL accept OpenSpec CLI `>=1.2.0 <1.4.0`
+- **AND** SHALL treat OpenSpec CLI `>=1.3.0 <1.4.0` as the current target line
+- **AND** SHALL treat OpenSpec CLI `>=1.2.0 <1.3.0` as legacy-compatible
+- **AND** SHALL block versions outside `>=1.2.0 <1.4.0`
 
 #### Scenario: Missing project config or required skills
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
       "import": "./dist/hosted-app.mjs",
       "types": "./dist/hosted-app.d.mts"
     },
+    "./openspec-compat": {
+      "import": "./dist/openspec-compat.mjs",
+      "types": "./dist/openspec-compat.d.mts"
+    },
     "./opsx-display-path": {
       "import": "./dist/opsx-display-path.mjs",
       "types": "./dist/opsx-display-path.d.mts"
@@ -27,8 +31,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts --format esm --dts",
-    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts --format esm --dts --watch",
+    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts --format esm --dts",
+    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts --format esm --dts --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,6 +203,7 @@ export { OpsxKernel, type TemplateContentMap } from './opsx-kernel.js'
 
 // OPSX CLI output schemas and types
 export {
+  ApplyInstructionsContextFilesSchema,
   ApplyInstructionsSchema,
   ApplyTaskSchema,
   ArtifactInstructionsSchema,

--- a/packages/core/src/openspec-compat.test.ts
+++ b/packages/core/src/openspec-compat.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OPENSPEC_CLI_ACCEPTED_RANGE,
+  classifyOpenSpecCliVersion,
+  parseOpenSpecCliVersion,
+} from './openspec-compat.js'
+
+describe('openspec CLI compatibility law', () => {
+  it('parses versions from raw CLI output', () => {
+    expect(parseOpenSpecCliVersion('1.3.1')).toEqual({ major: 1, minor: 3, patch: 1 })
+    expect(parseOpenSpecCliVersion('openspec 1.2.0')).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 0,
+    })
+  })
+
+  it('classifies 1.3.x as the current OpenSpecUI 3.x target line', () => {
+    expect(classifyOpenSpecCliVersion('1.3.1')).toMatchObject({
+      status: 'current',
+      supported: true,
+      recommended: true,
+      blocksCoreInteractions: false,
+    })
+  })
+
+  it('classifies 1.2.x as backward-compatible but not recommended', () => {
+    expect(classifyOpenSpecCliVersion('1.2.0')).toMatchObject({
+      status: 'legacy-compatible',
+      supported: true,
+      recommended: false,
+      blocksCoreInteractions: false,
+    })
+  })
+
+  it('blocks versions outside the 3.x accepted range', () => {
+    expect(classifyOpenSpecCliVersion('1.1.1')).toMatchObject({
+      status: 'unsupported',
+      supported: false,
+      blocksCoreInteractions: true,
+    })
+    expect(classifyOpenSpecCliVersion('1.4.0')).toMatchObject({
+      status: 'unsupported',
+      supported: false,
+      blocksCoreInteractions: true,
+    })
+    expect(classifyOpenSpecCliVersion('1.4.0').message).toContain(OPENSPEC_CLI_ACCEPTED_RANGE)
+  })
+
+  it('blocks unknown versions', () => {
+    expect(classifyOpenSpecCliVersion('dev')).toMatchObject({
+      status: 'unknown',
+      supported: false,
+      blocksCoreInteractions: true,
+    })
+  })
+})

--- a/packages/core/src/openspec-compat.ts
+++ b/packages/core/src/openspec-compat.ts
@@ -1,0 +1,113 @@
+export const OPENSPECUI_TARGET_MAJOR = 3
+export const OPENSPEC_CLI_TARGET_SERIES = '1.3'
+export const OPENSPEC_CLI_LEGACY_SERIES = '1.2'
+export const OPENSPEC_CLI_MIN_VERSION = '1.2.0'
+export const OPENSPEC_CLI_TARGET_MIN_VERSION = '1.3.0'
+export const OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.4.0'
+export const OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.2.0 <1.4.0'
+export const OPENSPEC_CLI_RECOMMENDED_RANGE = '>=1.3.0 <1.4.0'
+export const OPENSPEC_CLI_LEGACY_RANGE = '>=1.2.0 <1.3.0'
+export const OPENSPEC_CLI_REFERENCE_TAG_PATTERN = 'v1.3.*'
+
+export interface OpenSpecCliVersion {
+  major: number
+  minor: number
+  patch: number
+}
+
+export type OpenSpecCliCompatibilityStatus =
+  | 'current'
+  | 'legacy-compatible'
+  | 'unsupported'
+  | 'unknown'
+
+export interface OpenSpecCliCompatibility {
+  rawVersion: string | undefined
+  version: OpenSpecCliVersion | null
+  status: OpenSpecCliCompatibilityStatus
+  supported: boolean
+  recommended: boolean
+  blocksCoreInteractions: boolean
+  message: string
+}
+
+export function parseOpenSpecCliVersion(raw: string | undefined): OpenSpecCliVersion | null {
+  if (!raw) return null
+  const match = raw.match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!match) return null
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  }
+}
+
+export function formatOpenSpecCliVersion(version: OpenSpecCliVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`
+}
+
+export function compareOpenSpecCliVersions(
+  left: OpenSpecCliVersion,
+  right: OpenSpecCliVersion
+): number {
+  if (left.major !== right.major) return left.major - right.major
+  if (left.minor !== right.minor) return left.minor - right.minor
+  return left.patch - right.patch
+}
+
+function isSeries(version: OpenSpecCliVersion, series: string): boolean {
+  const [major, minor] = series.split('.').map((part) => Number(part))
+  return version.major === major && version.minor === minor
+}
+
+export function classifyOpenSpecCliVersion(
+  rawVersion: string | undefined
+): OpenSpecCliCompatibility {
+  const version = parseOpenSpecCliVersion(rawVersion)
+
+  if (!version) {
+    return {
+      rawVersion,
+      version: null,
+      status: 'unknown',
+      supported: false,
+      recommended: false,
+      blocksCoreInteractions: true,
+      message: 'Unable to parse OpenSpec CLI version.',
+    }
+  }
+
+  if (isSeries(version, OPENSPEC_CLI_TARGET_SERIES)) {
+    return {
+      rawVersion,
+      version,
+      status: 'current',
+      supported: true,
+      recommended: true,
+      blocksCoreInteractions: false,
+      message: `OpenSpec CLI ${formatOpenSpecCliVersion(version)} matches the OpenSpecUI ${OPENSPECUI_TARGET_MAJOR}.x target line.`,
+    }
+  }
+
+  if (isSeries(version, OPENSPEC_CLI_LEGACY_SERIES)) {
+    return {
+      rawVersion,
+      version,
+      status: 'legacy-compatible',
+      supported: true,
+      recommended: false,
+      blocksCoreInteractions: false,
+      message: `OpenSpec CLI ${formatOpenSpecCliVersion(version)} is legacy-compatible with OpenSpecUI ${OPENSPECUI_TARGET_MAJOR}.x. Upgrade to ${OPENSPEC_CLI_RECOMMENDED_RANGE} for the current line.`,
+    }
+  }
+
+  return {
+    rawVersion,
+    version,
+    status: 'unsupported',
+    supported: false,
+    recommended: false,
+    blocksCoreInteractions: true,
+    message: `Detected OpenSpec CLI ${formatOpenSpecCliVersion(version)}, but OpenSpecUI ${OPENSPECUI_TARGET_MAJOR}.x accepts ${OPENSPEC_CLI_ACCEPTED_RANGE}.`,
+  }
+}

--- a/packages/core/src/opsx-kernel.ts
+++ b/packages/core/src/opsx-kernel.ts
@@ -36,7 +36,7 @@ export type TemplateContentMap = Record<
 // Helpers (migrated from router.ts)
 // ---------------------------------------------------------------------------
 
-function parseCliJson<T>(raw: string, schema: z.ZodSchema<T>, label: string): T {
+function parseCliJson<S extends z.ZodTypeAny>(raw: string, schema: S, label: string): z.output<S> {
   const trimmed = raw.trim()
   if (!trimmed) {
     throw new Error(`${label} returned empty output`)

--- a/packages/core/src/opsx-types.test.ts
+++ b/packages/core/src/opsx-types.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { ApplyInstructionsSchema } from './opsx-types.js'
+
+const baseApplyInstructions = {
+  changeName: 'add-example',
+  changeDir: '/repo/openspec/changes/add-example',
+  schemaName: 'spec-driven',
+  progress: {
+    total: 1,
+    complete: 0,
+    remaining: 1,
+  },
+  tasks: [
+    {
+      id: '1',
+      description: 'Do the work',
+      done: false,
+    },
+  ],
+  state: 'ready',
+  instruction: 'Read context files and apply the change.',
+} as const
+
+describe('ApplyInstructionsSchema', () => {
+  it('accepts OpenSpec CLI 1.3 contextFiles arrays', () => {
+    const parsed = ApplyInstructionsSchema.parse({
+      ...baseApplyInstructions,
+      contextFiles: {
+        proposal: ['/repo/openspec/changes/add-example/proposal.md'],
+        specs: [
+          '/repo/openspec/changes/add-example/specs/alpha/spec.md',
+          '/repo/openspec/changes/add-example/specs/beta/spec.md',
+        ],
+        tasks: ['/repo/openspec/changes/add-example/tasks.md'],
+      },
+    })
+
+    expect(parsed.contextFiles).toEqual({
+      proposal: ['/repo/openspec/changes/add-example/proposal.md'],
+      specs: [
+        '/repo/openspec/changes/add-example/specs/alpha/spec.md',
+        '/repo/openspec/changes/add-example/specs/beta/spec.md',
+      ],
+      tasks: ['/repo/openspec/changes/add-example/tasks.md'],
+    })
+  })
+
+  it('normalizes legacy contextFiles strings to arrays', () => {
+    const parsed = ApplyInstructionsSchema.parse({
+      ...baseApplyInstructions,
+      contextFiles: {
+        proposal: '/repo/openspec/changes/add-example/proposal.md',
+        specs: '/repo/openspec/changes/add-example/specs/alpha/spec.md',
+        tasks: '/repo/openspec/changes/add-example/tasks.md',
+      },
+    })
+
+    expect(parsed.contextFiles).toEqual({
+      proposal: ['/repo/openspec/changes/add-example/proposal.md'],
+      specs: ['/repo/openspec/changes/add-example/specs/alpha/spec.md'],
+      tasks: ['/repo/openspec/changes/add-example/tasks.md'],
+    })
+  })
+})

--- a/packages/core/src/opsx-types.ts
+++ b/packages/core/src/opsx-types.ts
@@ -42,11 +42,17 @@ export const ApplyTaskSchema = z.object({
 
 export type ApplyTask = z.infer<typeof ApplyTaskSchema>
 
+const ApplyInstructionsContextFilePathsSchema = z
+  .union([z.string(), z.array(z.string())])
+  .transform((paths) => (Array.isArray(paths) ? paths : [paths]))
+
+export const ApplyInstructionsContextFilesSchema = z.record(ApplyInstructionsContextFilePathsSchema)
+
 export const ApplyInstructionsSchema = z.object({
   changeName: z.string(),
   changeDir: z.string(),
   schemaName: z.string(),
-  contextFiles: z.record(z.string()),
+  contextFiles: ApplyInstructionsContextFilesSchema,
   progress: z.object({
     total: z.number(),
     complete: z.number(),

--- a/packages/core/src/tool-config.test.ts
+++ b/packages/core/src/tool-config.test.ts
@@ -28,6 +28,10 @@ describe('getDetectedProjectTools', () => {
     expect(getAllToolIds()).not.toContain('agents')
   })
 
+  it('includes OpenSpec CLI 1.3 tool ids', () => {
+    expect(getAllToolIds()).toEqual(expect.arrayContaining(['bob', 'forgecode', 'junie', 'lingma']))
+  })
+
   it('detects project-local tool directories only', async () => {
     await mkdir(join(tempDir, '.claude'), { recursive: true })
     await mkdir(join(tempDir, '.cursor'), { recursive: true })
@@ -35,5 +39,21 @@ describe('getDetectedProjectTools', () => {
     const detected = await getDetectedProjectTools(tempDir)
 
     expect(detected.map((tool) => tool.value)).toEqual(['claude', 'cursor'])
+  })
+
+  it('does not detect GitHub Copilot from a bare .github directory', async () => {
+    await mkdir(join(tempDir, '.github'), { recursive: true })
+
+    const detected = await getDetectedProjectTools(tempDir)
+
+    expect(detected.map((tool) => tool.value)).not.toContain('github-copilot')
+  })
+
+  it('detects GitHub Copilot from official Copilot paths', async () => {
+    await mkdir(join(tempDir, '.github', 'prompts'), { recursive: true })
+
+    const detected = await getDetectedProjectTools(tempDir)
+
+    expect(detected.map((tool) => tool.value)).toContain('github-copilot')
   })
 })

--- a/packages/core/src/tool-config.ts
+++ b/packages/core/src/tool-config.ts
@@ -23,6 +23,8 @@ export interface AIToolOption {
   successLabel?: string
   /** 技能目录（相对项目根目录） */
   skillsDir?: string
+  /** 自动检测路径；存在任一路径即表示项目已有该工具配置 */
+  detectionPaths?: string[]
 }
 
 /**
@@ -75,6 +77,13 @@ export const AI_TOOLS: ToolConfig[] = [
     skillsDir: '.augment',
   },
   {
+    name: 'Bob Shell',
+    value: 'bob',
+    available: true,
+    successLabel: 'Bob Shell',
+    skillsDir: '.bob',
+  },
+  {
     name: 'Claude Code',
     value: 'claude',
     available: true,
@@ -83,6 +92,13 @@ export const AI_TOOLS: ToolConfig[] = [
   },
   { name: 'Cline', value: 'cline', available: true, successLabel: 'Cline', skillsDir: '.cline' },
   { name: 'Codex', value: 'codex', available: true, successLabel: 'Codex', skillsDir: '.codex' },
+  {
+    name: 'ForgeCode',
+    value: 'forgecode',
+    available: true,
+    successLabel: 'ForgeCode',
+    skillsDir: '.forge',
+  },
   {
     name: 'CodeBuddy Code (CLI)',
     value: 'codebuddy',
@@ -132,8 +148,18 @@ export const AI_TOOLS: ToolConfig[] = [
     available: true,
     successLabel: 'GitHub Copilot',
     skillsDir: '.github',
+    detectionPaths: [
+      '.github/copilot-instructions.md',
+      '.github/instructions',
+      '.github/workflows/copilot-setup-steps.yml',
+      '.github/prompts',
+      '.github/agents',
+      '.github/skills',
+      '.github/.mcp.json',
+    ],
   },
   { name: 'iFlow', value: 'iflow', available: true, successLabel: 'iFlow', skillsDir: '.iflow' },
+  { name: 'Junie', value: 'junie', available: true, successLabel: 'Junie', skillsDir: '.junie' },
   {
     name: 'Kilo Code',
     value: 'kilocode',
@@ -151,6 +177,13 @@ export const AI_TOOLS: ToolConfig[] = [
   },
   { name: 'Pi', value: 'pi', available: true, successLabel: 'Pi', skillsDir: '.pi' },
   { name: 'Qoder', value: 'qoder', available: true, successLabel: 'Qoder', skillsDir: '.qoder' },
+  {
+    name: 'Lingma',
+    value: 'lingma',
+    available: true,
+    successLabel: 'Lingma',
+    skillsDir: '.lingma',
+  },
   {
     name: 'Qwen Code',
     value: 'qwen',
@@ -206,8 +239,14 @@ export async function getDetectedProjectTools(projectDir: string): Promise<ToolC
   const results = await Promise.all(
     AI_TOOLS.map(async (tool) => {
       if (!tool.skillsDir) return null
-      const exists = await reactiveExists(join(projectDir, tool.skillsDir))
-      return exists ? tool : null
+      const detectionPaths =
+        tool.detectionPaths && tool.detectionPaths.length > 0
+          ? tool.detectionPaths
+          : [tool.skillsDir]
+      const exists = await Promise.all(
+        detectionPaths.map((path) => reactiveExists(join(projectDir, path)))
+      )
+      return exists.some(Boolean) ? tool : null
     })
   )
   return results.filter((tool): tool is ToolConfig => tool !== null)

--- a/packages/core/src/tool-init-state.test.ts
+++ b/packages/core/src/tool-init-state.test.ts
@@ -114,6 +114,22 @@ describe('getToolInitStates', () => {
     expect(state?.presentExpectedCommandCount).toBe(1)
   })
 
+  it('treats OpenCode 1.2 command directory as legacy-compatible', async () => {
+    await writeArtifact(join(tempDir, '.opencode', 'command', 'opsx-explore.md'))
+
+    const states = await getToolInitStates(tempDir, {
+      delivery: 'commands',
+      workflows: ['explore'],
+    })
+    const state = states.find((entry) => entry.toolId === 'opencode')
+
+    expect(state?.status).toBe('initialized')
+    expect(state?.expectedCommandCount).toBe(1)
+    expect(state?.presentExpectedCommandCount).toBe(1)
+    expect(state?.missingCommandWorkflows).toEqual([])
+    expect(state?.legacyCommandWorkflows).toEqual(['explore'])
+  })
+
   it('refreshes stale cached file existence after init artifacts are created later', async () => {
     const before = await getToolInitStates(tempDir, {
       delivery: 'both',

--- a/packages/core/src/tool-init-state.ts
+++ b/packages/core/src/tool-init-state.ts
@@ -36,14 +36,23 @@ export interface ToolInitState {
   missingCommandWorkflows: ToolWorkflowId[]
   unexpectedSkillWorkflows: ToolWorkflowId[]
   unexpectedCommandWorkflows: ToolWorkflowId[]
+  legacyCommandWorkflows: ToolWorkflowId[]
 }
 
 interface ArtifactEntry {
   workflow: ToolWorkflowId
   path: string
+  legacyPaths?: readonly string[]
 }
 
 const ALL_TOOL_WORKFLOWS = Object.keys(TOOL_WORKFLOW_TO_SKILL_DIR) as ToolWorkflowId[]
+
+type CommandPathResolver = (projectDir: string, workflow: ToolWorkflowId) => string
+
+interface ToolCommandPathConfig {
+  primary: CommandPathResolver
+  legacy?: readonly CommandPathResolver[]
+}
 
 function toKnownWorkflows(workflows: readonly string[]): ToolWorkflowId[] {
   return workflows.filter(
@@ -56,60 +65,126 @@ function resolveCodexHome(): string {
   return resolve(configuredHome ? configuredHome : join(homedir(), '.codex'))
 }
 
-function resolveToolCommandPath(
+const TOOL_COMMAND_PATHS: Record<string, ToolCommandPathConfig> = {
+  'amazon-q': {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.amazonq', 'prompts', `opsx-${workflow}.md`),
+  },
+  antigravity: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.agent', 'workflows', `opsx-${workflow}.md`),
+  },
+  auggie: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.augment', 'commands', `opsx-${workflow}.md`),
+  },
+  bob: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.bob', 'commands', `opsx-${workflow}.md`),
+  },
+  claude: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.claude', 'commands', 'opsx', `${workflow}.md`),
+  },
+  cline: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.clinerules', 'workflows', `opsx-${workflow}.md`),
+  },
+  codebuddy: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.codebuddy', 'commands', 'opsx', `${workflow}.md`),
+  },
+  codex: {
+    primary: (_projectDir, workflow) =>
+      resolve(resolveCodexHome(), 'prompts', `opsx-${workflow}.md`),
+  },
+  continue: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.continue', 'prompts', `opsx-${workflow}.prompt`),
+  },
+  costrict: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.cospec', 'openspec', 'commands', `opsx-${workflow}.md`),
+  },
+  crush: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.crush', 'commands', 'opsx', `${workflow}.md`),
+  },
+  cursor: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.cursor', 'commands', `opsx-${workflow}.md`),
+  },
+  factory: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.factory', 'commands', `opsx-${workflow}.md`),
+  },
+  gemini: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.gemini', 'commands', 'opsx', `${workflow}.toml`),
+  },
+  'github-copilot': {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.github', 'prompts', `opsx-${workflow}.prompt.md`),
+  },
+  iflow: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.iflow', 'commands', `opsx-${workflow}.md`),
+  },
+  junie: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.junie', 'commands', `opsx-${workflow}.md`),
+  },
+  kilocode: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.kilocode', 'workflows', `opsx-${workflow}.md`),
+  },
+  kiro: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.kiro', 'prompts', `opsx-${workflow}.prompt.md`),
+  },
+  lingma: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.lingma', 'commands', 'opsx', `${workflow}.md`),
+  },
+  opencode: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.opencode', 'commands', `opsx-${workflow}.md`),
+    legacy: [
+      (projectDir, workflow) => resolve(projectDir, '.opencode', 'command', `opsx-${workflow}.md`),
+    ],
+  },
+  pi: {
+    primary: (projectDir, workflow) => resolve(projectDir, '.pi', 'prompts', `opsx-${workflow}.md`),
+  },
+  qoder: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.qoder', 'commands', 'opsx', `${workflow}.md`),
+  },
+  qwen: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.qwen', 'commands', `opsx-${workflow}.toml`),
+  },
+  roocode: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.roo', 'commands', `opsx-${workflow}.md`),
+  },
+  windsurf: {
+    primary: (projectDir, workflow) =>
+      resolve(projectDir, '.windsurf', 'workflows', `opsx-${workflow}.md`),
+  },
+}
+
+function resolveToolCommandArtifact(
   projectDir: string,
   toolId: string,
   workflow: ToolWorkflowId
-): string | null {
-  switch (toolId) {
-    case 'amazon-q':
-      return resolve(projectDir, '.amazonq', 'prompts', `opsx-${workflow}.md`)
-    case 'antigravity':
-      return resolve(projectDir, '.agent', 'workflows', `opsx-${workflow}.md`)
-    case 'auggie':
-      return resolve(projectDir, '.augment', 'commands', `opsx-${workflow}.md`)
-    case 'claude':
-      return resolve(projectDir, '.claude', 'commands', 'opsx', `${workflow}.md`)
-    case 'cline':
-      return resolve(projectDir, '.clinerules', 'workflows', `opsx-${workflow}.md`)
-    case 'codebuddy':
-      return resolve(projectDir, '.codebuddy', 'commands', 'opsx', `${workflow}.md`)
-    case 'codex':
-      return resolve(resolveCodexHome(), 'prompts', `opsx-${workflow}.md`)
-    case 'continue':
-      return resolve(projectDir, '.continue', 'prompts', `opsx-${workflow}.prompt`)
-    case 'costrict':
-      return resolve(projectDir, '.cospec', 'openspec', 'commands', `opsx-${workflow}.md`)
-    case 'crush':
-      return resolve(projectDir, '.crush', 'commands', 'opsx', `${workflow}.md`)
-    case 'cursor':
-      return resolve(projectDir, '.cursor', 'commands', `opsx-${workflow}.md`)
-    case 'factory':
-      return resolve(projectDir, '.factory', 'commands', `opsx-${workflow}.md`)
-    case 'gemini':
-      return resolve(projectDir, '.gemini', 'commands', 'opsx', `${workflow}.toml`)
-    case 'github-copilot':
-      return resolve(projectDir, '.github', 'prompts', `opsx-${workflow}.prompt.md`)
-    case 'iflow':
-      return resolve(projectDir, '.iflow', 'commands', `opsx-${workflow}.md`)
-    case 'kilocode':
-      return resolve(projectDir, '.kilocode', 'workflows', `opsx-${workflow}.md`)
-    case 'kiro':
-      return resolve(projectDir, '.kiro', 'prompts', `opsx-${workflow}.prompt.md`)
-    case 'opencode':
-      return resolve(projectDir, '.opencode', 'command', `opsx-${workflow}.md`)
-    case 'pi':
-      return resolve(projectDir, '.pi', 'prompts', `opsx-${workflow}.md`)
-    case 'qoder':
-      return resolve(projectDir, '.qoder', 'commands', 'opsx', `${workflow}.md`)
-    case 'qwen':
-      return resolve(projectDir, '.qwen', 'commands', `opsx-${workflow}.toml`)
-    case 'roocode':
-      return resolve(projectDir, '.roo', 'commands', `opsx-${workflow}.md`)
-    case 'windsurf':
-      return resolve(projectDir, '.windsurf', 'workflows', `opsx-${workflow}.md`)
-    default:
-      return null
+): ArtifactEntry | null {
+  const config = TOOL_COMMAND_PATHS[toolId]
+  if (!config) return null
+  return {
+    workflow,
+    path: config.primary(projectDir, workflow),
+    legacyPaths: config.legacy?.map((resolvePath) => resolvePath(projectDir, workflow)),
   }
 }
 
@@ -128,8 +203,8 @@ function getSkillArtifacts(projectDir: string, skillsDir: string): ArtifactEntry
 
 function getCommandArtifacts(projectDir: string, toolId: string): ArtifactEntry[] {
   return ALL_TOOL_WORKFLOWS.flatMap((workflow) => {
-    const path = resolveToolCommandPath(projectDir, toolId, workflow)
-    return path ? [{ workflow, path }] : []
+    const artifact = resolveToolCommandArtifact(projectDir, toolId, workflow)
+    return artifact ? [artifact] : []
   })
 }
 
@@ -141,10 +216,10 @@ function invalidateToolInitCaches(projectDir: string): void {
       cacheRoots.add(resolve(projectDir, tool.skillsDir))
     }
 
-    for (const workflow of ALL_TOOL_WORKFLOWS) {
-      const commandPath = resolveToolCommandPath(projectDir, tool.value, workflow)
-      if (commandPath) {
-        cacheRoots.add(dirname(commandPath))
+    for (const commandArtifact of getCommandArtifacts(projectDir, tool.value)) {
+      cacheRoots.add(dirname(commandArtifact.path))
+      for (const legacyPath of commandArtifact.legacyPaths ?? []) {
+        cacheRoots.add(dirname(legacyPath))
       }
     }
   }
@@ -155,24 +230,41 @@ function invalidateToolInitCaches(projectDir: string): void {
 }
 
 async function getExistingArtifactPaths(entries: readonly ArtifactEntry[]): Promise<Set<string>> {
+  const paths = entries.flatMap((entry) => [entry.path, ...(entry.legacyPaths ?? [])])
   const presence = await Promise.all(
-    entries.map(async (entry) => ({ path: entry.path, exists: await reactiveExists(entry.path) }))
+    paths.map(async (path) => ({ path, exists: await reactiveExists(path) }))
   )
   return new Set(presence.filter((entry) => entry.exists).map((entry) => entry.path))
+}
+
+function hasExistingArtifact(entry: ArtifactEntry, existingPaths: ReadonlySet<string>): boolean {
+  return (
+    existingPaths.has(entry.path) ||
+    (entry.legacyPaths?.some((legacyPath) => existingPaths.has(legacyPath)) ?? false)
+  )
+}
+
+function hasLegacyArtifact(entry: ArtifactEntry, existingPaths: ReadonlySet<string>): boolean {
+  return entry.legacyPaths?.some((legacyPath) => existingPaths.has(legacyPath)) ?? false
 }
 
 function countExisting(
   entries: readonly ArtifactEntry[],
   existingPaths: ReadonlySet<string>
 ): number {
-  return entries.reduce((count, entry) => count + (existingPaths.has(entry.path) ? 1 : 0), 0)
+  return entries.reduce(
+    (count, entry) => count + (hasExistingArtifact(entry, existingPaths) ? 1 : 0),
+    0
+  )
 }
 
 function collectMissingWorkflows(
   entries: readonly ArtifactEntry[],
   existingPaths: ReadonlySet<string>
 ): ToolWorkflowId[] {
-  return entries.filter((entry) => !existingPaths.has(entry.path)).map((entry) => entry.workflow)
+  return entries
+    .filter((entry) => !hasExistingArtifact(entry, existingPaths))
+    .map((entry) => entry.workflow)
 }
 
 function collectUnexpectedWorkflows(
@@ -181,7 +273,19 @@ function collectUnexpectedWorkflows(
   existingPaths: ReadonlySet<string>
 ): ToolWorkflowId[] {
   return entries
-    .filter((entry) => !desiredWorkflowSet.has(entry.workflow) && existingPaths.has(entry.path))
+    .filter(
+      (entry) =>
+        !desiredWorkflowSet.has(entry.workflow) && hasExistingArtifact(entry, existingPaths)
+    )
+    .map((entry) => entry.workflow)
+}
+
+function collectLegacyWorkflows(
+  entries: readonly ArtifactEntry[],
+  existingPaths: ReadonlySet<string>
+): ToolWorkflowId[] {
+  return entries
+    .filter((entry) => hasLegacyArtifact(entry, existingPaths))
     .map((entry) => entry.workflow)
 }
 
@@ -228,6 +332,7 @@ export async function getToolInitStates(
         shouldGenerateCommands ? desiredWorkflowSet : new Set<ToolWorkflowId>(),
         existingCommandPaths
       )
+      const legacyCommandWorkflows = collectLegacyWorkflows(commandArtifacts, existingCommandPaths)
 
       const expectedSkillCount = expectedSkillArtifacts.length
       const presentExpectedSkillCount = expectedSkillCount - missingSkillWorkflows.length
@@ -259,6 +364,7 @@ export async function getToolInitStates(
         missingCommandWorkflows,
         unexpectedSkillWorkflows,
         unexpectedCommandWorkflows,
+        legacyCommandWorkflows,
       } satisfies ToolInitState
     })
   )

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -789,7 +789,7 @@ export const cliRouter = router({
     })) satisfies AIToolOption[]
   }),
 
-  /** 获取 OpenSpec 1.2 profile/workflow 配置与当前项目漂移状态 */
+  /** 获取 OpenSpec CLI profile/workflow 配置与当前项目漂移状态 */
   getProfileState: publicProcedure.query(async ({ ctx }) => {
     return fetchOpsxProfileState(ctx)
   }),

--- a/packages/web/src/components/cli-health-gate.test.tsx
+++ b/packages/web/src/components/cli-health-gate.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CliHealthGate } from './cli-health-gate'
+
+interface CliAvailability {
+  available: boolean
+  version?: string
+  error?: string
+}
+
+let availability: CliAvailability = { available: true, version: '1.3.1' }
+
+vi.mock('@/lib/static-mode', () => ({
+  isStaticMode: () => false,
+}))
+
+vi.mock('@/lib/use-subscription', () => ({
+  useConfigSubscription: () => ({ data: undefined }),
+}))
+
+vi.mock('@/lib/trpc', () => ({
+  queryClient: {
+    invalidateQueries: async () => undefined,
+  },
+  trpc: {
+    cli: {
+      checkAvailability: {
+        queryOptions: () => ({
+          queryKey: ['cli.checkAvailability'],
+          queryFn: async () => availability,
+        }),
+        queryFilter: () => ({ queryKey: ['cli.checkAvailability'] }),
+      },
+    },
+    config: {
+      getEffectiveCliCommand: {
+        queryFilter: () => ({ queryKey: ['config.getEffectiveCliCommand'] }),
+      },
+    },
+  },
+  trpcClient: {
+    config: {
+      update: {
+        mutate: async () => ({ success: true }),
+      },
+    },
+  },
+}))
+
+function renderGate() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CliHealthGate />
+    </QueryClientProvider>
+  )
+}
+
+describe('CliHealthGate', () => {
+  beforeEach(() => {
+    availability = { available: true, version: '1.3.1' }
+  })
+
+  it('does not render for current OpenSpec CLI 1.3.x', async () => {
+    renderGate()
+
+    await waitFor(() => {
+      expect(screen.queryByText(/OpenSpec CLI .* Required/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/legacy-compatible/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders a non-blocking legacy-compatible notice for OpenSpec CLI 1.2.x', async () => {
+    availability = { available: true, version: '1.2.0' }
+
+    renderGate()
+
+    expect(await screen.findByText('OpenSpec CLI 1.2.0 is legacy-compatible')).toBeInTheDocument()
+    expect(screen.queryByText(/OpenSpec CLI .* Required/)).not.toBeInTheDocument()
+  })
+
+  it('blocks unsupported OpenSpec CLI versions', async () => {
+    availability = { available: true, version: '1.1.1' }
+
+    renderGate()
+
+    expect(await screen.findByText(/OpenSpec CLI >=1.2.0 <1.4.0 Required/)).toBeInTheDocument()
+    expect(screen.getByText(/Detected OpenSpec CLI 1.1.1/)).toBeInTheDocument()
+  })
+})

--- a/packages/web/src/components/cli-health-gate.tsx
+++ b/packages/web/src/components/cli-health-gate.tsx
@@ -1,34 +1,15 @@
 import { isStaticMode } from '@/lib/static-mode'
 import { queryClient, trpc, trpcClient } from '@/lib/trpc'
 import { useConfigSubscription } from '@/lib/use-subscription'
+import {
+  classifyOpenSpecCliVersion,
+  OPENSPEC_CLI_ACCEPTED_RANGE,
+  OPENSPEC_CLI_RECOMMENDED_RANGE,
+  OPENSPECUI_TARGET_MAJOR,
+} from '@openspecui/core/openspec-compat'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { AlertCircle, Loader2, Terminal } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-
-interface Semver {
-  major: number
-  minor: number
-  patch: number
-}
-
-const MIN_VERSION: Semver = { major: 1, minor: 2, patch: 0 }
-
-function parseVersion(raw: string | undefined): Semver | null {
-  if (!raw) return null
-  const match = raw.match(/(\d+)\.(\d+)\.(\d+)/)
-  if (!match) return null
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-  }
-}
-
-function isAtLeast(version: Semver, required: Semver): boolean {
-  if (version.major !== required.major) return version.major > required.major
-  if (version.minor !== required.minor) return version.minor > required.minor
-  return version.patch >= required.patch
-}
 
 function formatExecutePath(command: string, args: readonly string[] = []): string {
   const quote = (token: string): string => {
@@ -84,27 +65,39 @@ export function CliHealthGate() {
     return null
   }
 
-  const version = parseVersion(data?.version)
-  const compatible = version ? isAtLeast(version, MIN_VERSION) : false
+  const compatibility = classifyOpenSpecCliVersion(data?.version)
 
-  if (data?.available && compatible) {
+  if (data?.available && compatibility.status === 'current') {
     return null
+  }
+
+  if (data?.available && compatibility.status === 'legacy-compatible') {
+    return (
+      <div className="fixed bottom-4 right-4 z-40 mx-4 max-w-sm rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm shadow-lg backdrop-blur-sm">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" />
+          <div className="space-y-1">
+            <div className="font-medium">OpenSpec CLI {data.version} is legacy-compatible</div>
+            <p className="text-muted-foreground text-xs">
+              OpenSpecUI {OPENSPECUI_TARGET_MAJOR}.x accepts {OPENSPEC_CLI_ACCEPTED_RANGE}. Upgrade
+              to {OPENSPEC_CLI_RECOMMENDED_RANGE} for the current line.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   const checking = isFetching || saveCliCommandMutation.isPending
 
-  const reason = !data?.available
-    ? data?.error || 'OpenSpec CLI not found.'
-    : data?.version
-      ? `Detected ${data.version}, requires >= ${MIN_VERSION.major}.${MIN_VERSION.minor}.${MIN_VERSION.patch}.`
-      : 'Unable to parse CLI version.'
+  const reason = !data?.available ? data?.error || 'OpenSpec CLI not found.' : compatibility.message
 
   return (
     <div className="bg-background/80 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
       <div className="border-border bg-background mx-4 max-w-xl space-y-4 rounded-lg border p-6 shadow-xl">
         <div className="flex items-center gap-2 text-lg font-semibold">
           <AlertCircle className="h-5 w-5 text-amber-500" />
-          OpenSpec CLI 1.2+ Required
+          OpenSpec CLI {OPENSPEC_CLI_ACCEPTED_RANGE} Required
         </div>
         <p className="text-muted-foreground text-sm">{reason}</p>
         <div className="space-y-2">

--- a/packages/web/src/routes/settings-init.test.ts
+++ b/packages/web/src/routes/settings-init.test.ts
@@ -25,6 +25,7 @@ function createToolState(toolId: string, status: ToolInitState['status']): ToolI
     missingCommandWorkflows: [],
     unexpectedSkillWorkflows: [],
     unexpectedCommandWorkflows: [],
+    legacyCommandWorkflows: [],
   }
 }
 

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -1228,9 +1228,9 @@ export function Settings() {
             </div>
           </section>
 
-          {/* OpenSpec 1.2 Profile & Sync */}
+          {/* OpenSpec Profile & Sync */}
           <section className="space-y-4">
-            <h2 className="text-lg font-semibold">OpenSpec 1.2 Profile &amp; Sync</h2>
+            <h2 className="text-lg font-semibold">OpenSpec Profile &amp; Sync</h2>
             <div className="border-border space-y-4 rounded-lg border p-4">
               {isLoadingOpsxProfileState ? (
                 <div className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -1340,7 +1340,8 @@ export function Settings() {
 
                   <p className="text-muted-foreground text-xs">
                     Note: <code className="bg-muted rounded px-1">openspec update</code> follows
-                    OpenSpec 1.2 behavior and prunes deselected workflow command/skill files.
+                    OpenSpec CLI profile behavior and prunes deselected workflow command/skill
+                    files.
                   </p>
 
                   <p className="text-muted-foreground text-xs">
@@ -1471,7 +1472,8 @@ export function Settings() {
                     <option value="all">Use all tools</option>
                   </select>
                   <p className="text-muted-foreground text-xs">
-                    OpenSpec 1.2 can auto-detect existing tool directories.
+                    OpenSpec CLI can auto-detect existing tool directories. OpenSpecUI 3.x uses
+                    OpenSpec CLI 1.3.x as the current tool line.
                   </p>
                 </label>
 
@@ -1523,8 +1525,12 @@ export function Settings() {
                       const initialized = status === 'initialized'
                       const repairable = status === 'partial'
                       const selected = selectedTools.includes(tool.value)
+                      const legacyCommandWorkflows =
+                        toolInitStateById.get(tool.value)?.legacyCommandWorkflows ?? []
                       const statusTitle = initialized
-                        ? 'Initialized: exact match for current delivery/workflows'
+                        ? legacyCommandWorkflows.length > 0
+                          ? `Initialized: legacy-compatible command paths detected for ${legacyCommandWorkflows.join(', ')}`
+                          : 'Initialized: exact match for current delivery/workflows'
                         : repairable
                           ? 'Partial: detected artifacts need repair for current delivery/workflows'
                           : 'Uninitialized: no generated artifacts detected'

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -14,6 +14,7 @@
       "@openspecui/core": ["../core/src/index.ts"],
       "@openspecui/core/dashboard-display": ["../core/src/dashboard-display.ts"],
       "@openspecui/core/hosted-app": ["../core/src/hosted-app.ts"],
+      "@openspecui/core/openspec-compat": ["../core/src/openspec-compat.ts"],
       "@openspecui/core/opsx-display-path": ["../core/src/opsx-display-path.ts"],
       "@openspecui/core/pty-protocol": ["../core/src/pty-protocol.ts"],
       "@openspecui/search": ["../search/src/index.ts"],

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig(({ isSsrBuild }) => {
     '@openspecui/core': resolve(__dirname, '../core/src'),
     '@openspecui/core/dashboard-display': resolve(__dirname, '../core/src/dashboard-display.ts'),
     '@openspecui/core/hosted-app': resolve(__dirname, '../core/src/hosted-app.ts'),
+    '@openspecui/core/openspec-compat': resolve(__dirname, '../core/src/openspec-compat.ts'),
     '@openspecui/core/opsx-display-path': resolve(__dirname, '../core/src/opsx-display-path.ts'),
     '@openspecui/core/pty-protocol': resolve(__dirname, '../core/src/pty-protocol.ts'),
     '@openspecui/search': resolve(__dirname, '../search/src'),

--- a/packages/website/src/locales/en.ts
+++ b/packages/website/src/locales/en.ts
@@ -39,7 +39,7 @@ export const en = {
     appOffSummary: 'Start the local backend and serve the local web UI from this machine.',
     exportLabel: 'Static export',
     exportSummary: 'Generate a deployable snapshot for docs hosting or offline review.',
-    compatibility: 'OpenSpecUI 2.x targets OpenSpec CLI 1.2+.',
+    compatibility: 'OpenSpecUI 3.x targets OpenSpec CLI 1.3.x and supports 1.2.x projects.',
   },
   modes: {
     title: 'Choose the right surface',

--- a/packages/website/src/locales/zh.ts
+++ b/packages/website/src/locales/zh.ts
@@ -38,7 +38,7 @@ export const zh = {
     appOffSummary: '启动本地后端，并由当前机器直接提供本地 Web UI。',
     exportLabel: '静态导出',
     exportSummary: '生成可部署的静态快照，用于文档站点或离线审阅。',
-    compatibility: 'OpenSpecUI 2.x 面向 OpenSpec CLI 1.2+。',
+    compatibility: 'OpenSpecUI 3.x 面向 OpenSpec CLI 1.3.x，并兼容 1.2.x 项目。',
   },
   modes: {
     title: '选择合适的界面',

--- a/scripts/check-openspec-reference.mjs
+++ b/scripts/check-openspec-reference.mjs
@@ -12,9 +12,9 @@ try {
   if (!existsSync('references/openspec/.git')) {
     run('git submodule update --init references/openspec')
   }
-  const describe = run('git -C references/openspec describe --tags --match "v1.2.*" --always')
-  if (!describe.startsWith('v1.2.')) {
-    throw new Error(`references/openspec must point to OpenSpec v1.2.x, but got "${describe}".`)
+  const describe = run('git -C references/openspec describe --tags --match "v1.3.*" --always')
+  if (!describe.startsWith('v1.3.')) {
+    throw new Error(`references/openspec must point to OpenSpec v1.3.x, but got "${describe}".`)
   }
   console.log(`[openspec-ref-check] OK: ${describe}`)
 } catch (error) {


### PR DESCRIPTION
## Summary
- establish OpenSpecUI 3.x as the OpenSpec CLI 1.3.x target line while accepting 1.2.x as legacy-compatible
- sync OpenSpec CLI 1.3.1 tool metadata and command artifact paths
- normalize `instructions apply --json` context files to artifact-to-path-array mappings
- archive the completed OpenSpec change

## Issues
Addresses #101 and #102. I will close them only after npm publish and post-release validation pass.

## Local Checks
- `pnpm openspec:check-reference`
- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm test:browser:ci`
