### PR TITLE
[codex] fix terminal tabs chrome and theme polish

### DIFF
--- a/.changeset/mean-pumpkins-confess.md
+++ b/.changeset/mean-pumpkins-confess.md
@@ -1,0 +1,9 @@
+---
+'openspecui': patch
+'@openspecui/web': patch
+'@openspecui/server': patch
+'@openspecui/core': patch
+'@openspecui/search': patch
+---
+
+Polish terminal theme application and terminal tab chrome so the terminal header matches the active terminal theme, tab overflow stays horizontally scrollable, and inactive tab motion uses a smoother iOS-style transform without causing vertical scroll jitter.

--- a/packages/app/src/components/hosted-shell.tsx
+++ b/packages/app/src/components/hosted-shell.tsx
@@ -1,5 +1,6 @@
 import { Dialog } from '@openspecui/web-src/components/dialog'
-import { Tabs, type Tab } from '@openspecui/web-src/components/tabs'
+import { type Tab } from '@openspecui/web-src/components/tabs'
+import { TerminalTabs } from '@openspecui/web-src/components/terminal/terminal-tabs'
 import { AlertCircle, Download, Link2, LoaderCircle, Plus, RefreshCw, Unlink2 } from 'lucide-react'
 import {
   useCallback,
@@ -1175,9 +1176,8 @@ export function HostedShell({
           </div>
         </div>
       ) : (
-        <Tabs
+        <TerminalTabs
           tabs={tabs}
-          variant="terminal"
           selectedTab={shellState.activeTabId ?? tabs[0]?.id}
           onTabChange={(tabId) => {
             setShellState((current) => activateHostedTab(current, tabId))

--- a/packages/web/src/components/git/git-panel-detail.tsx
+++ b/packages/web/src/components/git/git-panel-detail.tsx
@@ -981,7 +981,6 @@ export function GitEntryDetailPanel({
         <div ref={tabsRootRef}>
           <Tabs
             ref={tabsRef}
-            variant="default"
             selectedTab={activePane}
             onTabChange={onTabChange}
             tabs={[

--- a/packages/web/src/components/tabs.test.tsx
+++ b/packages/web/src/components/tabs.test.tsx
@@ -49,30 +49,58 @@ describe('Tabs double-click behavior', () => {
     expect(onTabBarDoubleClick).not.toHaveBeenCalled()
   })
 
-  it('supports the terminal variant used by the hosted shell', () => {
+  it('supports slot-style class overrides and indicator toggles', () => {
     const { container } = render(
       <Tabs
         tabs={tabs}
-        variant="terminal"
         selectedTab="a"
         actions={<button type="button">+</button>}
+        showHeaderShell={false}
+        showSelectionIndicator={false}
+        decorateStrip={false}
+        classNames={{
+          header: 'bg-terminal text-terminal-foreground',
+          strip: 'px-4',
+          list: 'pt-2',
+          buttonBase: 'rounded-t-[8px] py-1',
+          buttonInner: 'gap-3 px-3',
+          activeButton: 'bg-terminal-foreground/10 text-terminal-foreground',
+          inactiveButton:
+            'bg-terminal text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground',
+          activeButtonInner: '[transform:translateY(0)]',
+          inactiveButtonInner: '[transform:translateY(0.25em)]',
+          actions: 'bg-terminal border-terminal-foreground/20 text-terminal-foreground',
+          closeButtonActive: 'text-terminal-foreground/70 hover:text-terminal-foreground',
+          closeButtonInactive: 'text-terminal-foreground/50 hover:text-terminal-foreground',
+        }}
       />
     )
 
-    const root = container.firstElementChild
-    expect(root?.getAttribute('data-tabs-variant')).toBe('terminal')
+    const header = container.querySelector('.tabs-header')
+    expect(header?.className).toContain('bg-terminal')
+    const strip = container.querySelector('.tabs-strip')
+    expect(strip?.className).not.toContain('bg-terminal')
+    expect(container.firstElementChild?.getAttribute('data-tabs-strip-decoration')).toBe('off')
+    expect(container.querySelector('[data-tabs-header-shell="true"]')).toBeNull()
 
     const selected = within(container).getByRole('button', { name: 'A' })
-    expect(selected.className).toContain('bg-background')
-    expect(selected.className).toContain('text-foreground')
+    expect(selected.className).toContain('bg-terminal-foreground/10')
+    expect(selected.className).toContain('text-terminal-foreground')
     expect(selected.className).toContain('rounded-t-[8px]')
+    expect(selected.querySelector('[data-tabs-button-inner="true"]')?.className).toContain(
+      '[transform:translateY(0)]'
+    )
 
     const unselected = within(container).getByRole('button', { name: 'B' })
     expect(unselected.className).toContain('bg-terminal')
-    expect(unselected.className).toContain('text-terminal-foreground')
+    expect(unselected.className).toContain('text-terminal-foreground/72')
+    expect(unselected.querySelector('[data-tabs-button-inner="true"]')?.className).toContain(
+      '[transform:translateY(0.25em)]'
+    )
 
     const actions = container.querySelector('[data-tabs-actions="true"]')
     expect(actions?.className).toContain('bg-terminal')
+    expect(actions?.className).toContain('border-terminal-foreground/20')
     expect(container.querySelector('[data-tabs-selection-indicator="true"]')).toBeNull()
   })
 

--- a/packages/web/src/components/tabs.tsx
+++ b/packages/web/src/components/tabs.tsx
@@ -14,6 +14,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from 'react'
+import { cn } from '../lib/utils'
 import { useHeadStyle } from './use-head-style'
 
 export interface Tab {
@@ -29,9 +30,25 @@ export interface Tab {
   closeButtonVisibility?: 'hover' | 'always'
 }
 
-export type TabsVariant = 'default' | 'terminal'
+export interface TabsClassNames {
+  header?: string
+  headerShell?: string
+  headerForeground?: string
+  strip?: string
+  list?: string
+  buttonBase?: string
+  buttonInner?: string
+  activeButton?: string
+  inactiveButton?: string
+  activeButtonInner?: string
+  inactiveButtonInner?: string
+  actions?: string
+  closeButtonActive?: string
+  closeButtonInactive?: string
+  selectionIndicator?: string
+}
 
-interface TabsProps {
+export interface TabsProps {
   tabs: Tab[]
   /** Controlled selected tab id */
   selectedTab?: string
@@ -45,7 +62,10 @@ interface TabsProps {
   /** Called when the tabs bar is double-clicked (usually on empty space) */
   onTabBarDoubleClick?: () => void
   className?: string
-  variant?: TabsVariant
+  classNames?: TabsClassNames
+  showHeaderShell?: boolean
+  showSelectionIndicator?: boolean
+  decorateStrip?: boolean
 }
 
 export interface TabsHandle {
@@ -109,7 +129,7 @@ const tabsStyleText = (id: string) => {
       transform: scaleX(0.5);
     }
 
-    #${id} .tabs-strip {
+    #${id}[data-tabs-strip-decoration='on'] .tabs-strip {
       background-image: linear-gradient(
         to bottom,
         transparent,
@@ -167,7 +187,10 @@ function TabsImpl(
     actions,
     onTabBarDoubleClick,
     className = '',
-    variant = 'default',
+    classNames,
+    showHeaderShell = true,
+    showSelectionIndicator = true,
+    decorateStrip = true,
   }: TabsProps,
   ref: ForwardedRef<TabsHandle>
 ) {
@@ -237,7 +260,7 @@ function TabsImpl(
       return
     }
 
-    if (variant !== 'default' || !header || !activeTrigger) {
+    if (!showSelectionIndicator || !header || !activeTrigger) {
       indicator.style.opacity = '0'
       indicator.style.width = '0px'
       indicator.style.height = '0px'
@@ -254,14 +277,14 @@ function TabsImpl(
     indicator.style.transform = `translate(${triggerRect.left - headerRect.left}px, ${
       triggerRect.top - headerRect.top
     }px)`
-  }, [activeTab, variant])
+  }, [activeTab, showSelectionIndicator])
 
   useLayoutEffect(() => {
     syncSelectionIndicator()
   }, [syncSelectionIndicator, tabLayoutSignature])
 
   useLayoutEffect(() => {
-    if (variant !== 'default') {
+    if (!showSelectionIndicator) {
       return
     }
 
@@ -300,7 +323,7 @@ function TabsImpl(
       tabsButton.removeEventListener('scroll', handleScroll)
       observer.disconnect()
     }
-  }, [activeTab, syncSelectionIndicator, tabLayoutSignature, variant])
+  }, [activeTab, showSelectionIndicator, syncSelectionIndicator, tabLayoutSignature])
 
   const handleChange = (id: string) => {
     if (!controlled) {
@@ -422,37 +445,58 @@ function TabsImpl(
 
   if (tabs.length === 0) return null
 
-  const headerClassName =
-    variant === 'terminal'
-      ? 'tabs-header bg-terminal text-terminal-foreground sticky top-0 z-20 flex min-w-0 items-stretch'
-      : 'tabs-header relative sticky top-0 z-20 min-w-0'
+  const headerClassName = cn(
+    'tabs-header relative sticky top-0 z-20 flex min-w-0 items-stretch',
+    classNames?.header
+  )
 
-  const stripClassName =
-    variant === 'terminal'
-      ? 'tabs-strip min-w-0 flex-1 bg-terminal px-4'
-      : 'tabs-strip min-w-0 flex-1 rounded-l-md px-4'
+  const headerShellClassName = cn(
+    'tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm',
+    classNames?.headerShell
+  )
 
-  const listClassName =
-    variant === 'terminal'
-      ? 'tabs-button scrollbar-none flex min-w-0 gap-1 overflow-x-auto pt-2'
-      : 'tabs-button scrollbar-none flex min-w-0 gap-1 overflow-x-auto'
+  const headerForegroundClassName = cn(
+    'tabs-header-foreground relative z-20 flex min-w-0 items-stretch',
+    classNames?.headerForeground
+  )
 
-  const buttonBaseClassName = `group relative z-10 m-0 flex h-full shrink-0 items-center gap-2 px-2 text-sm font-medium transition-colors ${variant === 'terminal' ? 'rounded-t-[8px] py-1' : 'py-2'}`
+  const stripClassName = cn(
+    'tabs-strip flex min-w-0 flex-1 items-stretch rounded-l-md px-4',
+    classNames?.strip
+  )
 
-  const activeButtonClassName =
-    variant === 'terminal'
-      ? 'tab-selected bg-background text-foreground'
-      : 'tab-selected text-foreground'
+  const listClassName = cn(
+    'tabs-button scrollbar-none flex min-w-0 flex-1 gap-1 overflow-x-auto',
+    classNames?.list
+  )
 
-  const inactiveButtonClassName =
-    variant === 'terminal'
-      ? 'bg-terminal text-terminal-foreground/80 hover:bg-terminal hover:text-terminal-foreground'
-      : 'text-muted-foreground hover:bg-background/35 hover:text-foreground'
+  const buttonBaseClassName = cn(
+    'group relative z-10 m-0 flex h-full shrink-0 px-2 py-2 text-sm font-medium transition-colors',
+    classNames?.buttonBase
+  )
 
-  const actionsClassName =
-    variant === 'terminal'
-      ? 'tabs-actions border-border bg-terminal text-terminal-foreground flex shrink-0 items-center border-b px-1'
-      : 'tabs-actions border-zinc-500/15 flex shrink-0 items-center rounded-r-md border-l px-1'
+  const buttonInnerClassName = cn('inline-flex h-full items-center gap-2', classNames?.buttonInner)
+
+  const activeButtonClassName = cn('tab-selected text-foreground', classNames?.activeButton)
+
+  const inactiveButtonClassName = cn(
+    'text-muted-foreground hover:bg-background/35 hover:text-foreground',
+    classNames?.inactiveButton
+  )
+
+  const activeButtonInnerClassName = cn(classNames?.activeButtonInner)
+
+  const inactiveButtonInnerClassName = cn(classNames?.inactiveButtonInner)
+
+  const actionsClassName = cn(
+    'tabs-actions border-zinc-500/15 flex shrink-0 items-center rounded-r-md border-l px-1 h-full',
+    classNames?.actions
+  )
+
+  const selectionIndicatorClassName = cn(
+    'tabs-selection-indicator border-primary bg-background/70 duration-280 absolute left-0 top-0 border-b-4 opacity-0 transition-[transform,width,height,opacity] ease-[cubic-bezier(0.22,1,0.36,1)]',
+    classNames?.selectionIndicator
+  )
 
   const handleTabBarDoubleClick = (event: ReactMouseEvent<HTMLDivElement>) => {
     if (!onTabBarDoubleClick) return
@@ -490,32 +534,46 @@ function TabsImpl(
         } ${reorderable ? 'cursor-grab active:cursor-grabbing' : ''}`}
         style={dragIndicatorStyle}
       >
-        {tab.icon}
-        {tab.label}
-        {tab.closable && onTabClose && (
-          <span
-            role="button"
-            tabIndex={0}
-            onClick={(event) => {
-              event.stopPropagation()
-              onTabClose(tab.id)
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
+        <span
+          data-tabs-button-inner="true"
+          className={`${buttonInnerClassName} ${
+            activeTab === tab.id ? activeButtonInnerClassName : inactiveButtonInnerClassName
+          }`}
+        >
+          {tab.icon}
+          {tab.label}
+          {tab.closable && onTabClose && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(event) => {
                 event.stopPropagation()
                 onTabClose(tab.id)
-              }
-            }}
-            draggable={false}
-            className={`hover:text-foreground -mr-1 rounded p-0.5 transition ${
-              tab.closeButtonVisibility === 'always'
-                ? 'opacity-100'
-                : 'opacity-0 group-hover:opacity-100 [button:hover>&]:opacity-100'
-            } ${activeTab === tab.id ? 'text-current/80' : 'text-muted-foreground'}`}
-          >
-            <X className="h-3 w-3" />
-          </span>
-        )}
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.stopPropagation()
+                  onTabClose(tab.id)
+                }
+              }}
+              draggable={false}
+              className={`-mr-1 rounded p-0.5 transition ${
+                tab.closeButtonVisibility === 'always'
+                  ? 'opacity-100'
+                  : 'opacity-0 group-hover:opacity-100 [button:hover>&]:opacity-100'
+              } ${
+                activeTab === tab.id
+                  ? cn('text-current/80 hover:text-foreground', classNames?.closeButtonActive)
+                  : cn(
+                      'text-muted-foreground hover:text-foreground',
+                      classNames?.closeButtonInactive
+                    )
+              }`}
+            >
+              <X className="h-3 w-3" />
+            </span>
+          )}
+        </span>
       </button>
     )
   })
@@ -524,50 +582,33 @@ function TabsImpl(
     <div
       id={id}
       ref={rootRef}
-      data-tabs-variant={variant}
+      data-tabs-strip-decoration={decorateStrip ? 'on' : 'off'}
       className={`relative isolate flex min-h-0 min-w-0 flex-1 flex-col ${className}`}
     >
       <div ref={headerRef} className={headerClassName}>
-        {variant === 'default' ? (
-          <>
+        <>
+          {showHeaderShell && (
             <div
               ref={headerShellRef}
               data-tabs-header-shell="true"
-              className="tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm"
+              className={headerShellClassName}
             />
+          )}
+          {showSelectionIndicator && (
             <div className="pointer-events-none absolute inset-0 z-10">
               <div
                 ref={selectionIndicatorRef}
                 data-tabs-selection-indicator="true"
                 aria-hidden="true"
-                className="tabs-selection-indicator border-primary bg-background/70 duration-280 absolute left-0 top-0 border-b-4 opacity-0 transition-[transform,width,height,opacity] ease-[cubic-bezier(0.22,1,0.36,1)]"
+                className={selectionIndicatorClassName}
               />
             </div>
-            <div
-              ref={headerForegroundRef}
-              data-tabs-header-foreground="true"
-              className="tabs-header-foreground relative z-20 flex min-w-0 items-stretch"
-            >
-              <div className={stripClassName}>
-                <div
-                  ref={tabsButtonRef}
-                  className={listClassName}
-                  onDoubleClick={handleTabBarDoubleClick}
-                  onDragOver={handleListDragOver}
-                  onDrop={handleListDrop}
-                >
-                  {tabButtons}
-                </div>
-              </div>
-              {actions && (
-                <div data-tabs-actions="true" className={actionsClassName}>
-                  {actions}
-                </div>
-              )}
-            </div>
-          </>
-        ) : (
-          <>
+          )}
+          <div
+            ref={headerForegroundRef}
+            data-tabs-header-foreground="true"
+            className={headerForegroundClassName}
+          >
             <div className={stripClassName}>
               <div
                 ref={tabsButtonRef}
@@ -584,8 +625,8 @@ function TabsImpl(
                 {actions}
               </div>
             )}
-          </>
-        )}
+          </div>
+        </>
       </div>
 
       <div className="relative flex min-h-0 flex-1 overflow-hidden">

--- a/packages/web/src/components/terminal/resize-handle.tsx
+++ b/packages/web/src/components/terminal/resize-handle.tsx
@@ -94,7 +94,7 @@ export function ResizeHandle({ onResize, minHeight = 100, maxHeight }: ResizeHan
   )
 
   return (
-    <div ref={slotRef} className="border-border relative h-2 shrink-0 border-t">
+    <div ref={slotRef} className="border-border/20 relative h-2 shrink-0 border-b border-t">
       <div
         onMouseDown={onMouseDown}
         onTouchStart={onTouchStart}

--- a/packages/web/src/components/terminal/terminal-panel.test.tsx
+++ b/packages/web/src/components/terminal/terminal-panel.test.tsx
@@ -1,0 +1,121 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerminalPanel } from './terminal-panel'
+
+const noopUnsubscribe = () => {}
+
+const {
+  useTerminalContextMock,
+  useNavLayoutMock,
+  tabsPropsSpy,
+  getResolvedThemeMock,
+  getSnapshotMock,
+  subscribeMock,
+  setInputPanelMountTargetMock,
+  setInputPanelDefaultLayoutMock,
+} = vi.hoisted(() => ({
+  useTerminalContextMock: vi.fn(),
+  useNavLayoutMock: vi.fn(),
+  tabsPropsSpy: vi.fn(),
+  getResolvedThemeMock: vi.fn(),
+  getSnapshotMock: vi.fn(),
+  subscribeMock: vi.fn<() => typeof noopUnsubscribe>(() => noopUnsubscribe),
+  setInputPanelMountTargetMock: vi.fn(),
+  setInputPanelDefaultLayoutMock: vi.fn(),
+}))
+
+vi.mock('@/lib/terminal-context', () => ({
+  useTerminalContext: () => useTerminalContextMock(),
+}))
+
+vi.mock('@/lib/use-nav-controller', () => ({
+  useNavLayout: () => useNavLayoutMock(),
+}))
+
+vi.mock('@/lib/nav-controller', () => ({
+  navController: {
+    moveTab: vi.fn(),
+    closeTab: vi.fn(),
+  },
+}))
+
+vi.mock('./terminal-tabs', () => ({
+  TerminalTabs: (props: {
+    actions?: ReactNode
+    tabs: Array<{ id: string; content: ReactNode }>
+  }) => {
+    tabsPropsSpy(props)
+    return (
+      <div data-testid="tabs">
+        {props.actions}
+        {props.tabs.map((tab) => (
+          <div key={tab.id}>{tab.content}</div>
+        ))}
+      </div>
+    )
+  },
+}))
+
+vi.mock('./xterm-terminal', () => ({
+  XtermTerminal: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid={`xterm-${sessionId}`} />
+  ),
+}))
+
+vi.mock('@/lib/terminal-controller', () => ({
+  terminalController: {
+    subscribe: () => subscribeMock(),
+    getSnapshot: () => getSnapshotMock(),
+    getResolvedTheme: () => getResolvedThemeMock(),
+    setInputPanelMountTarget: (target: HTMLElement | null) => setInputPanelMountTargetMock(target),
+    setInputPanelDefaultLayout: (layout: 'floating' | 'fixed') =>
+      setInputPanelDefaultLayoutMock(layout),
+    openInputPanel: vi.fn(),
+  },
+}))
+
+describe('TerminalPanel', () => {
+  beforeEach(() => {
+    tabsPropsSpy.mockReset()
+    useTerminalContextMock.mockReturnValue({
+      sessions: [
+        {
+          id: 'shell-1',
+          displayTitle: 'shell-1',
+          isExited: false,
+          exitCode: null,
+          outputActive: false,
+        },
+      ],
+      activeSessionId: 'shell-1',
+      setActiveSession: vi.fn(),
+      createSession: vi.fn(),
+      closeSession: vi.fn(),
+      setCustomTitle: vi.fn(),
+    })
+    useNavLayoutMock.mockReturnValue({
+      bottomTabs: ['/terminal'],
+    })
+    getSnapshotMock.mockReturnValue({ sessions: [] })
+    getResolvedThemeMock.mockReturnValue({
+      definition: {
+        palette: {
+          background: '#fdf6e3',
+          foreground: '#586e75',
+        },
+      },
+    })
+  })
+
+  it('renders terminal tabs with resolved theme css vars', () => {
+    const { getByTestId } = render(<TerminalPanel />)
+
+    expect(tabsPropsSpy).toHaveBeenCalledTimes(1)
+
+    const tabs = getByTestId('tabs')
+    const wrapper = tabs.parentElement
+    expect(wrapper?.style.getPropertyValue('--terminal')).toBe('#fdf6e3')
+    expect(wrapper?.style.getPropertyValue('--terminal-foreground')).toBe('#586e75')
+  })
+})

--- a/packages/web/src/components/terminal/terminal-panel.tsx
+++ b/packages/web/src/components/terminal/terminal-panel.tsx
@@ -1,11 +1,21 @@
-import { Tabs, type Tab } from '@/components/tabs'
+import type { Tab } from '@/components/tabs'
 import { navController } from '@/lib/nav-controller'
 import { useTerminalContext } from '@/lib/terminal-context'
 import { terminalController } from '@/lib/terminal-controller'
 import { useNavLayout } from '@/lib/use-nav-controller'
 import '@/styles/terminal-effects.css'
 import { Keyboard, PanelBottomClose, PanelTopClose, Plus, X } from 'lucide-react'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+import { TerminalTabs } from './terminal-tabs'
 import { XtermTerminal } from './xterm-terminal'
 
 function EditableTabLabel({
@@ -99,6 +109,19 @@ export function TerminalPanel({ className }: { className?: string }) {
   } = useTerminalContext()
 
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const terminalSnapshot = useSyncExternalStore(
+    (cb) => terminalController.subscribe(cb),
+    () => terminalController.getSnapshot(),
+    () => terminalController.getSnapshot()
+  )
+
+  const terminalThemeStyle = useMemo(() => {
+    const resolvedTheme = terminalController.getResolvedTheme()
+    return {
+      '--terminal': resolvedTheme.definition.palette.background,
+      '--terminal-foreground': resolvedTheme.definition.palette.foreground,
+    } as CSSProperties
+  }, [terminalSnapshot])
 
   // Set a stable mount target for the InputPanel addon panel.
   // This persists across tab switches so the singleton panel doesn't get orphaned.
@@ -160,7 +183,7 @@ export function TerminalPanel({ className }: { className?: string }) {
     <button
       type="button"
       onClick={() => createSession()}
-      className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0 rounded-md p-1.5 transition"
+      className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
       title="New terminal"
     >
       <Plus className="h-3.5 w-3.5" />
@@ -173,7 +196,7 @@ export function TerminalPanel({ className }: { className?: string }) {
       <button
         type="button"
         onClick={handleOpenInputPanel}
-        className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0 rounded-md p-1.5 transition"
+        className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
         title="Open InputPanel"
       >
         <Keyboard className="h-3.5 w-3.5" />
@@ -181,7 +204,7 @@ export function TerminalPanel({ className }: { className?: string }) {
       <button
         type="button"
         onClick={handleSwitchArea}
-        className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0 rounded-md p-1.5 transition"
+        className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
         title={isInBottom ? 'Move to main area' : 'Move to bottom area'}
       >
         {isInBottom ? (
@@ -194,7 +217,7 @@ export function TerminalPanel({ className }: { className?: string }) {
         <button
           type="button"
           onClick={handleClosePanel}
-          className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0 rounded-md p-1.5 transition"
+          className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
           title="Close panel"
         >
           <X className="h-3.5 w-3.5" />
@@ -206,6 +229,7 @@ export function TerminalPanel({ className }: { className?: string }) {
   return (
     <div
       ref={wrapperRef}
+      style={terminalThemeStyle}
       className={`bg-background flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${className}`}
     >
       {sessions.length === 0 ? (
@@ -221,7 +245,7 @@ export function TerminalPanel({ className }: { className?: string }) {
           <span>to create one.</span>
         </div>
       ) : (
-        <Tabs
+        <TerminalTabs
           tabs={tabs}
           selectedTab={activeSessionId ?? undefined}
           onTabChange={setActiveSession}

--- a/packages/web/src/components/terminal/terminal-tabs.test.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalTabs } from './terminal-tabs'
+
+const tabsPropsSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/tabs', () => ({
+  Tabs: (props: {
+    showHeaderShell?: boolean
+    showSelectionIndicator?: boolean
+    decorateStrip?: boolean
+    classNames?: Record<string, string | undefined>
+    actions?: ReactNode
+    onTabOrderChange?: (orderedTabIds: string[]) => void
+  }) => {
+    tabsPropsSpy(props)
+    return <div data-testid="tabs-root">{props.actions}</div>
+  },
+}))
+
+describe('TerminalTabs', () => {
+  it('configures shared Tabs with terminal-specific chrome styling', () => {
+    render(
+      <TerminalTabs
+        tabs={[
+          { id: 'a', label: 'A', content: <div>A</div> },
+          { id: 'b', label: 'B', content: <div>B</div> },
+        ]}
+        selectedTab="a"
+        onTabOrderChange={() => {}}
+        actions={<button type="button">+</button>}
+      />
+    )
+
+    expect(tabsPropsSpy).toHaveBeenCalledTimes(1)
+    expect(tabsPropsSpy.mock.calls[0]?.[0].showHeaderShell).toBe(false)
+    expect(tabsPropsSpy.mock.calls[0]?.[0].showSelectionIndicator).toBe(true)
+    expect(tabsPropsSpy.mock.calls[0]?.[0].decorateStrip).toBe(false)
+    expect(tabsPropsSpy.mock.calls[0]?.[0].classNames).toMatchObject({
+      header: 'bg-terminal text-terminal-foreground',
+      headerForeground: 'z-auto flex-1 items-end',
+      strip: 'min-w-0 flex-1 items-end border-b border-terminal-foreground/20 px-4 rounded-none',
+      list: 'flex-1 items-end overflow-y-hidden pt-2',
+      buttonBase:
+        'z-20 rounded-t-[8px] border-x border-t border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
+      buttonInner:
+        'inline-flex h-full items-center gap-2 rounded-t-[8px] px-3 py-1.5 transition-[color,background-color,transform,filter] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)] will-change-transform',
+      activeButton: 'bg-transparent text-terminal-foreground',
+      activeButtonInner: 'bg-transparent text-terminal-foreground [transform:translateY(0)]',
+      inactiveButton: 'bg-transparent text-terminal-foreground/72',
+      inactiveButtonInner:
+        'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
+      selectionIndicator:
+        'border-terminal-foreground/20 border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
+    })
+  })
+})

--- a/packages/web/src/components/terminal/terminal-tabs.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.tsx
@@ -1,0 +1,60 @@
+import { Tabs, type TabsProps } from '../tabs'
+
+type TerminalTabsProps = Pick<
+  TabsProps,
+  | 'tabs'
+  | 'selectedTab'
+  | 'onTabChange'
+  | 'onTabClose'
+  | 'onTabOrderChange'
+  | 'actions'
+  | 'onTabBarDoubleClick'
+  | 'className'
+>
+
+const TERMINAL_CHROME_BORDER = 'border-terminal-foreground/20'
+const IOS_TAB_EASE = 'ease-[cubic-bezier(0.22,0.61,0.36,1)]'
+
+export function TerminalTabs({
+  tabs,
+  selectedTab,
+  onTabChange,
+  onTabClose,
+  onTabOrderChange,
+  actions,
+  onTabBarDoubleClick,
+  className,
+}: TerminalTabsProps) {
+  return (
+    <Tabs
+      tabs={tabs}
+      selectedTab={selectedTab}
+      onTabChange={onTabChange}
+      onTabClose={onTabClose}
+      onTabOrderChange={onTabOrderChange}
+      onTabBarDoubleClick={onTabBarDoubleClick}
+      actions={actions}
+      className={className}
+      showHeaderShell={false}
+      showSelectionIndicator
+      decorateStrip={false}
+      classNames={{
+        header: 'bg-terminal text-terminal-foreground',
+        headerForeground: 'z-auto flex-1 items-end',
+        strip: `min-w-0 flex-1 items-end border-b ${TERMINAL_CHROME_BORDER} px-4 rounded-none`,
+        list: 'flex-1 items-end overflow-y-hidden pt-2',
+        buttonBase: `z-20 rounded-t-[8px] border-x border-t border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ${IOS_TAB_EASE}`,
+        buttonInner: `inline-flex h-full items-center gap-2 rounded-t-[8px] px-3 py-1.5 transition-[color,background-color,transform,filter] duration-180 ${IOS_TAB_EASE} will-change-transform`,
+        activeButton: 'bg-transparent text-terminal-foreground',
+        activeButtonInner: 'bg-transparent text-terminal-foreground [transform:translateY(0)]',
+        inactiveButton: 'bg-transparent text-terminal-foreground/72',
+        inactiveButtonInner:
+          'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
+        actions: `${TERMINAL_CHROME_BORDER} bg-terminal text-terminal-foreground border-b rounded-none px-1`,
+        closeButtonActive: 'text-terminal-foreground/70 hover:text-terminal-foreground',
+        closeButtonInactive: 'text-terminal-foreground/50 hover:text-terminal-foreground',
+        selectionIndicator: `${TERMINAL_CHROME_BORDER} border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ${IOS_TAB_EASE}`,
+      }}
+    />
+  )
+}

--- a/packages/web/src/lib/terminal-controller.test.ts
+++ b/packages/web/src/lib/terminal-controller.test.ts
@@ -699,6 +699,27 @@ describe('terminal-controller PTY behavior', () => {
     unsubscribe()
   })
 
+  it('exposes the resolved terminal theme for shell consumers', async () => {
+    const terminalController = await loadTerminalController()
+    const unsubscribe = terminalController.subscribe(() => {})
+    terminalController.applyConfig({
+      useTheme: 'light',
+      lightTheme: 'solarized-light',
+      darkTheme: 'monokai',
+    })
+
+    expect(terminalController.getResolvedTheme().definition.palette.background).toBe('#fdf6e3')
+    expect(terminalController.getResolvedTheme().definition.palette.foreground).toBe('#586e75')
+
+    terminalController.applyConfig({ useTheme: 'dark' })
+
+    expect(terminalController.getResolvedTheme().definition.palette.background).toBe('#272822')
+    expect(terminalController.getResolvedTheme().definition.palette.foreground).toBe('#f8f8f2')
+
+    terminalController.closeAll()
+    unsubscribe()
+  })
+
   it('allows regular key input in ghostty mode', async () => {
     const terminalController = await loadTerminalController()
     const unsubscribe = terminalController.subscribe(() => {})

--- a/packages/web/src/lib/terminal-controller.ts
+++ b/packages/web/src/lib/terminal-controller.ts
@@ -18,6 +18,7 @@ import { navController } from './nav-controller'
 import { TerminalInputHistoryStore } from './terminal-input-history'
 import {
   resolveTerminalTheme,
+  type ResolvedTerminalTheme,
   type TerminalPalette,
   type TerminalThemeId,
   type TerminalThemeMode,
@@ -263,6 +264,13 @@ class TerminalController {
   private ghosttyInitPromise: Promise<GhosttyModule> | null = null
   private appDarkMode = false
   private systemDarkMode = false
+  private resolvedTheme: ResolvedTerminalTheme = resolveTerminalTheme({
+    useTheme: DEFAULT_TERMINAL_CONFIG.useTheme,
+    lightTheme: DEFAULT_TERMINAL_CONFIG.lightTheme,
+    darkTheme: DEFAULT_TERMINAL_CONFIG.darkTheme,
+    appDarkMode: false,
+    systemDarkMode: false,
+  })
 
   // Shared WebSocket
   private ws: WebSocket | null = null
@@ -873,6 +881,10 @@ class TerminalController {
     return { ...this.config }
   }
 
+  getResolvedTheme(): ResolvedTerminalTheme {
+    return this.resolvedTheme
+  }
+
   setThemeContext(input: { appDarkMode: boolean; systemDarkMode: boolean }): void {
     const changed =
       this.appDarkMode !== input.appDarkMode || this.systemDarkMode !== input.systemDarkMode
@@ -917,6 +929,7 @@ class TerminalController {
       appDarkMode: this.appDarkMode,
       systemDarkMode: this.systemDarkMode,
     })
+    this.resolvedTheme = resolvedTheme
 
     for (const instance of this.instances.values()) {
       instance.terminal.options.theme = resolvedTheme.definition.palette


### PR DESCRIPTION
## Summary
- polish shared tabs extensibility and introduce a dedicated `TerminalTabs` chrome for terminal surfaces
- align terminal header theme colors with the resolved terminal theme and smooth inactive-tab motion without vertical scroll jitter
- reuse the same terminal tab chrome in the hosted shell to keep terminal surfaces visually consistent across packages

## Why
Issue #104 and the follow-up terminal tab polish exposed two underlying problems:
- the shared `Tabs` component was not extensible enough, which forced terminal-specific styling into the shared surface
- terminal tab motion and border treatment needed a dedicated visual layer so inactive tabs could animate cleanly without shifting layout or causing vertical overflow

This change moves terminal-specific behavior into `TerminalTabs`, upgrades shared `Tabs` slot extensibility, and keeps active border geometry and terminal theme colors consistent across terminal shells.

## Validation
- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm test:browser:ci`
