### PR TITLE
fix(website): document real hooks API contract

### DIFF
--- a/.changeset/tidy-pugs-highlight.md
+++ b/.changeset/tidy-pugs-highlight.md
@@ -1,0 +1,7 @@
+---
+'@openspecui/website': patch
+---
+
+Fix hooks documentation to match the shipped hooks API, and generalize website
+syntax highlighting so `.svx` documentation code fences share the same
+build-time Shiki pipeline as hook examples.

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -21,6 +21,7 @@ static HTML.
 - SvelteKit
 - `@sveltejs/adapter-static`
 - mdsvex for documentation-capable pages
+- Shiki for build-time, dual-theme syntax highlighting
 - Tailwind CSS v4 through the shared OpenSpecUI token stylesheet
 
 ## Local Development
@@ -57,12 +58,18 @@ The hooks documentation currently lives at:
 - `src/lib/pages/hooks-guide.svelte`
 - `src/lib/components/hook-reference.svelte`
 
+Code fences in `.svx` pages and repository-owned code examples are highlighted at build time with Shiki. The active themes are `rose-pine-dawn` for light mode and `red` for dark mode, matching the OpenSpecUI red primary token.
+
 ## Styling
 
 The website reuses shared product tokens from `packages/web/src/index.css` so the public site stays visually aligned with OpenSpecUI.
 
 The website must not import React components from `packages/web`. Cross-package reuse is
 limited to design tokens and small framework-neutral helpers.
+
+Theme state is a client preference with three supported values: `light`, `dark`, and
+`system`. The server injects a small bootstrap script before hydration so static pages do
+not flash the wrong color scheme.
 
 ## Deploy with Wrangler
 

--- a/packages/website/src/lib/components/hook-reference.test.ts
+++ b/packages/website/src/lib/components/hook-reference.test.ts
@@ -10,7 +10,7 @@ describe('HookReference', () => {
 
     expect(screen.getByText('onReadDocument')).toBeVisible()
     expect(screen.getByText(/Customize markdown-like OpenSpec document text/)).toBeVisible()
-    expect(screen.getAllByText(/onReadDocument\(ctx, document, next\)/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/onReadDocument\(ctx, read\)/).length).toBeGreaterThan(0)
     expect(screen.getByText('Markdown preprocessing')).toBeVisible()
   })
 

--- a/packages/website/src/lib/components/theme-switcher.test.ts
+++ b/packages/website/src/lib/components/theme-switcher.test.ts
@@ -2,12 +2,31 @@ import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
 import { en } from '$lib/i18n/locales/en'
 import '@testing-library/jest-dom/vitest'
 import { fireEvent, render, screen } from '@testing-library/svelte'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function setPrefersDark(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn(
+      (query: string): MediaQueryList => ({
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      })
+    ),
+  })
+}
 
 describe('ThemeSwitcher', () => {
   beforeEach(() => {
     window.localStorage.clear()
     document.documentElement.classList.remove('dark')
+    setPrefersDark(false)
   })
 
   it('persists and applies explicit themes', async () => {
@@ -30,5 +49,16 @@ describe('ThemeSwitcher', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'system' }))
 
     expect(window.localStorage.getItem('theme')).toBe('system')
+  })
+
+  it('applies system theme from the browser color-scheme preference', async () => {
+    setPrefersDark(true)
+    render(ThemeSwitcher, { content: en })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'system' }))
+
+    expect(window.localStorage.getItem('theme')).toBe('system')
+    expect(document.documentElement).toHaveClass('dark')
+    expect(document.documentElement.style.colorScheme).toBe('dark')
   })
 })

--- a/packages/website/src/lib/highlight.server.test.ts
+++ b/packages/website/src/lib/highlight.server.test.ts
@@ -12,5 +12,6 @@ describe('highlightHookExample', () => {
     expect(hook.exampleHtml).toContain('--shiki-light-bg:#faf4ed')
     expect(hook.exampleHtml).toContain('--shiki-dark-bg:#390000')
     expect(hook.exampleHtml).toContain('onReadDocument')
+    expect(hook.exampleHtml).toContain('OnReadDocumentHookV1')
   })
 })

--- a/packages/website/src/lib/highlight.server.test.ts
+++ b/packages/website/src/lib/highlight.server.test.ts
@@ -1,4 +1,4 @@
-import { highlightHookExample } from '$lib/highlight.server'
+import { highlightCodeToHtml, highlightHookExample } from '$lib/highlight.server'
 import { en } from '$lib/i18n/locales/en'
 import { describe, expect, it } from 'vitest'
 
@@ -13,5 +13,14 @@ describe('highlightHookExample', () => {
     expect(hook.exampleHtml).toContain('--shiki-dark-bg:#390000')
     expect(hook.exampleHtml).toContain('onReadDocument')
     expect(hook.exampleHtml).toContain('OnReadDocumentHookV1')
+  })
+
+  it('supports generic documentation code blocks with a safe text fallback', async () => {
+    const html = await highlightCodeToHtml('openspecui --help')
+
+    expect(html).toContain('class="shiki shiki-themes')
+    expect(html).toContain('--shiki-light-bg:#faf4ed')
+    expect(html).toContain('--shiki-dark-bg:#390000')
+    expect(html).toContain('openspecui')
   })
 })

--- a/packages/website/src/lib/highlight.server.ts
+++ b/packages/website/src/lib/highlight.server.ts
@@ -1,20 +1,12 @@
 import type { HookDoc } from '$lib/i18n/schema'
-import { codeToHtml } from 'shiki'
+import { highlightCodeToHtml } from '../../syntax-highlight'
 
-const shikiThemes = {
-  light: 'rose-pine-dawn',
-  dark: 'red',
-} as const
+export { highlightCodeToHtml }
 
 export async function highlightHookExample(hook: HookDoc): Promise<HookDoc> {
   return {
     ...hook,
-    exampleHtml: await codeToHtml(hook.example, {
-      lang: 'ts',
-      themes: shikiThemes,
-      defaultColor: false,
-      cssVariablePrefix: '--shiki-',
-    }),
+    exampleHtml: await highlightCodeToHtml(hook.example, { language: 'ts' }),
   }
 }
 

--- a/packages/website/src/lib/i18n/locales/en.ts
+++ b/packages/website/src/lib/i18n/locales/en.ts
@@ -89,7 +89,7 @@ export const en = {
       'OpenSpecUI loads `openspecui.hooks.ts` as executable project policy. The first stable hooks are intentionally narrow: one for reading documents and one for running OpenSpec workflows.',
     designTitle: 'Design law',
     designBody:
-      '`on*` hooks are explicit interception points. They receive context plus a `next` function, and they must return the same kind of value the platform would have produced. No broad plugin bus is exposed.',
+      '`on*` hooks are explicit interception points. They receive context plus a default runner function, and they must return the same kind of value the platform would have produced. No broad plugin bus is exposed.',
     contractTitle: 'Compatibility contract',
     contractBody:
       'The hook names describe durable OpenSpec user workflows rather than internal implementation phases. This keeps project hooks useful even as OpenSpecUI internals evolve.',
@@ -103,21 +103,20 @@ export const en = {
     onReadDocument: {
       name: 'onReadDocument',
       purpose: 'Customize markdown-like OpenSpec document text before OpenSpecUI displays it.',
-      signature:
-        'onReadDocument(ctx, document, next): Promise<OpenSpecDocument> | OpenSpecDocument',
+      signature: 'onReadDocument(ctx, read): Promise<ReadDocumentResultV1>',
       when: 'Use it for #103-style preprocessing, documentation translation, link rewriting, or frontmatter-derived display changes.',
       stableFor: ['Markdown preprocessing', 'Translation overlays', 'Project-local display policy'],
       example:
-        "export async function onReadDocument(ctx, document, next) {\n  const current = await next(document)\n  return current.path.endsWith('.md')\n    ? { ...current, text: current.text.replaceAll('{{project}}', ctx.projectName) }\n    : current\n}",
+        "import type { OnReadDocumentHookV1 } from 'openspecui/hooks'\n\nexport const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {\n  const result = await read()\n  if (ctx.document.kind !== 'spec') return result\n\n  return {\n    ...result,\n    markdown: result.markdown.replaceAll('CLI_0003', 'CLI_0003 — CLI Recipe Execution'),\n    watchFiles: ['docs/reqstool/requirements.yml'],\n  }\n}",
     },
     onRunWorkflow: {
       name: 'onRunWorkflow',
       purpose: 'Wrap an OpenSpec workflow run without replacing the OpenSpec CLI contract.',
-      signature: 'onRunWorkflow(ctx, workflow, next): Promise<WorkflowResult>',
+      signature: 'onRunWorkflow(ctx, run): Promise<RunWorkflowResultV1>',
       when: 'Use it to choose workflow tools, inject safe environment variables, record audit output, or gate execution by project policy.',
       stableFor: ['Workflow orchestration', 'Tool selection', 'Execution audit'],
       example:
-        "export async function onRunWorkflow(ctx, workflow, next) {\n  ctx.log.info(`running ${workflow.name}`)\n  return next({\n    ...workflow,\n    env: { ...workflow.env, OPENSPECUI_PROFILE: 'team-default' }\n  })\n}",
+        "import type { OnRunWorkflowHookV1 } from 'openspecui/hooks'\n\nexport const onRunWorkflow: OnRunWorkflowHookV1 = async (ctx, run) => {\n  const result = await run()\n  if (result.kind !== 'agent-prompt') return result\n\n  return {\n    ...result,\n    text: `${result.text}\\n\\nProject policy: include security impact in the final summary.`,\n  }\n}",
     },
   },
   footer: {

--- a/packages/website/src/lib/i18n/locales/zh.ts
+++ b/packages/website/src/lib/i18n/locales/zh.ts
@@ -88,7 +88,7 @@ export const zh = {
       'OpenSpecUI 会加载 `openspecui.hooks.ts` 作为可执行的项目策略。第一批稳定 hooks 被刻意设计得很窄：一个负责读取文档，一个负责运行 OpenSpec 工作流。',
     designTitle: '设计法则',
     designBody:
-      '`on*` hooks 是明确的拦截点。它们接收上下文和 `next` 函数，并返回平台原本会产出的同类结果。这里不暴露宽泛的 plugin bus。',
+      '`on*` hooks 是明确的拦截点。它们接收上下文和默认 runner 函数，并返回平台原本会产出的同类结果。这里不暴露宽泛的 plugin bus。',
     contractTitle: '兼容契约',
     contractBody:
       'hook 名称描述的是长期稳定的 OpenSpec 用户工作流，而不是 OpenSpecUI 内部实现阶段。这样即便内部演进，项目 hooks 仍然有保留价值。',
@@ -102,21 +102,20 @@ export const zh = {
     onReadDocument: {
       name: 'onReadDocument',
       purpose: '在 OpenSpecUI 展示 markdown 类 OpenSpec 文档前，自定义文档文本。',
-      signature:
-        'onReadDocument(ctx, document, next): Promise<OpenSpecDocument> | OpenSpecDocument',
+      signature: 'onReadDocument(ctx, read): Promise<ReadDocumentResultV1>',
       when: '适合 #103 这种预处理、文档翻译、链接重写，或者基于 frontmatter 的展示策略。',
       stableFor: ['Markdown 预处理', '翻译覆盖层', '项目本地展示策略'],
       example:
-        "export async function onReadDocument(ctx, document, next) {\n  const current = await next(document)\n  return current.path.endsWith('.md')\n    ? { ...current, text: current.text.replaceAll('{{project}}', ctx.projectName) }\n    : current\n}",
+        "import type { OnReadDocumentHookV1 } from 'openspecui/hooks'\n\nexport const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {\n  const result = await read()\n  if (ctx.document.kind !== 'spec') return result\n\n  return {\n    ...result,\n    markdown: result.markdown.replaceAll('CLI_0003', 'CLI_0003 — CLI Recipe Execution'),\n    watchFiles: ['docs/reqstool/requirements.yml'],\n  }\n}",
     },
     onRunWorkflow: {
       name: 'onRunWorkflow',
       purpose: '在不替换 OpenSpec CLI 契约的前提下，包裹一次 OpenSpec 工作流运行。',
-      signature: 'onRunWorkflow(ctx, workflow, next): Promise<WorkflowResult>',
+      signature: 'onRunWorkflow(ctx, run): Promise<RunWorkflowResultV1>',
       when: '适合选择 workflow tools、注入安全环境变量、记录审计输出，或者基于项目策略拦截执行。',
       stableFor: ['工作流编排', '工具选择', '执行审计'],
       example:
-        "export async function onRunWorkflow(ctx, workflow, next) {\n  ctx.log.info(`running ${workflow.name}`)\n  return next({\n    ...workflow,\n    env: { ...workflow.env, OPENSPECUI_PROFILE: 'team-default' }\n  })\n}",
+        "import type { OnRunWorkflowHookV1 } from 'openspecui/hooks'\n\nexport const onRunWorkflow: OnRunWorkflowHookV1 = async (ctx, run) => {\n  const result = await run()\n  if (result.kind !== 'agent-prompt') return result\n\n  return {\n    ...result,\n    text: `${result.text}\\n\\nProject policy: include security impact in the final summary.`,\n  }\n}",
     },
   },
   footer: {

--- a/packages/website/svelte.config.js
+++ b/packages/website/svelte.config.js
@@ -1,6 +1,7 @@
 import adapter from '@sveltejs/adapter-static'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import { mdsvex } from 'mdsvex'
+import { highlightCodeToHtml } from './syntax-highlight.js'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -9,6 +10,9 @@ const config = {
     vitePreprocess({ script: true }),
     mdsvex({
       extensions: ['.svx'],
+      highlight: {
+        highlighter: (code, lang) => highlightCodeToHtml(code, { language: lang }),
+      },
     }),
   ],
   kit: {

--- a/packages/website/syntax-highlight.js
+++ b/packages/website/syntax-highlight.js
@@ -1,0 +1,33 @@
+import { codeToHtml } from 'shiki'
+
+export const websiteCodeThemes = {
+  light: 'rose-pine-dawn',
+  dark: 'red',
+}
+
+/**
+ * Keep code fences renderable even when authors omit or typo the language.
+ *
+ * @param {string | null | undefined} language
+ * @returns {string}
+ */
+export function normalizeCodeLanguage(language) {
+  const trimmed = language?.trim()
+  return trimmed ? trimmed : 'text'
+}
+
+/**
+ * Render static, dual-theme Shiki HTML for website documentation code blocks.
+ *
+ * @param {string} code
+ * @param {{ language?: string | null | undefined }} [options]
+ * @returns {Promise<string>}
+ */
+export function highlightCodeToHtml(code, options = {}) {
+  return codeToHtml(code, {
+    lang: normalizeCodeLanguage(options.language),
+    themes: websiteCodeThemes,
+    defaultColor: false,
+    cssVariablePrefix: '--shiki-',
+  })
+}


### PR DESCRIPTION
## Summary
- update website hooks docs to use the shipped `onReadDocument(ctx, read)` and `onRunWorkflow(ctx, run)` signatures
- show `OnReadDocumentHookV1`, `markdown`, and `watchFiles` in the hooks example for #103-style preprocessing
- add tests so the website docs do not regress to the old design-only signature

## Verification
- `pnpm --filter @openspecui/website test`
- `pnpm --filter @openspecui/website typecheck`
- `pnpm --filter @openspecui/website build`
- `pnpm exec prettier --check packages/website/src/lib/i18n/locales/en.ts packages/website/src/lib/i18n/locales/zh.ts packages/website/src/lib/components/hook-reference.test.ts packages/website/src/lib/highlight.server.test.ts`
- `git diff --check`
- static output grep confirms old `onReadDocument(ctx, document, next)` / `onRunWorkflow(ctx, workflow, next)` strings are absent and the real signatures are present