### PR TITLE
[codex] harden hosted app shell upgrade flow

### DIFF
--- a/.changeset/green-lamps-spark.md
+++ b/.changeset/green-lamps-spark.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/app': patch
+---
+
+Harden hosted app shell upgrade flow so service-worker cache revisions follow shell content, idle shells auto-apply waiting updates, and legacy `?version=` launch semantics stay retired.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -154,4 +154,8 @@ Immutable hashed assets can be long-lived:
 
 - `/assets/*`
 
+The service worker cache namespace is derived from the app workspace contents. Rebuilding the same source tree keeps the same cache revision; changing the shell source or public assets produces a new revision and lets the new worker evict the old shell cache on activation.
+
+If a newer shell arrives while at least one backend tab is open, the shell exposes the update action and waits for the user to apply it. If no backend tabs are open, the waiting worker is promoted immediately so the shell can upgrade without interrupting an active session.
+
 The included `public/_headers` file is tuned for Cloudflare Pages with that split.

--- a/packages/app/src/components/hosted-shell-updates.test.tsx
+++ b/packages/app/src/components/hosted-shell-updates.test.tsx
@@ -46,8 +46,16 @@ async function renderShell(
 }
 
 describe('HostedShell updates', () => {
+  let serviceWorkerRegistration: {
+    addEventListener: ReturnType<typeof vi.fn>
+    removeEventListener: ReturnType<typeof vi.fn>
+    waiting: { postMessage: ReturnType<typeof vi.fn> } | null
+    update: ReturnType<typeof vi.fn>
+  }
+
   beforeEach(() => {
     document.body.innerHTML = ''
+    window.localStorage.clear()
     window.matchMedia = vi.fn().mockImplementation(() => ({
       matches: false,
       addEventListener: vi.fn(),
@@ -59,17 +67,21 @@ describe('HostedShell updates', () => {
     HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
       this.removeAttribute('open')
     }
+    serviceWorkerRegistration = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      waiting: {
+        postMessage: vi.fn(),
+      },
+      update: vi.fn(async () => undefined),
+    }
     Object.defineProperty(navigator, 'serviceWorker', {
       configurable: true,
       value: {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
-        getRegistration: vi.fn(async () => ({
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          waiting: {},
-          update: vi.fn(async () => undefined),
-        })),
+        controller: {},
+        getRegistration: vi.fn(async () => serviceWorkerRegistration),
       },
     })
 
@@ -125,5 +137,18 @@ describe('HostedShell updates', () => {
     await flushEffects(8)
 
     expect(screen.getByRole('button', { name: 'Apply app update' })).toBeTruthy()
+  })
+
+  it('keeps update actions hidden without an active backend tab', async () => {
+    await renderShell(
+      <HostedShell initialLaunchRequest={null} fallbackLaunchRequest={null} initialError={null} />
+    )
+
+    await flushEffects(8)
+
+    expect(screen.queryByRole('button', { name: 'Apply app update' })).toBeNull()
+    expect(serviceWorkerRegistration.waiting?.postMessage).toHaveBeenCalledWith({
+      type: 'SKIP_WAITING',
+    })
   })
 })

--- a/packages/app/src/components/hosted-shell.tsx
+++ b/packages/app/src/components/hosted-shell.tsx
@@ -141,6 +141,23 @@ function cx(...classes: Array<string | false | null | undefined>): string {
   return classes.filter(Boolean).join(' ')
 }
 
+function shouldExposeHostedAppUpdate(options: {
+  hasTabs: boolean
+  registration: Pick<ServiceWorkerRegistration, 'waiting'>
+}): HostedAppUpdateState {
+  if (options.registration.waiting && options.hasTabs) {
+    return { status: 'ready', errorMessage: null }
+  }
+  return { status: 'idle', errorMessage: null }
+}
+
+function shouldAutoApplyHostedAppUpdate(options: {
+  hasTabs: boolean
+  registration: Pick<ServiceWorkerRegistration, 'waiting'>
+}): boolean {
+  return !options.hasTabs && Boolean(options.registration.waiting)
+}
+
 function buildHostedTabIframeSrc(
   tab: HostedShellTab,
   runtime: HostedTabRuntimeState
@@ -839,14 +856,30 @@ export function HostedShell({
     [shellState.tabs, startRefreshFeedback]
   )
 
-  const syncUpdateStateFromRegistration = useCallback((registration: ServiceWorkerRegistration) => {
-    serviceWorkerRegistrationRef.current = registration
-    setUpdateState(
-      registration.waiting
-        ? { status: 'ready', errorMessage: null }
-        : { status: 'idle', errorMessage: null }
-    )
+  const activateWaitingHostedAppUpdate = useCallback((registration: ServiceWorkerRegistration) => {
+    if (!registration.waiting || shouldReloadForUpdateRef.current) {
+      return false
+    }
+
+    shouldReloadForUpdateRef.current = true
+    registration.waiting.postMessage({ type: 'SKIP_WAITING' })
+    return true
   }, [])
+
+  const syncUpdateStateFromRegistration = useCallback(
+    (registration: ServiceWorkerRegistration, options?: { hasTabsOverride?: boolean }) => {
+      serviceWorkerRegistrationRef.current = registration
+      const hasTabs = options?.hasTabsOverride ?? shellState.tabs.length > 0
+      if (shouldAutoApplyHostedAppUpdate({ hasTabs, registration })) {
+        if (activateWaitingHostedAppUpdate(registration)) {
+          setUpdateState({ status: 'idle', errorMessage: null })
+        }
+        return
+      }
+      setUpdateState(shouldExposeHostedAppUpdate({ hasTabs, registration }))
+    },
+    [activateWaitingHostedAppUpdate, shellState.tabs.length]
+  )
 
   const checkForHostedAppUpdate = useCallback(async () => {
     if (
@@ -889,9 +922,21 @@ export function HostedShell({
         }
 
         const onStateChange = () => {
-          if (installing.state === 'installed' && navigator.serviceWorker.controller) {
-            syncUpdateStateFromRegistration(registration)
+          if (installing.state !== 'installed') {
+            return
           }
+
+          if (!navigator.serviceWorker.controller) {
+            syncUpdateStateFromRegistration(registration, { hasTabsOverride: false })
+            return
+          }
+
+          if (shellState.tabs.length === 0) {
+            activateWaitingHostedAppUpdate(registration)
+            return
+          }
+
+          syncUpdateStateFromRegistration(registration, { hasTabsOverride: true })
         }
 
         installing.addEventListener('statechange', onStateChange)
@@ -950,7 +995,12 @@ export function HostedShell({
       document.removeEventListener('visibilitychange', onVisibilityChange)
       window.clearInterval(interval)
     }
-  }, [checkForHostedAppUpdate, syncUpdateStateFromRegistration])
+  }, [
+    activateWaitingHostedAppUpdate,
+    checkForHostedAppUpdate,
+    shellState.tabs.length,
+    syncUpdateStateFromRegistration,
+  ])
 
   useEffect(() => {
     if (shellState.tabs.length === 0) {

--- a/packages/app/src/lib/bootstrap.test.ts
+++ b/packages/app/src/lib/bootstrap.test.ts
@@ -20,11 +20,11 @@ describe('hosted app bootstrap helpers', () => {
     })
   })
 
-  it('reports stale launch parameters without api', () => {
+  it('ignores legacy launch parameters without api', () => {
     expect(parseHostedLaunchParams('?version=v2.1')).toEqual({
       request: null,
-      error: 'Hosted launch URLs require ?api.',
-      hasLaunchParams: true,
+      error: null,
+      hasLaunchParams: false,
     })
   })
 

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -25,23 +25,13 @@ export interface HostedBootstrapRuntime {
 
 export function parseHostedLaunchParams(search: string): HostedLaunchParseResult {
   const params = new URLSearchParams(search)
-  const rawVersion = params.get('version')?.trim() ?? ''
   const rawApi = params.get('api')?.trim() ?? ''
-  const hasLaunchParams = rawApi.length > 0 || rawVersion.length > 0
 
-  if (!hasLaunchParams) {
+  if (rawApi.length === 0) {
     return {
       request: null,
       error: null,
       hasLaunchParams: false,
-    }
-  }
-
-  if (!rawApi) {
-    return {
-      request: null,
-      error: 'Hosted launch URLs require ?api.',
-      hasLaunchParams: true,
     }
   }
 

--- a/packages/app/src/service-worker.ts
+++ b/packages/app/src/service-worker.ts
@@ -4,7 +4,7 @@ type HostedServiceWorkerGlobalScope = ServiceWorkerGlobalScope
 
 const sw = self as unknown as HostedServiceWorkerGlobalScope
 
-const APP_SHELL_CACHE = 'openspecui-app-shell-v1'
+const APP_SHELL_CACHE = `openspecui-app-shell-${__OPENSPECUI_APP_SHELL_REVISION__}`
 const APP_SHELL_PATHS = [
   '/',
   '/index.html',

--- a/packages/app/src/types/globals.d.ts
+++ b/packages/app/src/types/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __OPENSPECUI_APP_SHELL_REVISION__: string

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,6 +1,8 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
-import { resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
 import { defineConfig, type Plugin } from 'vite'
 import { createHostedAppPwaManifest } from './src/lib/pwa-manifest'
 import { hostedAppPlugin } from './src/vite-plugin-hosted-app'
@@ -28,8 +30,36 @@ function hostedAppDevPlugin(): Plugin {
   }
 }
 
+function collectHostedShellRevisionSeed(rootDir: string): string {
+  const files = [
+    resolve(rootDir, 'package.json'),
+    ...collectFiles(resolve(rootDir, 'src')),
+    ...collectFiles(resolve(rootDir, 'public')),
+  ]
+  const hash = createHash('sha256')
+  for (const file of files) {
+    hash.update(relative(rootDir, file))
+    hash.update(readFileSync(file))
+  }
+  return hash.digest('hex').slice(0, 12)
+}
+
+function collectFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true })
+  return entries.flatMap((entry) => {
+    const fullPath = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      return collectFiles(fullPath)
+    }
+    return [fullPath]
+  })
+}
+
 export default defineConfig({
   base: '/',
+  define: {
+    __OPENSPECUI_APP_SHELL_REVISION__: JSON.stringify(collectHostedShellRevisionSeed(__dirname)),
+  },
   plugins: [react(), tailwindcss(), hostedAppDevPlugin(), hostedAppPlugin()],
   resolve: {
     alias: {


### PR DESCRIPTION
## What changed
- switch the hosted app shell service-worker cache namespace to a build-time content revision instead of a hand-written static key
- auto-apply waiting shell updates when no backend tabs are open, while keeping the explicit update action when active tabs exist
- remove remaining hosted launch dependence on `?version=` and document the new cache/update behavior in `@openspecui/app`

## Why
The hosted shell now acts only as a persistent PWA tab manager. Its upgrade law should follow shell content, not build environment noise or legacy version-site semantics.

Before this patch:
- the shell cache key was a manual `v1`, so upgrades relied on ad hoc cache bumps
- the revision seed included environment-dependent data during the local hardening pass, which could produce unnecessary cache churn
- a waiting update always surfaced the apply action, even when there was no active backend session to protect
- legacy `?version=` launch URLs were still tolerated in implementation paths that should now be `api`-only

## Impact
- same-source rebuilds keep the same shell revision
- real shell content changes roll the cache namespace and evict the old shell cache on activation
- idle app shells upgrade silently
- active sessions still get an explicit update affordance
- hosted launch and cleanup logic now align with the simplified `app.openspecui.com` contract

## Validation
- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm --filter @openspecui/app typecheck`
- `pnpm --filter @openspecui/app test`
- `pnpm --filter @openspecui/app build`
- verified two consecutive app builds emit the same `openspecui-app-shell-<revision>` value when sources are unchanged
