### PR TITLE
fix(web): refine tabs chrome and terminal tab integration

### DIFF
--- a/.changeset/fuzzy-bobcats-judge.md
+++ b/.changeset/fuzzy-bobcats-judge.md
@@ -1,0 +1,6 @@
+---
+'openspecui': patch
+'@openspecui/web': patch
+---
+
+Fix the shared tabs chrome so the default underline indicator stays within the tab strip, restore the terminal tab active state so it visually joins the terminal content, and correct tab view-transition direction handling. Document the preferred local workflow of running `pnpm dev` first and using `pnpm openspecui` only to verify bundled CLI-served behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,15 @@ pnpm dev
 ## Development Workflow
 
 1. Create a branch from `main`.
-2. Implement your changes.
-3. Run checks locally:
+2. Start the repo development environment with `pnpm dev`.
+3. Implement your changes against the source dev environment first.
+4. When you need to verify the bundled/CLI-served result, open a second terminal and run `pnpm openspecui`.
+5. Do not treat `pnpm openspecui` as the primary monorepo dev entry. It serves the built web assets and is meant for final packaged-behavior verification, so it can look stale if you skip `pnpm dev`.
+6. Run checks locally:
    - `pnpm lint`
    - `pnpm test:ci`
    - `pnpm build`
-4. Open a Pull Request.
+7. Open a Pull Request.
 
 ## Branch and PR Rules
 

--- a/README-1.x.md
+++ b/README-1.x.md
@@ -264,6 +264,11 @@ pnpm build:packages
 # Start Bun + OpenTUI dev dashboard
 pnpm dev
 
+# Primary monorepo development flow:
+# keep pnpm dev running, then use pnpm openspecui in another terminal only
+# when you want to verify the bundled/CLI-served final behavior
+pnpm openspecui
+
 # Legacy multi-process dev script
 pnpm dev:legacy
 

--- a/README-zh-1.x.md
+++ b/README-zh-1.x.md
@@ -263,6 +263,11 @@ pnpm build:packages
 # 启动 Bun + OpenTUI 开发面板
 pnpm dev
 
+# Monorepo 的主要开发方式：
+# 持续运行 pnpm dev，再在另一个终端中按需执行 pnpm openspecui，
+# 只用它来校验 CLI/打包态下的最终行为
+pnpm openspecui
+
 # 旧版多进程开发脚本
 pnpm dev:legacy
 

--- a/packages/web/src/components/tabs.test.tsx
+++ b/packages/web/src/components/tabs.test.tsx
@@ -62,6 +62,7 @@ describe('Tabs double-click behavior', () => {
           header: 'bg-terminal text-terminal-foreground',
           strip: 'px-4',
           list: 'pt-2',
+          headerFrame: 'items-end',
           buttonBase: 'rounded-t-[8px] py-1',
           buttonInner: 'gap-3 px-3',
           activeButton: 'bg-terminal-foreground/10 text-terminal-foreground',
@@ -70,9 +71,13 @@ describe('Tabs double-click behavior', () => {
           activeButtonInner: '[transform:translateY(0)]',
           inactiveButtonInner: '[transform:translateY(0.25em)]',
           actions: 'bg-terminal border-terminal-foreground/20 text-terminal-foreground',
+          actionsDivider: 'bg-terminal-foreground/20',
+          selectionTrack: 'bg-terminal-foreground/20',
+          selectionIndicatorViewport: 'inset-0',
           closeButtonActive: 'text-terminal-foreground/70 hover:text-terminal-foreground',
           closeButtonInactive: 'text-terminal-foreground/50 hover:text-terminal-foreground',
         }}
+        selectionIndicatorLayout="overlay"
       />
     )
 
@@ -112,13 +117,22 @@ describe('Tabs double-click behavior', () => {
 
     const headerShell = container.querySelector('[data-tabs-header-shell="true"]')
     expect(headerShell?.className).toContain('bg-card/95')
-    expect(headerShell?.className).toContain('rounded-md')
+    expect(headerShell?.className).toContain('rounded-t-md')
+    expect(headerShell?.className).toContain('rounded-b-none')
 
     const indicator = container.querySelector('[data-tabs-selection-indicator="true"]')
     expect(indicator).not.toBeNull()
 
     const actions = container.querySelector('[data-tabs-actions="true"]')
-    expect(actions?.className).toContain('border-l')
+    expect(actions?.className).toContain('tabs-actions')
+    expect(container.querySelector('.tabs-selection-track')).not.toBeNull()
+    expect(container.querySelector('.tabs-actions-divider')).not.toBeNull()
+    expect(container.querySelector('.tabs-actions-divider')?.className).toContain('inset-y-0')
+    expect(
+      container
+        .querySelector('.tabs-strip')
+        ?.contains(container.querySelector('[data-tabs-selection-indicator="true"]') as Node)
+    ).toBe(true)
   })
 
   it('exposes default VT layer handles and syncs the selection indicator to the active tab', () => {
@@ -145,6 +159,14 @@ describe('Tabs double-click behavior', () => {
           return rect(20, 40, 320, 44)
         }
 
+        if (this.classList.contains('tabs-header-frame')) {
+          return rect(20, 40, 320, 44)
+        }
+
+        if (this.classList.contains('tabs-strip')) {
+          return rect(30, 40, 210, 44)
+        }
+
         if (this.dataset.tabId === 'a') {
           return rect(36, 40, 80, 36)
         }
@@ -169,14 +191,14 @@ describe('Tabs double-click behavior', () => {
       expect(handleRef.current?.getHeaderForeground()).toBe(
         container.querySelector('[data-tabs-header-foreground="true"]')
       )
-      expect(indicator?.style.transform).toBe('translate(16px, 0px)')
-      expect(indicator?.style.width).toBe('80px')
-      expect(indicator?.style.height).toBe('36px')
+      expect(indicator?.style.transform).toBe('translateX(16px)')
+      expect(indicator?.style.width).toBe('60px')
+      expect(indicator?.style.height).toBe('')
 
       rerender(<Tabs ref={handleRef} tabs={tabs} selectedTab="b" actions={<button>x</button>} />)
 
-      expect(indicator?.style.transform).toBe('translate(108px, 0px)')
-      expect(indicator?.style.width).toBe('96px')
+      expect(indicator?.style.transform).toBe('translateX(108px)')
+      expect(indicator?.style.width).toBe('76px')
     } finally {
       Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
         configurable: true,

--- a/packages/web/src/components/tabs.tsx
+++ b/packages/web/src/components/tabs.tsx
@@ -34,6 +34,7 @@ export interface TabsClassNames {
   header?: string
   headerShell?: string
   headerForeground?: string
+  headerFrame?: string
   strip?: string
   list?: string
   buttonBase?: string
@@ -43,10 +44,15 @@ export interface TabsClassNames {
   activeButtonInner?: string
   inactiveButtonInner?: string
   actions?: string
+  actionsDivider?: string
   closeButtonActive?: string
   closeButtonInactive?: string
+  selectionTrack?: string
+  selectionIndicatorViewport?: string
   selectionIndicator?: string
 }
+
+export type TabsSelectionIndicatorLayout = 'underline' | 'overlay'
 
 export interface TabsProps {
   tabs: Tab[]
@@ -66,6 +72,7 @@ export interface TabsProps {
   showHeaderShell?: boolean
   showSelectionIndicator?: boolean
   decorateStrip?: boolean
+  selectionIndicatorLayout?: TabsSelectionIndicatorLayout
 }
 
 export interface TabsHandle {
@@ -129,15 +136,6 @@ const tabsStyleText = (id: string) => {
       transform: scaleX(0.5);
     }
 
-    #${id}[data-tabs-strip-decoration='on'] .tabs-strip {
-      background-image: linear-gradient(
-        to bottom,
-        transparent,
-        transparent calc(100% - 1px),
-        var(--border) calc(100% - 1px),
-        var(--border)
-      );
-    }
   `
 }
 
@@ -191,6 +189,7 @@ function TabsImpl(
     showHeaderShell = true,
     showSelectionIndicator = true,
     decorateStrip = true,
+    selectionIndicatorLayout = 'underline',
   }: TabsProps,
   ref: ForwardedRef<TabsHandle>
 ) {
@@ -202,6 +201,8 @@ function TabsImpl(
   const headerRef = useRef<HTMLDivElement | null>(null)
   const headerShellRef = useRef<HTMLDivElement | null>(null)
   const headerForegroundRef = useRef<HTMLDivElement | null>(null)
+  const headerFrameRef = useRef<HTMLDivElement | null>(null)
+  const stripRef = useRef<HTMLDivElement | null>(null)
   const selectionIndicatorRef = useRef<HTMLDivElement | null>(null)
   const tabsButtonRef = useRef<HTMLDivElement | null>(null)
   const triggerRefs = useRef(new Map<string, HTMLButtonElement | null>())
@@ -236,7 +237,7 @@ function TabsImpl(
         return panelRefs.current.get(tabId) ?? null
       },
       getHeaderShell() {
-        return headerShellRef.current
+        return headerShellRef.current ?? stripRef.current
       },
       getHeaderForeground() {
         return headerForegroundRef.current
@@ -253,31 +254,48 @@ function TabsImpl(
 
   const syncSelectionIndicator = useCallback(() => {
     const indicator = selectionIndicatorRef.current
-    const header = headerRef.current
+    const strip = stripRef.current ?? headerFrameRef.current
     const activeTrigger = activeTab ? triggerRefs.current.get(activeTab) : null
 
     if (!indicator) {
       return
     }
 
-    if (!showSelectionIndicator || !header || !activeTrigger) {
+    if (!showSelectionIndicator || !strip || !activeTrigger) {
       indicator.style.opacity = '0'
       indicator.style.width = '0px'
-      indicator.style.height = '0px'
-      indicator.style.transform = 'translate(0px, 0px)'
+      indicator.style.height = selectionIndicatorLayout === 'overlay' ? '0px' : ''
+      indicator.style.transform =
+        selectionIndicatorLayout === 'overlay' ? 'translate(0px, 0px)' : 'translateX(0px)'
       return
     }
 
-    const headerRect = header.getBoundingClientRect()
+    const stripRect = strip.getBoundingClientRect()
     const triggerRect = activeTrigger.getBoundingClientRect()
+
+    if (selectionIndicatorLayout === 'underline') {
+      const indicatorStyle = getComputedStyle(indicator)
+      const inlineInset =
+        parseFloat(indicatorStyle.getPropertyValue('--tabs-selection-inline-inset')) || 10
+      const minWidth =
+        parseFloat(indicatorStyle.getPropertyValue('--tabs-selection-min-width')) || 40
+      const width = Math.max(minWidth, triggerRect.width - inlineInset * 2)
+      const translateX = triggerRect.left - stripRect.left + (triggerRect.width - width) / 2
+
+      indicator.style.opacity = '1'
+      indicator.style.width = `${width}px`
+      indicator.style.height = ''
+      indicator.style.transform = `translateX(${translateX}px)`
+      return
+    }
 
     indicator.style.opacity = '1'
     indicator.style.width = `${triggerRect.width}px`
-    indicator.style.height = `${triggerRect.height}px`
-    indicator.style.transform = `translate(${triggerRect.left - headerRect.left}px, ${
-      triggerRect.top - headerRect.top
+    indicator.style.height = `${triggerRect.height + 1}px`
+    indicator.style.transform = `translate(${triggerRect.left - stripRect.left}px, ${
+      triggerRect.top - stripRect.top
     }px)`
-  }, [activeTab, showSelectionIndicator])
+  }, [activeTab, selectionIndicatorLayout, showSelectionIndicator])
 
   useLayoutEffect(() => {
     syncSelectionIndicator()
@@ -312,6 +330,12 @@ function TabsImpl(
     observer.observe(tabsButton)
     if (headerRef.current) {
       observer.observe(headerRef.current)
+    }
+    if (stripRef.current) {
+      observer.observe(stripRef.current)
+    }
+    if (headerFrameRef.current) {
+      observer.observe(headerFrameRef.current)
     }
 
     const activeTrigger = activeTab ? triggerRefs.current.get(activeTab) : null
@@ -451,17 +475,24 @@ function TabsImpl(
   )
 
   const headerShellClassName = cn(
-    'tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm',
+    selectionIndicatorLayout === 'underline'
+      ? 'tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-t-md rounded-b-none border border-b-0 border-zinc-500/15 backdrop-blur-sm'
+      : 'tabs-header-shell bg-card/95 pointer-events-none absolute inset-0 z-0 rounded-md border border-zinc-500/15 shadow-[inset_0_-1px_0_color-mix(in_srgb,var(--border)_85%,transparent)] backdrop-blur-sm',
     classNames?.headerShell
   )
 
   const headerForegroundClassName = cn(
-    'tabs-header-foreground relative z-20 flex min-w-0 items-stretch',
+    'tabs-header-foreground relative z-20 flex min-w-0 flex-1',
     classNames?.headerForeground
   )
 
+  const headerFrameClassName = cn(
+    'tabs-header-frame relative flex min-w-0 flex-1 items-stretch',
+    classNames?.headerFrame
+  )
+
   const stripClassName = cn(
-    'tabs-strip flex min-w-0 flex-1 items-stretch rounded-l-md px-4',
+    'tabs-strip relative flex min-w-0 flex-1 items-stretch px-4',
     classNames?.strip
   )
 
@@ -480,7 +511,7 @@ function TabsImpl(
   const activeButtonClassName = cn('tab-selected text-foreground', classNames?.activeButton)
 
   const inactiveButtonClassName = cn(
-    'text-muted-foreground hover:bg-background/35 hover:text-foreground',
+    'text-muted-foreground hover:text-foreground',
     classNames?.inactiveButton
   )
 
@@ -489,12 +520,31 @@ function TabsImpl(
   const inactiveButtonInnerClassName = cn(classNames?.inactiveButtonInner)
 
   const actionsClassName = cn(
-    'tabs-actions border-zinc-500/15 flex shrink-0 items-center rounded-r-md border-l px-1 h-full',
+    'tabs-actions relative flex shrink-0 items-center px-1',
     classNames?.actions
   )
 
+  const actionsDividerClassName = cn(
+    'tabs-actions-divider bg-border/60 absolute inset-y-0 left-0 w-px',
+    classNames?.actionsDivider
+  )
+
+  const selectionTrackClassName = cn(
+    'tabs-selection-track bg-border/85 pointer-events-none absolute inset-x-0 bottom-0 h-px',
+    classNames?.selectionTrack
+  )
+
+  const selectionIndicatorViewportClassName = cn(
+    selectionIndicatorLayout === 'underline'
+      ? 'pointer-events-none absolute inset-x-0 top-0 bottom-[-1px] z-10 overflow-hidden'
+      : 'pointer-events-none absolute inset-0 z-10 overflow-hidden',
+    classNames?.selectionIndicatorViewport
+  )
+
   const selectionIndicatorClassName = cn(
-    'tabs-selection-indicator border-primary bg-background/70 duration-280 absolute left-0 top-0 border-b-4 opacity-0 transition-[transform,width,height,opacity] ease-[cubic-bezier(0.22,1,0.36,1)]',
+    selectionIndicatorLayout === 'underline'
+      ? 'tabs-selection-indicator absolute bottom-0 left-0 h-[3px] rounded-full bg-primary opacity-0 transition-[transform,width,opacity] duration-280 ease-[cubic-bezier(0.22,1,0.36,1)] [--tabs-selection-inline-inset:10px] [--tabs-selection-min-width:40px]'
+      : 'tabs-selection-indicator border-primary bg-background/70 duration-280 absolute left-0 top-0 border-b opacity-0 transition-[transform,width,height,opacity] ease-[cubic-bezier(0.22,1,0.36,1)]',
     classNames?.selectionIndicator
   )
 
@@ -594,37 +644,41 @@ function TabsImpl(
               className={headerShellClassName}
             />
           )}
-          {showSelectionIndicator && (
-            <div className="pointer-events-none absolute inset-0 z-10">
-              <div
-                ref={selectionIndicatorRef}
-                data-tabs-selection-indicator="true"
-                aria-hidden="true"
-                className={selectionIndicatorClassName}
-              />
-            </div>
-          )}
           <div
             ref={headerForegroundRef}
             data-tabs-header-foreground="true"
             className={headerForegroundClassName}
           >
-            <div className={stripClassName}>
-              <div
-                ref={tabsButtonRef}
-                className={listClassName}
-                onDoubleClick={handleTabBarDoubleClick}
-                onDragOver={handleListDragOver}
-                onDrop={handleListDrop}
-              >
-                {tabButtons}
+            <div ref={headerFrameRef} className={headerFrameClassName}>
+              <div ref={stripRef} className={stripClassName}>
+                <div
+                  ref={tabsButtonRef}
+                  className={listClassName}
+                  onDoubleClick={handleTabBarDoubleClick}
+                  onDragOver={handleListDragOver}
+                  onDrop={handleListDrop}
+                >
+                  {tabButtons}
+                </div>
+                {showSelectionIndicator && (
+                  <div className={selectionIndicatorViewportClassName}>
+                    <div
+                      ref={selectionIndicatorRef}
+                      data-tabs-selection-indicator="true"
+                      aria-hidden="true"
+                      className={selectionIndicatorClassName}
+                    />
+                  </div>
+                )}
               </div>
+              {actions && (
+                <div data-tabs-actions="true" className={actionsClassName}>
+                  {decorateStrip && <div aria-hidden="true" className={actionsDividerClassName} />}
+                  {actions}
+                </div>
+              )}
+              {decorateStrip && <div aria-hidden="true" className={selectionTrackClassName} />}
             </div>
-            {actions && (
-              <div data-tabs-actions="true" className={actionsClassName}>
-                {actions}
-              </div>
-            )}
           </div>
         </>
       </div>

--- a/packages/web/src/components/terminal/terminal-tabs.test.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.test.tsx
@@ -37,20 +37,24 @@ describe('TerminalTabs', () => {
     expect(tabsPropsSpy.mock.calls[0]?.[0].showHeaderShell).toBe(false)
     expect(tabsPropsSpy.mock.calls[0]?.[0].showSelectionIndicator).toBe(true)
     expect(tabsPropsSpy.mock.calls[0]?.[0].decorateStrip).toBe(false)
+    expect(tabsPropsSpy.mock.calls[0]?.[0].selectionIndicatorLayout).toBe('overlay')
     expect(tabsPropsSpy.mock.calls[0]?.[0].classNames).toMatchObject({
       header: 'bg-terminal text-terminal-foreground',
-      headerForeground: 'z-auto flex-1 items-end',
+      headerForeground: 'z-auto flex-1',
+      headerFrame: 'items-end',
       strip: 'min-w-0 flex-1 items-end border-b border-terminal-foreground/20 px-4 rounded-none',
       list: 'flex-1 items-end overflow-y-hidden pt-2',
       buttonBase:
-        'z-20 rounded-t-[8px] border-x border-t border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
+        'z-20 rounded-t-[8px] border border-b-0 border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
       buttonInner:
         'inline-flex h-full items-center gap-2 rounded-t-[8px] px-3 py-1.5 transition-[color,background-color,transform,filter] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)] will-change-transform',
       activeButton: 'bg-transparent text-terminal-foreground',
       activeButtonInner: 'bg-transparent text-terminal-foreground [transform:translateY(0)]',
-      inactiveButton: 'bg-transparent text-terminal-foreground/72',
+      inactiveButton:
+        'bg-transparent text-terminal-foreground/72 hover:border-[color-mix(in_oklab,var(--background)_10%,transparent)] hover:text-terminal-foreground',
       inactiveButtonInner:
         'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
+      selectionIndicatorViewport: 'inset-x-0 top-0 bottom-[-1px] overflow-visible',
       selectionIndicator:
         'border-terminal-foreground/20 border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
     })

--- a/packages/web/src/components/terminal/terminal-tabs.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.tsx
@@ -38,19 +38,23 @@ export function TerminalTabs({
       showHeaderShell={false}
       showSelectionIndicator
       decorateStrip={false}
+      selectionIndicatorLayout="overlay"
       classNames={{
         header: 'bg-terminal text-terminal-foreground',
-        headerForeground: 'z-auto flex-1 items-end',
+        headerForeground: 'z-auto flex-1',
+        headerFrame: 'items-end',
         strip: `min-w-0 flex-1 items-end border-b ${TERMINAL_CHROME_BORDER} px-4 rounded-none`,
         list: 'flex-1 items-end overflow-y-hidden pt-2',
-        buttonBase: `z-20 rounded-t-[8px] border-x border-t border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ${IOS_TAB_EASE}`,
+        buttonBase: `z-20 rounded-t-[8px] border border-b-0 border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ${IOS_TAB_EASE}`,
         buttonInner: `inline-flex h-full items-center gap-2 rounded-t-[8px] px-3 py-1.5 transition-[color,background-color,transform,filter] duration-180 ${IOS_TAB_EASE} will-change-transform`,
         activeButton: 'bg-transparent text-terminal-foreground',
         activeButtonInner: 'bg-transparent text-terminal-foreground [transform:translateY(0)]',
-        inactiveButton: 'bg-transparent text-terminal-foreground/72',
+        inactiveButton:
+          'bg-transparent text-terminal-foreground/72 hover:border-[color-mix(in_oklab,var(--background)_10%,transparent)] hover:text-terminal-foreground',
         inactiveButtonInner:
           'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
         actions: `${TERMINAL_CHROME_BORDER} bg-terminal text-terminal-foreground border-b rounded-none px-1`,
+        selectionIndicatorViewport: 'inset-x-0 top-0 bottom-[-1px] overflow-visible',
         closeButtonActive: 'text-terminal-foreground/70 hover:text-terminal-foreground',
         closeButtonInactive: 'text-terminal-foreground/50 hover:text-terminal-foreground',
         selectionIndicator: `${TERMINAL_CHROME_BORDER} border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ${IOS_TAB_EASE}`,

--- a/packages/web/src/lib/view-transitions/tab-direction.test.ts
+++ b/packages/web/src/lib/view-transitions/tab-direction.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTabCarouselDirection } from './tab-direction'
+
+describe('resolveTabCarouselDirection', () => {
+  const tabs = [{ id: 'a' }, { id: 'b' }, { id: 'c' }] as const
+
+  it('returns forward when moving to a later tab', () => {
+    expect(resolveTabCarouselDirection(tabs, 'a', 'c')).toBe('forward')
+  })
+
+  it('returns backward when moving to an earlier tab', () => {
+    expect(resolveTabCarouselDirection(tabs, 'c', 'a')).toBe('backward')
+  })
+
+  it('returns null when current and next tab are the same', () => {
+    expect(resolveTabCarouselDirection(tabs, 'b', 'b')).toBeNull()
+  })
+
+  it('returns null when tab ids are missing', () => {
+    expect(resolveTabCarouselDirection(tabs, 'x', 'b')).toBeNull()
+    expect(resolveTabCarouselDirection(tabs, 'a', 'y')).toBeNull()
+  })
+})

--- a/packages/web/src/lib/view-transitions/tab-direction.ts
+++ b/packages/web/src/lib/view-transitions/tab-direction.ts
@@ -1,0 +1,16 @@
+import type { VTDirection } from './route-semantics'
+
+export function resolveTabCarouselDirection<TTab extends { id: string }>(
+  tabs: readonly TTab[],
+  currentTabId: string,
+  nextTabId: string
+): VTDirection | null {
+  const currentIndex = tabs.findIndex((tab) => tab.id === currentTabId)
+  const nextIndex = tabs.findIndex((tab) => tab.id === nextTabId)
+
+  if (currentIndex < 0 || nextIndex < 0 || currentIndex === nextIndex) {
+    return null
+  }
+
+  return nextIndex > currentIndex ? 'forward' : 'backward'
+}

--- a/packages/web/src/lib/view-transitions/tabs.ts
+++ b/packages/web/src/lib/view-transitions/tabs.ts
@@ -13,8 +13,9 @@ import {
   useSyncExternalStore,
 } from 'react'
 import { flushSync } from 'react-dom'
-import type { VTArea } from './route-semantics'
+import type { VTArea, VTDirection } from './route-semantics'
 import { runViewTransition } from './runtime'
+import { resolveTabCarouselDirection } from './tab-direction'
 import {
   captureTabScrollMemory,
   cleanupFrozenTab,
@@ -544,11 +545,17 @@ export function useRoutedCarouselTabs<TTabId extends string>({
           return
         }
 
+        const direction = resolveTabCarouselDirection(latestTabs, currentTab, nextTabId)
+        if (!direction) {
+          commitSelection()
+          return
+        }
+
         void runViewTransition({
           intent: {
             area: resolveTabArea(latestLocation.pathname, latestArea),
             kind: 'tab-carousel',
-            direction: 'forward',
+            direction,
           },
           collectBeforeEntries: () => collectTabEntries(tabsRef.current, currentTab),
           collectAfterEntries: () => collectTabEntries(tabsRef.current, nextTabId),
@@ -557,7 +564,9 @@ export function useRoutedCarouselTabs<TTabId extends string>({
         return
       }
 
-      const runSelectionWithScrollTransfer = (animated: boolean) => {
+      const direction = resolveTabCarouselDirection(latestTabs, currentTab, nextTabId)
+
+      const runSelectionWithScrollTransfer = (animated: boolean, direction?: VTDirection) => {
         const outgoingSnapshot = captureTabSnapshot(currentTab, latestViewportSelector)
         const incomingSeedSnapshot =
           scrollMemoryByTabRef.current.get(nextTabId) ??
@@ -628,14 +637,11 @@ export function useRoutedCarouselTabs<TTabId extends string>({
         return
       }
 
-      const currentIndex = latestTabs.findIndex((tab) => tab.id === currentTab)
-      const nextIndex = latestTabs.findIndex((tab) => tab.id === nextTabId)
-      if (currentIndex < 0 || nextIndex < 0) {
+      if (!direction) {
         runSelectionWithScrollTransfer(false)
         return
       }
-      const direction = nextIndex >= currentIndex ? 'forward' : 'backward'
-      runSelectionWithScrollTransfer(true)
+      runSelectionWithScrollTransfer(true, direction)
     },
     [
       captureOutgoingTab,

--- a/packages/web/src/tabs-lab.tsx
+++ b/packages/web/src/tabs-lab.tsx
@@ -1,0 +1,557 @@
+import {
+  CheckCircle2,
+  FileCode2,
+  FileText,
+  FolderTree,
+  GitBranch,
+  Plus,
+  Search,
+  SlidersHorizontal,
+  Sparkles,
+} from 'lucide-react'
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Tabs } from './components/tabs'
+import { TerminalTabs } from './components/terminal/terminal-tabs'
+import { ThemeBootstrap } from './components/theme-bootstrap'
+import './index.css'
+import { resolveTerminalTheme } from './lib/terminal-theme'
+
+const labStyles = String.raw`
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at top, color-mix(in srgb, var(--primary) 16%, transparent), transparent 32%),
+      linear-gradient(180deg, color-mix(in srgb, var(--background) 94%, black 6%), var(--background));
+    color: var(--foreground);
+  }
+
+  .tabs-lab-page {
+    min-height: 100vh;
+    padding: 32px;
+    display: grid;
+    gap: 24px;
+  }
+
+  .tabs-lab-hero {
+    display: grid;
+    gap: 8px;
+    max-width: 980px;
+  }
+
+  .tabs-lab-eyebrow {
+    font: 600 12px/1.2 'JetBrains Mono', monospace;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--foreground) 52%, transparent);
+  }
+
+  .tabs-lab-title {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 3rem);
+    line-height: 1;
+  }
+
+  .tabs-lab-copy {
+    margin: 0;
+    max-width: 76ch;
+    color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  }
+
+  .tabs-lab-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    gap: 20px;
+  }
+
+  .lab-card {
+    min-width: 0;
+    min-height: 420px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px;
+    border-radius: 24px;
+    border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+    background: color-mix(in srgb, var(--card) 90%, transparent);
+    box-shadow: 0 24px 80px color-mix(in srgb, black 12%, transparent);
+    backdrop-filter: blur(18px);
+  }
+
+  .lab-card-head {
+    display: grid;
+    gap: 6px;
+  }
+
+  .lab-card-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .lab-card-note {
+    margin: 0;
+    font-size: 0.92rem;
+    color: color-mix(in srgb, currentColor 70%, transparent);
+  }
+
+  .lab-preview {
+    min-width: 0;
+    min-height: 0;
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+    border-radius: 20px;
+    border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--card) 94%, white 6%), color-mix(in srgb, var(--background) 96%, black 4%));
+  }
+
+  .lab-canvas {
+    min-width: 0;
+    min-height: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+  }
+
+  .lab-canvas--terminal {
+    background: var(--terminal);
+    color: var(--terminal-foreground);
+  }
+
+  .scenario-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .scenario-header-block {
+    min-width: 0;
+    display: grid;
+    gap: 6px;
+  }
+
+  .scenario-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.35rem;
+    font-weight: 700;
+  }
+
+  .scenario-subtitle {
+    color: color-mix(in srgb, var(--foreground) 68%, transparent);
+    font-size: 0.94rem;
+  }
+
+  .scenario-command-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .scenario-command-bar--terminal .lab-pill {
+    border-color: color-mix(in srgb, var(--terminal-foreground) 18%, transparent);
+    background: color-mix(in srgb, var(--terminal-foreground) 8%, transparent);
+    color: var(--terminal-foreground);
+  }
+
+  .lab-pill {
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    background: color-mix(in srgb, var(--background) 82%, transparent);
+    padding-inline: 12px;
+    font-size: 0.86rem;
+    color: inherit;
+  }
+
+  .lab-pill--primary {
+    border-color: color-mix(in srgb, var(--primary) 24%, transparent);
+    background: color-mix(in srgb, var(--primary) 12%, transparent);
+  }
+
+  .lab-tab-body {
+    min-height: 0;
+    flex: 1;
+    display: grid;
+    gap: 14px;
+    padding: 18px 18px 22px;
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--background) 88%, transparent), color-mix(in srgb, var(--card) 96%, transparent));
+  }
+
+  .lab-tab-body--terminal {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--terminal) 96%, white 4%),
+      color-mix(in srgb, var(--terminal) 100%, black 0%)
+    );
+    color: var(--terminal-foreground);
+  }
+
+  .lab-tab-kicker {
+    font: 600 11px/1.2 'JetBrains Mono', monospace;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, currentColor 58%, transparent);
+  }
+
+  .lab-tab-title {
+    margin: 0;
+    font-size: 1.08rem;
+    font-weight: 600;
+  }
+
+  .lab-tab-copy {
+    margin: 0;
+    font-size: 0.94rem;
+    line-height: 1.55;
+    color: color-mix(in srgb, currentColor 72%, transparent);
+  }
+
+  .lab-tab-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .lab-chip {
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--border) 66%, transparent);
+    background: color-mix(in srgb, var(--muted) 70%, transparent);
+    padding: 0.36rem 0.7rem;
+    font-size: 0.76rem;
+    color: color-mix(in srgb, var(--foreground) 76%, transparent);
+  }
+
+  .lab-action-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .lab-action-row--terminal .lab-tool-button {
+    border-color: color-mix(in srgb, var(--terminal-foreground) 14%, transparent);
+    background: color-mix(in srgb, var(--terminal-foreground) 8%, transparent);
+    color: var(--terminal-foreground);
+  }
+
+  .lab-tool-button {
+    height: 30px;
+    width: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+    background: color-mix(in srgb, var(--background) 78%, transparent);
+    color: inherit;
+  }
+
+  @media (max-width: 760px) {
+    .tabs-lab-page {
+      padding: 20px;
+    }
+  }
+`
+
+type ScenarioTab = {
+  id: string
+  label: string
+  icon: ReactNode
+  title: string
+  copy: string
+  chips: string[]
+}
+
+type LabTab = {
+  id: string
+  label: ReactNode
+  icon?: ReactNode
+  content: ReactNode
+}
+
+const changeScenarioTabs: ScenarioTab[] = [
+  {
+    id: 'proposal',
+    label: 'proposal.md',
+    icon: <CheckCircle2 className="h-4 w-4 text-emerald-500" />,
+    title: 'Proposal Draft',
+    copy: 'The change detail page wants the header to retreat and the content to dominate. This lets you judge whether the indicator feels calm or intrusive.',
+    chips: ['Artifacts', 'Reader-first', 'Low chrome'],
+  },
+  {
+    id: 'design',
+    label: 'design.md',
+    icon: <Sparkles className="h-4 w-4 text-sky-500" />,
+    title: 'Design Notes',
+    copy: 'Longer labels, icon rhythm, and content continuity matter here. The active tab must be obvious without becoming another card surface.',
+    chips: ['Long-form', 'Spec review', 'Quiet active'],
+  },
+  {
+    id: 'folder',
+    label: 'Folder',
+    icon: <FolderTree className="h-4 w-4" />,
+    title: 'Change Folder',
+    copy: 'Folder view is the utility stress case. The active signal still needs to hold together when one tab is much more tool-like than the others.',
+    chips: ['Mixed mode', 'Browser + text', 'Utility tab'],
+  },
+]
+
+const configScenarioTabs: ScenarioTab[] = [
+  {
+    id: 'project',
+    label: 'Project Config',
+    icon: <FileText className="h-4 w-4" />,
+    title: 'Project Config',
+    copy: 'Config wants denser spacing and better scanability. Tabs should feel like a navigation rail rather than like decorative cards.',
+    chips: ['Dense', 'Operational', 'Frequent switching'],
+  },
+  {
+    id: 'global',
+    label: 'Global Config',
+    icon: <SlidersHorizontal className="h-4 w-4" />,
+    title: 'Global Config',
+    copy: 'This page often has more tabs and longer labels. The active state should stay readable without increasing the header height too much.',
+    chips: ['High tab count', 'Compact', 'Clear active'],
+  },
+  {
+    id: 'schema-spec-driven',
+    label: 'schema:spec-driven',
+    icon: <FileCode2 className="h-4 w-4" />,
+    title: 'Schema Details',
+    copy: 'This is the long-label case. The underline treatment needs to hold up when labels become obviously developer-facing and verbose.',
+    chips: ['Long labels', 'Horizontal overflow', 'Utility-first'],
+  },
+]
+
+function buildTabs(prefix: string, tabs: ScenarioTab[]): LabTab[] {
+  return tabs.map((item) => ({
+    id: `${prefix}-${item.id}`,
+    label: item.label,
+    icon: item.icon,
+    content: (
+      <div className="lab-tab-body">
+        <div className="lab-tab-kicker">{item.label}</div>
+        <h3 className="lab-tab-title">{item.title}</h3>
+        <p className="lab-tab-copy">{item.copy}</p>
+        <div className="lab-tab-chips">
+          {item.chips.map((chip) => (
+            <span key={chip} className="lab-chip">
+              {chip}
+            </span>
+          ))}
+        </div>
+      </div>
+    ),
+  }))
+}
+
+function ActionRow() {
+  return (
+    <div className="lab-action-row">
+      <button type="button" className="lab-tool-button" aria-label="Search">
+        <Search className="h-4 w-4" />
+      </button>
+      <button type="button" className="lab-tool-button" aria-label="Add tab">
+        <Plus className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+function TerminalActionRow() {
+  return (
+    <div className="lab-action-row lab-action-row--terminal">
+      <button type="button" className="lab-tool-button" aria-label="Search">
+        <Search className="h-4 w-4" />
+      </button>
+      <button type="button" className="lab-tool-button" aria-label="Add tab">
+        <Plus className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+function DemoCard(props: { title: string; note: string; children: ReactNode }) {
+  return (
+    <section className="lab-card">
+      <header className="lab-card-head">
+        <div className="lab-card-title">{props.title}</div>
+        <p className="lab-card-note">{props.note}</p>
+      </header>
+      <div className="lab-preview">{props.children}</div>
+    </section>
+  )
+}
+
+function buildTerminalThemeStyle() {
+  const theme = resolveTerminalTheme({
+    appDarkMode: true,
+    systemDarkMode: true,
+    useTheme: 'dark',
+    darkTheme: 'default-dark',
+    lightTheme: 'default-light',
+  })
+
+  return {
+    '--terminal': theme.definition.palette.background,
+    '--terminal-foreground': theme.definition.palette.foreground,
+  } as CSSProperties
+}
+
+function DefaultTabsShowcase(props: { scenario: 'change' | 'config' }) {
+  const scenarioTabs = props.scenario === 'change' ? changeScenarioTabs : configScenarioTabs
+  const tabs = useMemo(
+    () => buildTabs(`final-default-${props.scenario}`, scenarioTabs),
+    [props.scenario, scenarioTabs]
+  )
+  const [selectedTab, setSelectedTab] = useState(tabs[0]?.id ?? '')
+
+  return (
+    <div className="lab-canvas">
+      <header className="scenario-header">
+        <div className="scenario-header-block">
+          <div className="scenario-title">
+            {props.scenario === 'change' ? (
+              <GitBranch className="h-5 w-5" />
+            ) : (
+              <SlidersHorizontal className="h-5 w-5" />
+            )}
+            <span>{props.scenario === 'change' ? 'Change Detail' : 'Config'}</span>
+          </div>
+          <div className="scenario-subtitle">
+            Default Tabs final surface. Shared component, built on the Scheme 3 dedicated-rail
+            structure.
+          </div>
+        </div>
+        {props.scenario === 'change' ? (
+          <div className="scenario-command-bar">
+            <button type="button" className="lab-pill">
+              Refresh
+            </button>
+            <button type="button" className="lab-pill">
+              Verify
+            </button>
+            <button type="button" className="lab-pill lab-pill--primary">
+              Compose
+            </button>
+          </div>
+        ) : null}
+      </header>
+      <Tabs
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onTabChange={setSelectedTab}
+        actions={<ActionRow />}
+        className="min-h-0 flex-1"
+      />
+    </div>
+  )
+}
+
+function FinalTerminalTabsShowcase() {
+  const terminalThemeStyle = useMemo(() => buildTerminalThemeStyle(), [])
+  const tabs = useMemo(
+    () =>
+      buildTabs('final-terminal', changeScenarioTabs).map((tab) => ({
+        ...tab,
+        content: <div className="lab-tab-body lab-tab-body--terminal">{tab.content}</div>,
+      })),
+    []
+  )
+  const [selectedTab, setSelectedTab] = useState(tabs[0]?.id ?? '')
+
+  return (
+    <div className="lab-canvas lab-canvas--terminal" style={terminalThemeStyle}>
+      <header className="scenario-header">
+        <div className="scenario-header-block">
+          <div className="scenario-title">
+            <Sparkles className="h-5 w-5" />
+            <span>Final TerminalTabs</span>
+          </div>
+          <div className="scenario-subtitle">
+            Independent motion language kept separate from default Tabs
+          </div>
+        </div>
+        <div className="scenario-command-bar scenario-command-bar--terminal">
+          <button type="button" className="lab-pill">
+            Split
+          </button>
+          <button type="button" className="lab-pill">
+            Theme
+          </button>
+        </div>
+      </header>
+      <TerminalTabs
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onTabChange={setSelectedTab}
+        actions={<TerminalActionRow />}
+        className="min-h-0 flex-1"
+      />
+    </div>
+  )
+}
+
+function TabsLabApp() {
+  return (
+    <>
+      <ThemeBootstrap />
+      <style>{labStyles}</style>
+      <main className="tabs-lab-page">
+        <section className="tabs-lab-hero">
+          <div className="tabs-lab-eyebrow">Tabs Lab / Final Acceptance</div>
+          <h1 className="tabs-lab-title">Final Tabs and TerminalTabs</h1>
+          <p className="tabs-lab-copy">
+            Scheme 3 won as the structural law for the shared default Tabs. The cards below show the
+            final shipped surfaces: default Tabs in change detail and config, plus the independent
+            TerminalTabs variant.
+          </p>
+        </section>
+
+        <section className="tabs-lab-grid">
+          <DemoCard
+            title="Final / Default Tabs / Change Detail"
+            note="The product-facing shared Tabs surface for the change detail page."
+          >
+            <DefaultTabsShowcase scenario="change" />
+          </DemoCard>
+
+          <DemoCard
+            title="Final / Default Tabs / Config"
+            note="The same shared Tabs component under the denser config page workload."
+          >
+            <DefaultTabsShowcase scenario="config" />
+          </DemoCard>
+
+          <DemoCard
+            title="Final / TerminalTabs"
+            note="Terminal-specific chrome remains isolated from the default Tabs language."
+          >
+            <FinalTerminalTabsShowcase />
+          </DemoCard>
+        </section>
+      </main>
+    </>
+  )
+}
+
+const root = document.getElementById('root')
+
+if (!root) {
+  throw new Error('Tabs lab root element not found')
+}
+
+createRoot(root).render(<TabsLabApp />)

--- a/packages/web/tabs-lab.html
+++ b/packages/web/tabs-lab.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenSpec UI Tabs Lab</title>
+    <script>
+      ;(() => {
+        const lang =
+          (navigator.languages && navigator.languages[0]) ||
+          navigator.language ||
+          navigator.userLanguage ||
+          ''
+        const useCnCdn = /^zh\b/i.test(lang)
+        const apiHost = useCnCdn ? 'https://fonts.googleapis.cn' : 'https://fonts.googleapis.com'
+        const staticHost = useCnCdn ? 'https://fonts.gstatic.cn' : 'https://fonts.gstatic.com'
+
+        const preconnectApi = document.createElement('link')
+        preconnectApi.rel = 'preconnect'
+        preconnectApi.href = apiHost
+
+        const preconnectStatic = document.createElement('link')
+        preconnectStatic.rel = 'preconnect'
+        preconnectStatic.href = staticHost
+        preconnectStatic.crossOrigin = 'anonymous'
+
+        const stylesheet = document.createElement('link')
+        stylesheet.rel = 'stylesheet'
+        stylesheet.href = `${apiHost}/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Share+Tech+Mono&display=swap`
+
+        document.head.append(preconnectApi, preconnectStatic, stylesheet)
+      })()
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/tabs-lab.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- refine shared Tabs chrome so the default underline indicator stays inside the tab strip and the tabs/actions divider spans the full header height
- restore TerminalTabs active-tab integration so the terminal tab surface masks the bottom border and visually joins the terminal content
- fix routed tab view-transition direction handling and document the source-first local development workflow

## Verification
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
- pnpm --filter @openspecui/web build:ssg
