### PR TITLE
feat: add terminal shell profiles and spawn commands

### DIFF
--- a/.changeset/terminal-invocation-settings.md
+++ b/.changeset/terminal-invocation-settings.md
@@ -1,0 +1,8 @@
+---
+'openspecui': minor
+'@openspecui/core': minor
+'@openspecui/server': minor
+'@openspecui/web': minor
+---
+
+Add terminal shell profiles and data-driven spawn commands with shared create-terminal flows.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp/
 .playwright-mcp/
 .chat/
 *.tgz
+codedb.snapshot
 
 # Example directory for E2E testing
 example/

--- a/CHAT.md
+++ b/CHAT.md
@@ -1044,3 +1044,51 @@ Terminal的字体选择器它应该是个 `Array<string>`+`Input|TextArea`，用
    3. 这里有两种做法：
       1. 一种是直接在所有接口添加统一的中间件来支持；
       2. 一种是不同的目录，使用不同的入口。比如我们默认的接口都是`/trpc`和`/ws/pty`，我们可以提供`/trpc?cwd=/path`和`/ws/pty?cwd=/path`
+
+---
+
+接下来我们将实现一些新的功能来满足 #98#99 这两个issues。
+
+1. #98，这是一个非常简单的功能，首先默认情况下，我们当然使用 env.SHELL (windows操作系统我不清楚，你来决定如何适配)。这个默认功能也会成为界面上配置的 Input的placeholder值。
+
+2. #99，这里我到想法和这个issue的提出者不一样，我认为，我们可以提供“快捷命令配置”，比如 `claude --dangerously-skip-permissions \$0`,这里 `\$0` 只是一个举例，意味着我可以往这里插入命令。我们可以内置一些快捷命令，比如claude/codex/gemini这类常用的。这样一来，我们在选择“发送到某个终端实例”的时候，既可以选择已经存在的终端，还可以快捷命令来创建一个新的终端，并将参数带到新的终端。
+
+3. 所以我们需要开发一个新组件：终端发送器。它是由一个Select和一组actions组成的卡片。
+   3.1. 在选中已经存在的终端的时候，那么Actions只有一个Send按钮。
+   3.2. 在选择通过预设的命令创建终端实例的时候，会根据配置来显示一些表单来满足参数的填入，然后最后 Actions 提供一个 Create 按钮。
+   3.3. 这里如何定义创建命令所需的参数？这里的本质是拼接字符串（或者字符串数组），然后将内容发送给终端。然后我们需要通过一些配置，来实现自动化的表单。对此有什么成熟的技术可以借鉴吗？
+
+你有什么问题或者建议吗？
+
+1.  spawn command 这个底层也是可以配置shell的，你不传递这个参数，它自己会有一个默认参数: [shell <boolean> | <string> If true, runs command inside of a shell. Uses '/bin/sh' on Unix, and process.env.ComSpec on Windows. A different shell can be specified as a string. See Shell requirements and Default Windows shell. Default: false (no shell).](https://nodejs.org/api/ child_process.html#child_processspawncommand-args-options)
+2.  `--dangerously-skip-permissions`到时候在ui上，就是一个toggle，打开就会启用。
+3.  我们整理一下，这里其实有两个东西，一个是配置shell，一个是配置command。我们运行配置多个shell，macOS/ Linux提供 [`/bin/sh`,SHELL]，window提供 [cmd,ps,bash(WSL)]，然后允许自定义添加，比如window用户可能需要添 加git-bash。用户可以管理这个数组，然后可以选择一个作为默认。
+4.  有了这个shell数组后，我们在配置command的时候，就可以配置它的shell是哪个，默认就是我们配置的shell。然 后还有，我们的TerminalPanel页面，点击“+”按钮，默认是打开一个默认shell，如果右键，那么会弹出一个菜单，会 显示两组menuItems，第一组就是配置好的shells，第二组就是commands，点击commands，会弹出一个Dialog，显示配 置表单，在这个表单中，我们可以配置参数，然后点击 `Create` 就可以创建一个新的终端实例
+5.  上面提到的表单，在我们的原本要解决的#99 这个问题中，可以在目标Dialog中，嵌入同样的组件。所以我的想法是，“终端发送器”这个要改一改，不用那么复杂，还是一个 Select+button(Send|Create) 即可。差别在于，如果选择 Create，那么会和 4 提到的交互一样，弹出一个新的 Dialog，而不是在原有的 Dialog 中再嵌套复杂的表单组件。所以可以叫做 TerminalSpawnCommandDialog，允许提供一些预设的参数来打开这个 Dialog，所以我们就可以把 command|compose 得出的要发给终端的内容，传递给 TerminalSpawnCommandDialog ，然后再点击 Create，就可以正式创建出 Terminal 实例。
+
+> PS: 当前目录还在做官网相关的开发，不影响你这个开发。
+
+---
+
+## implement `#100 Support for browser notifications when a terminal bell is fired`
+
+对于这个需求。我的想法是，我们在前端，实现一个 web-notifications 的功能（为了区分，我们将原生的 NotificationAPI，称为 browser-notifications）
+
+1. 渲染在 TopLayer（参考 Search），入口在底部`Watching for changes`这个位置，这里放一个🔔图标，如果有通知，通过角标来显示有新的通知。
+2. 原本的`Watching for changes`这个，在 hover 到`Live`这个文字的时候，通过 popover 来显示这个提示信息
+3. notifications的功能，就是订阅后端 notifications，收到消息后（一种结构化信息），如果和前端的某个页面有关，结构化信息也会根据前端的排布，点击进行动态跳转。比如#100提到的，TerminalPanel 的某个TerminalTab 的聚焦。
+4. 然后我们还要触发 browser-notifications（显示有几条新消息、最近的一条消息的概览），点击browser-Notification可以打开我们的 NotificationsPanel(TopLayer)
+   > 不要忘记调用 window.focus()。用户很多时候是把 WebUI 挂在后台，在看其他网页或写代码。点击系统原生通知时，首要任务是把 WebUI 所在的浏览器 Tab 切换到前台，然后再打开 NotificationsPanel 并高亮对应的 TerminalTab。
+5. web-notifications 基本和 browser-notifications 的接口设计一样（包括通知、进度控制等等能力），但是结构上会更安全，我们会通过 typescript 的类型推断来强化类型安全。我们之所以不直接用 browser-notifications，是因为部分情况下，browser-notifications不一定能用，比如说有些浏览器是嵌入在某些 app 内部的，所以如果 app 没有适配，那么就无法显示 browser-notifications，并且browser-notifications还存在权限问题。所以我们的设计上，browser-notifications只是一个统一的入口（可能公用一个 Notification-id）。真正要实现这个可靠的能力，还需要依靠 web-notifications
+6. 和 browser-notifications 类似，web-notifications 是阅后即焚，不需要持久化，我们只在后端内存中存储。
+   > 不在前端存储，是因为我们要跨终端实现同步：我在手机上读取了通知，在桌面端也可以同时焚烧。
+   > 通知可能很多，我们还需要提供一个一键清理的功能，或者在移动端提供滑动删除的功能（这里要有动画的支持，比如 1234，我删除 3，那么动画要平滑。）
+7. 我们会有列表动画的支持：关于新的 Notification 添加到 web-notifications，或者已读后自动溢移除的动画。
+8. 我们的 web-notifications 只是为了解决`OSC 9|777`的通知功能的绑定，对于#100需要的铃声绑定，这个不属于 web-Notifications的工作，而是前端的TerminalTab需要自己去适配。但是我对于提出这个issue 发起者的理解来说，他其实要的是`OSC 9|777`的通知功能的铃声功能。不过这里涉及到一个历史遗留问题，古老的终端会使用 bell声音来替代通知，所以如果发出了 bell 声音，我们可以在 web-notifications 中自动发起一条通知，比如`Terminal xxx has an Event.`
+9. 我们需要在 Settings 面板中，为 web-notifications 提供一些基础的设置，目前可以配置有两个：
+   9.1. `Notification Sound`：需要你上网搜罗一些常见的操作系统通知声音的资源，或者你找一下 cmux 这个开源项目，源代码中是不是也有一些声音资源，我们需要做一个Popover选择器，可以直接在下拉选择器中进行点击播放按钮播放声音，或者悬停一会儿也播放。或者简单一点，使用原生的 Select，然后在旁边放一个播放按钮，点击播放即可。当然，也可以选择静音。
+   9.2. `Enable System Notifications`: 申请操作系统级别的通知，这里也能知道，浏览器有没有权限或者有没有适配 browser-notifications
+10. 因为我们的 Settings 面板越来越复杂，我们需要将项目的 ToC 组件给这个页面使用，从而实现便捷的导航。
+11. 浏览器对于播放音频的自动播放策略，onBell、onNotification 都是需要我们主动播放声音的，你要么就找到一个专业的音频播放库，要么就是手动监听用户的第一次全局点击交互(`onpointerdown`)默默播放一个 0.1 秒的静音音频，从而解锁当前的 AudioContext。
+12. 我们需要根据元数据进行分组，比如某一个终端同时发出了 100 条数据，我们 web-notifications 渲染出来的效果是类似于 iOS 的通知分组功能：同一个应用的通知是规划成一组，需要手动展开才能查看全部，滑动删除可以直接删除一整组。同理，我们的 web-notifications 是强类型安全的结构化，所以通知可能来自某个 Terminal、来自某个 OpenspecChange、来自某个 HooksPlugin，所以理论上是可以实现安全可靠的分组。这能有效避免 web-notifications 面板爆炸
+13. 如果我们点击的 Notification的跳转，发现对应的实例已经被销毁了，比如 Terminal 被 killed，或者 OpenspecChange 被 archive，那么在跳转之前要能预判，直接将跳转按钮进行禁用。

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/.openspec.yaml
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-05-12

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/checkpoints.md
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/checkpoints.md
@@ -1,0 +1,12 @@
+## Checklist
+
+- [x] 1. Define terminal shell profile and spawn command schemas.
+- [x] 2. Add platform default shell profile resolution and expose effective defaults to the frontend.
+- [x] 3. Add local/user configuration persistence for shell profiles, default shell selection, and command presets.
+- [x] 4. Update terminal session creation to accept selected shell profile and command preset invocations through the terminal platform path.
+- [x] 5. Implement `TerminalSpawnCommandDialog` with typed fields, boolean toggles, preset values, and `Create`.
+- [x] 6. Update Terminal Panel `+` to create the default shell and right-click menu to show shells and commands.
+- [x] 7. Update send-to-terminal target flows to support existing-session `Send` and create-target `Create` via the shared dialog.
+- [x] 8. Add built-in Claude, Codex, and Gemini command presets as data, with dangerous flags exposed only as explicit toggles.
+- [x] 9. Add focused unit/component tests for defaults, schema rendering, sender behavior, and dialog behavior.
+- [x] 10. Run local verification gates and record results before PR.

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/implementation.md
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/implementation.md
@@ -1,0 +1,17 @@
+## Implementation Notes
+
+No implementation has been performed yet. This artifact records the approved architecture boundary before code changes.
+
+## Key Decisions
+
+- Shell configuration and command configuration are separate platform atoms.
+- `TerminalSpawnCommandDialog` is the shared command-form UI. It should be opened from terminal creation menus and send-target creation flows rather than embedded as a nested complex form.
+- Dangerous command flags, such as Claude `--dangerously-skip-permissions`, must be explicit UI toggles.
+- Built-in agent command presets are data. The terminal platform must not branch on specific agent names.
+- The persisted custom executable configuration should default to a local user preference layer, not project `.openspecui.json`.
+
+## Loopback Triggers
+
+- If implementation requires executable project config by default, return to research-plan for approval.
+- If command rendering requires shell-line interpolation of arbitrary user input, return to design for a safer invocation model.
+- If terminal session creation needs a new backend lifecycle beyond PTY manager options, return to research-plan before changing server boundaries.

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/intake.md
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/intake.md
@@ -1,0 +1,36 @@
+## User Input
+
+The manager wants OpenSpecUI to satisfy GitHub issues #98 and #99 with terminal-centered platform features:
+
+- For #98, OpenSpecUI should support configurable shells. By default, macOS/Linux should offer `/bin/sh` and the user's `SHELL`, Windows should offer `cmd`, PowerShell, and WSL bash where applicable, and users should be able to add custom shell entries such as Git Bash. Users should manage this shell array and choose one default shell.
+- For #99, OpenSpecUI should provide configurable shortcut commands. Built-in examples include Claude, Codex, and Gemini. Commands may expose UI fields and toggles, such as a `--dangerously-skip-permissions` toggle for Claude.
+- The terminal panel `+` button should create a default-shell terminal. Right-clicking the `+` button should open a menu with two groups: configured shells and configured commands.
+- Choosing a shell should directly create a terminal instance for that shell.
+- Choosing a command should open a `TerminalSpawnCommandDialog` that renders the command's configuration form, lets the user fill parameters, and creates the terminal after `Create`.
+- The same `TerminalSpawnCommandDialog` should be reusable from #99 target-selection flows. The target sender itself should stay simple: a `Select` plus one `Send` or `Create` button. If the user selects `Create`, it should open `TerminalSpawnCommandDialog` with preset values such as the command/compose payload to send to the terminal.
+
+## Objective Scope
+
+- Add a terminal shell profile model that separates configured shells from command presets.
+- Add terminal spawn command presets with schema-driven fields and explicit rendering into terminal creation/write behavior.
+- Add UI affordances for terminal creation from shell profiles and spawn commands.
+- Add a reusable `TerminalSpawnCommandDialog` that can be launched from both Terminal Panel creation and target-selection flows.
+- Keep #98 and #99 behavior as terminal platform capabilities rather than OPSX- or agent-specific page logic.
+
+## Non-Goals
+
+- Do not implement a generic plugin bus or broad agent orchestration framework.
+- Do not hard-code Claude, Codex, or Gemini behavior into the terminal platform layer.
+- Do not persist unsafe executable command configuration into project files by default.
+- Do not replace the current PTY session lifecycle or terminal renderer architecture.
+- Do not implement #103 markdown preprocessing or translation hooks in this change.
+
+## Acceptance Boundary
+
+- Users can configure multiple shell profiles and choose a default shell.
+- The default shell placeholder reflects the effective platform default without persisting a duplicate default value.
+- Terminal Panel `+` creates a terminal using the configured default shell.
+- Terminal Panel right-click menu can create terminals from shell profiles or open command preset creation dialogs.
+- Command presets can render forms, including boolean toggles, and create terminals with the generated invocation.
+- Existing send-to-terminal flows can choose an existing terminal or choose creation via the shared spawn dialog.
+- Built-in command presets remain configurable atoms, with dangerous flags exposed only through explicit toggles.

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/research-plan.md
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/loop/research-plan.md
@@ -1,0 +1,47 @@
+## Research Findings
+
+- The server already resolves PTY defaults in `packages/server/src/pty-manager.ts`: Windows uses `ComSpec` or `cmd.exe`; other platforms use `SHELL` or `/bin/sh`.
+- The current terminal context exposes `createSession` and `createDedicatedSession`, so new creation flows can build on the existing PTY lifecycle instead of replacing it.
+- The current Quick Propose route sends prepared payloads only to existing live terminals. Its target model is page-local and can be generalized behind a terminal sender primitive.
+- The terminal settings config is currently synced from `.openspecui.json` into `terminalController.applyConfig`, but shell paths and command presets are user-machine execution preferences and should not be treated as project truth by default.
+- Node `child_process.spawn` supports a `shell` option, but OpenSpecUI's interactive terminal creation currently uses node-pty. The user-facing model should therefore be named shell profiles and spawn commands, not Node child_process options.
+- VS Code task/input-style variable substitution is the closest mature precedent for command presets with user-provided inputs. JSON Schema form ideas are useful for rendering fields, but command rendering needs its own typed invocation model.
+
+## Decision & Plan (for approval)
+
+Implement a platform-level terminal invocation model with two orthogonal atoms:
+
+- Shell profiles: named, selectable interactive shell definitions with platform-aware built-ins and user-managed custom entries.
+- Spawn commands: named command presets with typed fields, optional shell profile selection, and explicit invocation rendering.
+
+Preferred architecture:
+
+1. Add shared type/schema definitions for terminal shell profiles, spawn commands, command fields, and rendered invocations.
+2. Add configuration read/write support for shell profile arrays, default shell selection, and command presets.
+3. Expose effective platform defaults to the frontend so placeholders reflect the real default without persisting it.
+4. Update terminal creation APIs so sessions can be created from shell profiles and command presets through a single platform path.
+5. Add `TerminalSpawnCommandDialog` as the reusable UI for spawn command forms.
+6. Keep the target sender small: existing terminal target sends immediately; create target launches the shared spawn dialog with preset values.
+7. Add Terminal Panel `+` default-shell behavior and right-click menu grouping shells and commands.
+
+## Risks and Mitigations
+
+- Risk: Shell and command presets could become project-level executable configuration with supply-chain risk.
+  Mitigation: Default to local user configuration for custom executable entries; project config should not be the default persistence layer for user command paths.
+- Risk: String template rendering may introduce shell injection behavior.
+  Mitigation: Prefer typed `argv`/`stdin` invocation models. Any shell-line template must be explicit and documented as shell-evaluated.
+- Risk: Built-in agent presets could pollute terminal platform logic.
+  Mitigation: Treat Claude/Codex/Gemini as preset data only. The platform consumes schema and invocation definitions, not agent-specific branches.
+- Risk: The dialog may become a complex nested form inside existing OPSX dialogs.
+  Mitigation: Launch `TerminalSpawnCommandDialog` as a separate dialog and pass preset values into it.
+- Risk: Windows shell discovery and WSL availability may vary by machine.
+  Mitigation: Provide conservative built-ins and validate availability before showing or before creation with actionable errors.
+
+## Verification Strategy
+
+- Unit-test shell profile default resolution for macOS/Linux/Windows inputs.
+- Unit-test spawn command field rendering into typed invocation payloads without `any` or unsafe casts.
+- Unit-test terminal sender target behavior for existing-session send and create-dialog launch.
+- Component-test `TerminalSpawnCommandDialog` with built-in Claude/Codex/Gemini-style presets and preset payload values.
+- Browser-test Terminal Panel `+` and right-click menu behavior after implementation.
+- Run scoped CI gates for touched packages, including format, lint, typecheck, and relevant web tests.

--- a/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/specs/opsx-terminal-panel/spec.md
+++ b/openspec/changes/add-terminal-shell-profiles-and-spawn-commands/specs/opsx-terminal-panel/spec.md
@@ -1,0 +1,110 @@
+# Delta for opsx-terminal-panel
+
+## ADDED Requirements
+
+### Requirement: Configurable Shell Profiles
+
+The terminal panel SHALL support platform-aware shell profiles that users can manage and select as the default terminal shell.
+
+#### Scenario: Resolve platform shell defaults
+
+- **GIVEN** no user shell profile has been selected as default
+- **WHEN** OpenSpecUI resolves terminal shell options
+- **THEN** macOS and Linux SHALL offer `/bin/sh` and the current environment `SHELL` when available
+- **AND** Windows SHALL offer `cmd`, PowerShell, and WSL bash when available
+- **AND** OpenSpecUI SHALL expose the effective platform default as UI placeholder text without persisting that value as a duplicate override
+
+#### Scenario: Manage shell profiles
+
+- **GIVEN** the user opens terminal shell settings
+- **WHEN** the user adds, edits, removes, or selects a shell profile
+- **THEN** OpenSpecUI SHALL persist the user-managed shell profile list
+- **AND** SHALL persist the selected default shell profile
+- **AND** built-in shell profiles SHALL remain distinguishable from custom shell profiles
+
+#### Scenario: Create default shell terminal
+
+- **GIVEN** terminal shell profiles are configured
+- **WHEN** the user activates the Terminal Panel `+` button
+- **THEN** OpenSpecUI SHALL create a terminal instance using the selected default shell profile
+- **AND** SHALL fall back to the effective platform default when no user default is configured
+
+### Requirement: Configurable Spawn Commands
+
+The terminal panel SHALL support named spawn command presets that render typed forms and create terminal instances through the terminal platform.
+
+#### Scenario: Configure command preset shell
+
+- **GIVEN** a spawn command preset exists
+- **WHEN** OpenSpecUI creates a terminal from that preset
+- **THEN** the preset SHALL run using its selected shell profile
+- **AND** SHALL use the configured default shell profile when the preset does not select a shell profile
+
+#### Scenario: Render command form from schema-backed parameters
+
+- **GIVEN** a spawn command preset declares JSON-schema-compatible parameters
+- **WHEN** the user chooses that command
+- **THEN** OpenSpecUI SHALL open `TerminalSpawnCommandDialog`
+- **AND** the dialog SHALL render controls for the declared parameter schema
+- **AND** boolean command flags SHALL render as toggles
+- **AND** the dialog SHALL render `Create` as the terminal creation action
+
+#### Scenario: Compose command output from a builder
+
+- **GIVEN** a spawn command preset declares parameters and a builder
+- **WHEN** OpenSpecUI renders the command for terminal creation
+- **THEN** the builder SHALL compose either a shell command line or an argv-style string array
+- **AND** OpenSpecUI SHALL NOT execute user-provided JavaScript to compose the command
+- **AND** OpenSpecUI SHALL quote argv-style parts according to the selected shell profile
+
+#### Scenario: Built-in agent command presets
+
+- **GIVEN** built-in command presets are available
+- **WHEN** the user opens command creation options
+- **THEN** OpenSpecUI SHALL offer presets for common agents such as Claude, Codex, and Gemini as data-driven command presets
+- **AND** SHALL NOT hard-code those agent names into terminal platform branching logic
+- **AND** dangerous flags such as Claude `--dangerously-skip-permissions` SHALL be disabled unless explicitly enabled by the user through a toggle
+
+### Requirement: Terminal Creation Menu
+
+The terminal panel SHALL expose terminal creation choices without coupling shell creation and command creation.
+
+#### Scenario: Terminal creation options menu
+
+- **GIVEN** shell profiles and spawn commands are configured
+- **WHEN** the user activates the `↓` icon-button beside the Terminal Panel `+` button
+- **THEN** OpenSpecUI SHALL show one menu group for shell profiles
+- **AND** SHALL show a separate menu group for spawn commands
+
+#### Scenario: Create from shell menu item
+
+- **GIVEN** the creation menu is open
+- **WHEN** the user selects a shell profile
+- **THEN** OpenSpecUI SHALL create a terminal instance for that shell profile immediately
+
+#### Scenario: Create from command menu item
+
+- **GIVEN** the creation menu is open
+- **WHEN** the user selects a spawn command
+- **THEN** OpenSpecUI SHALL open `TerminalSpawnCommandDialog` for that command
+- **AND** SHALL create the terminal only after the user confirms `Create`
+
+### Requirement: Reusable Terminal Spawn Dialog
+
+OpenSpecUI SHALL reuse `TerminalSpawnCommandDialog` for command-based terminal creation from both terminal menus and send-to-terminal flows.
+
+#### Scenario: Launch dialog with preset payload values
+
+- **GIVEN** a workflow has prepared content to send to a terminal
+- **WHEN** the user chooses to create a new terminal target
+- **THEN** OpenSpecUI SHALL launch `TerminalSpawnCommandDialog`
+- **AND** SHALL pass the prepared content as preset field values where the selected command supports it
+- **AND** SHALL create the terminal only after the user confirms `Create`
+
+#### Scenario: Simple terminal sender actions
+
+- **GIVEN** a terminal sender is displayed
+- **WHEN** the selected target is an existing live terminal
+- **THEN** the sender SHALL show a `Send` action that writes the prepared content to that terminal
+- **WHEN** the selected target is command-based creation
+- **THEN** the sender SHALL show a `Create` action that opens `TerminalSpawnCommandDialog`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,14 +29,18 @@
     "./terminal-theme": {
       "import": "./dist/terminal-theme.mjs",
       "types": "./dist/terminal-theme.d.mts"
+    },
+    "./terminal-invocation": {
+      "import": "./dist/terminal-invocation.mjs",
+      "types": "./dist/terminal-invocation.d.mts"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts src/terminal-theme.ts --format esm --dts",
-    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts src/terminal-theme.ts --format esm --dts --watch",
+    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts src/terminal-theme.ts src/terminal-invocation.ts --format esm --dts",
+    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/hosted-app.ts src/openspec-compat.ts src/terminal-theme.ts src/terminal-invocation.ts --format esm --dts --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -224,6 +224,30 @@ export {
 export { VIRTUAL_PROJECT_DIRNAME, toOpsxDisplayPath } from './opsx-display-path.js'
 export { type ProjectRecoveryStatus } from './runtime-types.js'
 export {
+  BUILTIN_TERMINAL_SPAWN_COMMANDS,
+  TERMINAL_COMMAND_FIELD_TYPE_VALUES,
+  TERMINAL_SHELL_QUOTE_STYLE_VALUES,
+  TerminalCommandFieldSchema,
+  TerminalInvocationSettingsSchema,
+  TerminalShellProfileSchema,
+  TerminalShellQuoteStyleSchema,
+  TerminalSpawnCommandSchema,
+  getTerminalCommandDefaultValues,
+  quoteTerminalShellArg,
+  renderTerminalCommandArgs,
+  renderTerminalSpawnCommandLine,
+  resolveTerminalShellDefaults,
+  type TerminalCommandArgument,
+  type TerminalCommandField,
+  type TerminalCommandFieldValue,
+  type TerminalCommandFieldValues,
+  type TerminalInvocationSettings,
+  type TerminalShellDefaults,
+  type TerminalShellProfile,
+  type TerminalShellQuoteStyle,
+  type TerminalSpawnCommand,
+} from './terminal-invocation.js'
+export {
   DEFAULT_TERMINAL_DARK_THEME,
   DEFAULT_TERMINAL_LIGHT_THEME,
   DEFAULT_TERMINAL_THEME_MODE,

--- a/packages/core/src/terminal-invocation.test.ts
+++ b/packages/core/src/terminal-invocation.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BUILTIN_TERMINAL_SPAWN_COMMANDS,
+  fieldsToTerminalCommandParameters,
+  getTerminalCommandDefaultValues,
+  renderTerminalCommandArgs,
+  renderTerminalSpawnCommand,
+  renderTerminalSpawnCommandLine,
+  resolveTerminalShellDefaults,
+  type TerminalSpawnCommand,
+} from './terminal-invocation.js'
+
+describe('resolveTerminalShellDefaults', () => {
+  it('uses SHELL as effective default and keeps /bin/sh as a builtin on unix-like platforms', () => {
+    const defaults = resolveTerminalShellDefaults({
+      platform: 'macos',
+      env: { SHELL: '/bin/zsh' },
+    })
+
+    expect(defaults.effectiveDefaultShell.command).toBe('/bin/zsh')
+    expect(defaults.builtinShellProfiles.map((profile) => profile.command)).toEqual([
+      '/bin/sh',
+      '/bin/zsh',
+    ])
+  })
+
+  it('falls back to /bin/sh when SHELL is unavailable', () => {
+    const defaults = resolveTerminalShellDefaults({
+      platform: 'common',
+      env: {},
+    })
+
+    expect(defaults.effectiveDefaultShell).toMatchObject({
+      id: 'builtin:sh',
+      command: '/bin/sh',
+    })
+  })
+
+  it('does not require a Node process global when env is omitted', () => {
+    const processDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'process')
+    try {
+      Reflect.deleteProperty(globalThis, 'process')
+
+      const defaults = resolveTerminalShellDefaults({
+        platform: 'common',
+      })
+
+      expect(defaults.effectiveDefaultShell).toMatchObject({
+        id: 'builtin:sh',
+        command: '/bin/sh',
+      })
+    } finally {
+      if (processDescriptor) {
+        Object.defineProperty(globalThis, 'process', processDescriptor)
+      }
+    }
+  })
+
+  it('uses ComSpec as the Windows cmd profile and offers PowerShell plus WSL bash', () => {
+    const defaults = resolveTerminalShellDefaults({
+      platform: 'windows',
+      env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    })
+
+    expect(defaults.effectiveDefaultShell.command).toBe('C:\\Windows\\System32\\cmd.exe')
+    expect(defaults.builtinShellProfiles.map((profile) => profile.id)).toEqual([
+      'builtin:cmd',
+      'builtin:powershell',
+      'builtin:wsl-bash',
+    ])
+  })
+})
+
+describe('terminal spawn commands', () => {
+  it('keeps Claude unsafe permission flag disabled by default', () => {
+    const claude = BUILTIN_TERMINAL_SPAWN_COMMANDS.find(
+      (command) => command.id === 'builtin:claude'
+    )
+    expect(claude).toBeDefined()
+    if (!claude) return
+
+    const values = getTerminalCommandDefaultValues(claude, { prompt: 'hello' })
+
+    expect(values.dangerouslySkipPermissions).toBe(false)
+    expect(renderTerminalCommandArgs(claude, values)).toEqual(['hello'])
+  })
+
+  it('renders boolean flags only when explicitly enabled', () => {
+    const claude = BUILTIN_TERMINAL_SPAWN_COMMANDS.find(
+      (command) => command.id === 'builtin:claude'
+    )
+    expect(claude).toBeDefined()
+    if (!claude) return
+
+    const values = getTerminalCommandDefaultValues(claude, {
+      prompt: 'do work',
+      dangerouslySkipPermissions: true,
+    })
+
+    expect(renderTerminalCommandArgs(claude, values)).toEqual([
+      '--dangerously-skip-permissions',
+      'do work',
+    ])
+  })
+
+  it('marks built-in risky and lower-frequency command fields as advanced', () => {
+    const commands = Object.fromEntries(
+      BUILTIN_TERMINAL_SPAWN_COMMANDS.map((command) => [command.id, command])
+    )
+
+    expect(
+      commands['builtin:claude']?.fields.find((field) => field.id === 'dangerouslySkipPermissions')
+    ).toMatchObject({ advanced: true })
+    expect(
+      commands['builtin:codex']?.fields.find(
+        (field) => field.id === 'dangerouslyBypassApprovalsAndSandbox'
+      )
+    ).toMatchObject({ advanced: true })
+    expect(commands['builtin:gemini']?.fields.find((field) => field.id === 'yolo')).toMatchObject({
+      advanced: true,
+    })
+  })
+
+  it('renders common Codex options and keeps dangerous bypass disabled by default', () => {
+    const codex = BUILTIN_TERMINAL_SPAWN_COMMANDS.find((command) => command.id === 'builtin:codex')
+    expect(codex).toBeDefined()
+    if (!codex) return
+
+    const defaults = getTerminalCommandDefaultValues(codex, {
+      prompt: 'build feature',
+      model: 'gpt-5.5',
+      sandbox: 'workspace-write',
+      approvalPolicy: 'on-request',
+      search: true,
+    })
+
+    expect(defaults.dangerouslyBypassApprovalsAndSandbox).toBe(false)
+    expect(renderTerminalSpawnCommand({ command: codex, values: defaults })).toEqual({
+      kind: 'argv',
+      argv: [
+        'codex',
+        '--model=gpt-5.5',
+        '--sandbox=workspace-write',
+        '--ask-for-approval=on-request',
+        '--search',
+        'build feature',
+      ],
+    })
+  })
+
+  it('renders common Gemini options and keeps yolo disabled by default', () => {
+    const gemini = BUILTIN_TERMINAL_SPAWN_COMMANDS.find(
+      (command) => command.id === 'builtin:gemini'
+    )
+    expect(gemini).toBeDefined()
+    if (!gemini) return
+
+    const defaults = getTerminalCommandDefaultValues(gemini, {
+      prompt: 'inspect app',
+      model: 'gemini-pro',
+      approvalMode: 'auto_edit',
+      sandbox: true,
+    })
+
+    expect(defaults.yolo).toBe(false)
+    expect(renderTerminalSpawnCommand({ command: gemini, values: defaults })).toEqual({
+      kind: 'argv',
+      argv: [
+        'gemini',
+        '--model=gemini-pro',
+        '--approval-mode=auto_edit',
+        '--sandbox',
+        'inspect app',
+      ],
+    })
+  })
+
+  it('quotes rendered shell lines according to shell profile quote style', () => {
+    const codex = BUILTIN_TERMINAL_SPAWN_COMMANDS.find((command) => command.id === 'builtin:codex')
+    expect(codex).toBeDefined()
+    if (!codex) return
+
+    const values = getTerminalCommandDefaultValues(codex, {
+      prompt: "write 'safe' code",
+    })
+
+    expect(
+      renderTerminalSpawnCommandLine({
+        command: codex,
+        values,
+        quoteStyle: 'posix',
+      })
+    ).toBe("codex 'write '\\''safe'\\'' code'")
+  })
+
+  it('renders argv builders from JSON-schema parameters', () => {
+    const command: TerminalSpawnCommand = {
+      id: 'custom:test',
+      label: 'Test',
+      command: 'runner',
+      args: [],
+      fields: [
+        {
+          id: 'mode',
+          label: 'Mode',
+          type: 'select',
+          options: ['fast', 'safe'],
+          defaultValue: 'fast',
+          required: false,
+        },
+      ],
+      parameters: fieldsToTerminalCommandParameters([
+        {
+          id: 'mode',
+          label: 'Mode',
+          type: 'select',
+          options: ['fast', 'safe'],
+          defaultValue: 'fast',
+          required: false,
+        },
+      ]),
+      builder: {
+        kind: 'argv',
+        parts: [
+          { kind: 'literal', value: 'runner' },
+          { kind: 'field', fieldId: 'mode', prefix: '--mode=', omitWhenEmpty: true },
+        ],
+      },
+      source: 'custom',
+    }
+
+    const values = getTerminalCommandDefaultValues(command)
+
+    expect(renderTerminalSpawnCommand({ command, values })).toEqual({
+      kind: 'argv',
+      argv: ['runner', '--mode=fast'],
+    })
+  })
+
+  it('renders shellLine builders without argv quoting', () => {
+    const command: TerminalSpawnCommand = {
+      id: 'custom:shell-line',
+      label: 'Shell Line',
+      command: 'echo',
+      args: [],
+      fields: [
+        {
+          id: 'payload',
+          label: 'Payload',
+          type: 'text',
+          options: [],
+          defaultValue: 'hello world',
+          required: false,
+        },
+      ],
+      parameters: fieldsToTerminalCommandParameters([
+        {
+          id: 'payload',
+          label: 'Payload',
+          type: 'text',
+          options: [],
+          defaultValue: 'hello world',
+          required: false,
+        },
+      ]),
+      builder: {
+        kind: 'shellLine',
+        template: 'echo {{payload}}',
+      },
+      source: 'custom',
+    }
+
+    expect(
+      renderTerminalSpawnCommandLine({
+        command,
+        values: getTerminalCommandDefaultValues(command),
+        quoteStyle: 'posix',
+      })
+    ).toBe('echo hello world')
+  })
+})

--- a/packages/core/src/terminal-invocation.ts
+++ b/packages/core/src/terminal-invocation.ts
@@ -1,0 +1,1110 @@
+import { z } from 'zod'
+import type { PtyPlatform } from './pty-protocol.js'
+
+export interface TerminalShellEnv {
+  SHELL?: string
+  ComSpec?: string
+}
+
+export const TERMINAL_SHELL_QUOTE_STYLE_VALUES = ['posix', 'cmd', 'powershell'] as const
+export const TERMINAL_COMMAND_FIELD_TYPE_VALUES = ['text', 'textarea', 'boolean', 'select'] as const
+
+export const TerminalShellQuoteStyleSchema = z.enum(TERMINAL_SHELL_QUOTE_STYLE_VALUES)
+export type TerminalShellQuoteStyle = z.infer<typeof TerminalShellQuoteStyleSchema>
+
+export const TerminalShellProfileSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  source: z.enum(['builtin', 'custom']).default('custom'),
+  quoteStyle: TerminalShellQuoteStyleSchema.default('posix'),
+})
+export type TerminalShellProfile = z.infer<typeof TerminalShellProfileSchema>
+
+export const TerminalCommandFieldSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  type: z.enum(TERMINAL_COMMAND_FIELD_TYPE_VALUES),
+  description: z.string().optional(),
+  placeholder: z.string().optional(),
+  defaultValue: z.union([z.string(), z.boolean()]).optional(),
+  options: z.array(z.string()).default([]),
+  required: z.boolean().default(false),
+  advanced: z.boolean().default(false),
+})
+export type TerminalCommandField = z.infer<typeof TerminalCommandFieldSchema>
+
+type TerminalCommandFieldInput = Omit<TerminalCommandField, 'advanced' | 'options' | 'required'> &
+  Partial<Pick<TerminalCommandField, 'advanced' | 'options' | 'required'>>
+
+function defineTerminalCommandField(field: TerminalCommandFieldInput): TerminalCommandField {
+  return {
+    ...field,
+    options: field.options ?? [],
+    required: field.required ?? false,
+    advanced: field.advanced ?? false,
+  }
+}
+
+function defineTerminalSpawnCommand(
+  command: Omit<TerminalSpawnCommand, 'parameters' | 'source'> & {
+    source?: TerminalSpawnCommand['source']
+  }
+): TerminalSpawnCommand {
+  return {
+    ...command,
+    parameters: fieldsToTerminalCommandParameters(command.fields),
+    source: command.source ?? 'builtin',
+  }
+}
+
+const TerminalCommandArgumentSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('literal'),
+    value: z.string(),
+  }),
+  z.object({
+    kind: z.literal('field'),
+    fieldId: z.string().min(1),
+    prefix: z.string().default(''),
+    omitWhenEmpty: z.boolean().default(true),
+  }),
+  z.object({
+    kind: z.literal('booleanFlag'),
+    fieldId: z.string().min(1),
+    flag: z.string().min(1),
+  }),
+])
+export type TerminalCommandArgument = z.infer<typeof TerminalCommandArgumentSchema>
+
+const TerminalCommandJsonSchemaPropertySchema = z.object({
+  type: z.enum(['string', 'boolean']).default('string'),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  default: z.union([z.string(), z.boolean()]).optional(),
+  enum: z.array(z.string()).optional(),
+})
+export type TerminalCommandJsonSchemaProperty = z.infer<
+  typeof TerminalCommandJsonSchemaPropertySchema
+>
+
+const TerminalCommandJsonSchemaSchema = z.object({
+  type: z.literal('object'),
+  properties: z.record(TerminalCommandJsonSchemaPropertySchema).default({}),
+  required: z.array(z.string()).default([]),
+})
+export type TerminalCommandJsonSchema = z.infer<typeof TerminalCommandJsonSchemaSchema>
+
+const TerminalCommandParametersSchema = z.object({
+  schema: TerminalCommandJsonSchemaSchema,
+  uiSchema: z.record(z.unknown()).default({}),
+})
+export type TerminalCommandParameters = z.infer<typeof TerminalCommandParametersSchema>
+
+const TerminalCommandBuilderPartSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('literal'),
+    value: z.string(),
+  }),
+  z.object({
+    kind: z.literal('field'),
+    fieldId: z.string().min(1),
+    prefix: z.string().default(''),
+    omitWhenEmpty: z.boolean().default(true),
+  }),
+  z.object({
+    kind: z.literal('booleanFlag'),
+    fieldId: z.string().min(1),
+    flag: z.string().min(1),
+  }),
+])
+export type TerminalCommandBuilderPart = z.infer<typeof TerminalCommandBuilderPartSchema>
+
+const TerminalCommandBuilderSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('argv'),
+    parts: z.array(TerminalCommandBuilderPartSchema).default([]),
+  }),
+  z.object({
+    kind: z.literal('shellLine'),
+    template: z.string().default(''),
+  }),
+])
+export type TerminalCommandBuilder = z.infer<typeof TerminalCommandBuilderSchema>
+
+export const TerminalSpawnCommandSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().optional(),
+  command: z.string().min(1),
+  args: z.array(TerminalCommandArgumentSchema).default([]),
+  fields: z.array(TerminalCommandFieldSchema).default([]),
+  parameters: TerminalCommandParametersSchema.optional(),
+  builder: TerminalCommandBuilderSchema.optional(),
+  shellProfileId: z.string().optional(),
+  source: z.enum(['builtin', 'custom']).default('custom'),
+})
+export type TerminalSpawnCommand = z.infer<typeof TerminalSpawnCommandSchema>
+
+export const TerminalInvocationSettingsSchema = z.object({
+  defaultShellProfileId: z.string().optional(),
+  customShellProfiles: z.array(TerminalShellProfileSchema).default([]),
+  customSpawnCommands: z.array(TerminalSpawnCommandSchema).default([]),
+})
+export type TerminalInvocationSettings = z.infer<typeof TerminalInvocationSettingsSchema>
+
+export type TerminalCommandFieldValue = string | boolean
+export type TerminalCommandFieldValues = Record<string, TerminalCommandFieldValue>
+export type TerminalCommandRenderResult =
+  | { kind: 'argv'; argv: string[] }
+  | { kind: 'shellLine'; commandLine: string }
+
+export interface TerminalShellDefaults {
+  platform: PtyPlatform
+  effectiveDefaultShell: TerminalShellProfile
+  builtinShellProfiles: TerminalShellProfile[]
+}
+
+function uniqueById<T extends { id: string }>(items: readonly T[]): T[] {
+  const seen = new Set<string>()
+  const result: T[] = []
+  for (const item of items) {
+    if (seen.has(item.id)) continue
+    seen.add(item.id)
+    result.push(item)
+  }
+  return result
+}
+
+function normalizeShellPath(input: string | undefined): string {
+  return input?.trim() || ''
+}
+
+function getAmbientTerminalShellEnv(): TerminalShellEnv {
+  if (typeof process === 'undefined') return {}
+  return {
+    SHELL: process.env.SHELL,
+    ComSpec: process.env.ComSpec,
+  }
+}
+
+export function resolveTerminalShellDefaults(options: {
+  platform: PtyPlatform
+  env?: TerminalShellEnv
+}): TerminalShellDefaults {
+  const env = options.env ?? getAmbientTerminalShellEnv()
+
+  if (options.platform === 'windows') {
+    const cmd = normalizeShellPath(env.ComSpec) || 'cmd.exe'
+    const builtinShellProfiles: TerminalShellProfile[] = [
+      {
+        id: 'builtin:cmd',
+        label: 'Command Prompt',
+        command: cmd,
+        args: [],
+        source: 'builtin',
+        quoteStyle: 'cmd',
+      },
+      {
+        id: 'builtin:powershell',
+        label: 'PowerShell',
+        command: 'powershell.exe',
+        args: [],
+        source: 'builtin',
+        quoteStyle: 'powershell',
+      },
+      {
+        id: 'builtin:wsl-bash',
+        label: 'WSL Bash',
+        command: 'wsl.exe',
+        args: ['bash'],
+        source: 'builtin',
+        quoteStyle: 'posix',
+      },
+    ]
+    return {
+      platform: options.platform,
+      effectiveDefaultShell: builtinShellProfiles[0]!,
+      builtinShellProfiles,
+    }
+  }
+
+  const envShell = normalizeShellPath(env.SHELL)
+  const fallbackShell: TerminalShellProfile = {
+    id: 'builtin:sh',
+    label: '/bin/sh',
+    command: '/bin/sh',
+    args: [],
+    source: 'builtin',
+    quoteStyle: 'posix',
+  }
+  const builtinShellProfiles = uniqueById<TerminalShellProfile>([
+    fallbackShell,
+    ...(envShell && envShell !== fallbackShell.command
+      ? [
+          {
+            id: 'builtin:env-shell',
+            label: `SHELL (${envShell})`,
+            command: envShell,
+            args: [],
+            source: 'builtin' as const,
+            quoteStyle: 'posix' as const,
+          },
+        ]
+      : []),
+  ])
+
+  return {
+    platform: options.platform,
+    effectiveDefaultShell:
+      builtinShellProfiles.find((profile) => profile.id === 'builtin:env-shell') ?? fallbackShell,
+    builtinShellProfiles,
+  }
+}
+
+const CLAUDE_COMMAND_FIELDS = [
+  defineTerminalCommandField({
+    id: 'prompt',
+    label: 'Prompt',
+    type: 'textarea',
+    description: 'Initial prompt to send to Claude.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'model',
+    label: 'Model',
+    type: 'text',
+    description: 'Claude model alias or full model name.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'permissionMode',
+    label: 'Permission mode',
+    type: 'select',
+    description: 'Permission mode for this session.',
+    defaultValue: '',
+    options: ['', 'default', 'acceptEdits', 'auto', 'dontAsk', 'plan', 'bypassPermissions'],
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'effort',
+    label: 'Effort',
+    type: 'select',
+    description: 'Reasoning effort for the current session.',
+    defaultValue: '',
+    options: ['', 'low', 'medium', 'high', 'xhigh', 'max'],
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'continueLatest',
+    label: 'Continue latest',
+    type: 'boolean',
+    description: 'Continue the most recent conversation in the current directory.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'resumeSession',
+    label: 'Resume session',
+    type: 'text',
+    description: 'Resume a conversation by session ID or picker search term.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'name',
+    label: 'Session name',
+    type: 'text',
+    description: 'Display name for the Claude session.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'addDir',
+    label: 'Additional dirs',
+    type: 'text',
+    description: 'Additional directories to allow tool access to.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'appendSystemPrompt',
+    label: 'Append system prompt',
+    type: 'textarea',
+    description: 'Text appended to the default system prompt.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'allowedTools',
+    label: 'Allowed tools',
+    type: 'text',
+    description: 'Comma or space-separated tool allowlist.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'disallowedTools',
+    label: 'Disallowed tools',
+    type: 'text',
+    description: 'Comma or space-separated tool denylist.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'print',
+    label: 'Print and exit',
+    type: 'boolean',
+    description: 'Run in non-interactive print mode.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'outputFormat',
+    label: 'Output format',
+    type: 'select',
+    description: 'Output format for print mode.',
+    defaultValue: '',
+    options: ['', 'text', 'json', 'stream-json'],
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'dangerouslySkipPermissions',
+    label: 'Skip permissions',
+    type: 'boolean',
+    description: 'Bypass all permission checks. Use only in externally sandboxed workspaces.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'allowDangerouslySkipPermissions',
+    label: 'Allow skip permissions',
+    type: 'boolean',
+    description: 'Expose the skip-permissions option without enabling it by default.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'bare',
+    label: 'Bare mode',
+    type: 'boolean',
+    description: 'Minimal mode that skips hooks, plugin sync, memory, and auto-discovery.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'verbose',
+    label: 'Verbose',
+    type: 'boolean',
+    description: 'Override verbose mode setting from config.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+]
+
+const CODEX_COMMAND_FIELDS = [
+  defineTerminalCommandField({
+    id: 'prompt',
+    label: 'Prompt',
+    type: 'textarea',
+    description: 'Initial prompt to send to Codex.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'model',
+    label: 'Model',
+    type: 'text',
+    description: 'Model the agent should use.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'profile',
+    label: 'Profile',
+    type: 'text',
+    description: 'Configuration profile from config.toml.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'sandbox',
+    label: 'Sandbox',
+    type: 'select',
+    description: 'Sandbox policy for model-generated commands.',
+    defaultValue: '',
+    options: ['', 'read-only', 'workspace-write', 'danger-full-access'],
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'approvalPolicy',
+    label: 'Approval policy',
+    type: 'select',
+    description: 'When Codex should ask for human approval.',
+    defaultValue: '',
+    options: ['', 'untrusted', 'on-request', 'never'],
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'search',
+    label: 'Web search',
+    type: 'boolean',
+    description: 'Enable live web search for the session.',
+    defaultValue: false,
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'cd',
+    label: 'Working root',
+    type: 'text',
+    description: 'Directory Codex should use as its working root.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'addDir',
+    label: 'Additional dir',
+    type: 'text',
+    description: 'Additional writable directory alongside the primary workspace.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'config',
+    label: 'Config override',
+    type: 'text',
+    description: 'Configuration override in key=value form.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'enableFeature',
+    label: 'Enable feature',
+    type: 'text',
+    description: 'Feature flag to enable.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'disableFeature',
+    label: 'Disable feature',
+    type: 'text',
+    description: 'Feature flag to disable.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'image',
+    label: 'Image file',
+    type: 'text',
+    description: 'Image file to attach to the initial prompt.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'oss',
+    label: 'OSS provider',
+    type: 'boolean',
+    description: 'Use an open-source provider.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'localProvider',
+    label: 'Local provider',
+    type: 'select',
+    description: 'Local provider to use with OSS mode.',
+    defaultValue: '',
+    options: ['', 'lmstudio', 'ollama'],
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'noAltScreen',
+    label: 'No alt screen',
+    type: 'boolean',
+    description: 'Disable alternate screen mode.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'dangerouslyBypassApprovalsAndSandbox',
+    label: 'Bypass approvals and sandbox',
+    type: 'boolean',
+    description: 'Skip all confirmation prompts and execute without sandboxing.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+]
+
+const GEMINI_COMMAND_FIELDS = [
+  defineTerminalCommandField({
+    id: 'prompt',
+    label: 'Prompt',
+    type: 'textarea',
+    description: 'Initial prompt to send to Gemini.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'model',
+    label: 'Model',
+    type: 'text',
+    description: 'Model Gemini CLI should use.',
+    defaultValue: '',
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'approvalMode',
+    label: 'Approval mode',
+    type: 'select',
+    description: 'Approval mode for tool execution.',
+    defaultValue: '',
+    options: ['', 'default', 'auto_edit', 'yolo', 'plan'],
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'sandbox',
+    label: 'Sandbox',
+    type: 'boolean',
+    description: 'Run Gemini in sandbox mode.',
+    defaultValue: false,
+    required: false,
+  }),
+  defineTerminalCommandField({
+    id: 'debug',
+    label: 'Debug',
+    type: 'boolean',
+    description: 'Run in debug mode.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'worktree',
+    label: 'Worktree',
+    type: 'text',
+    description: 'Start Gemini in a named new git worktree.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'yolo',
+    label: 'YOLO mode',
+    type: 'boolean',
+    description: 'Automatically accept all actions.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'policy',
+    label: 'Policy',
+    type: 'text',
+    description: 'Additional policy files or directories.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'adminPolicy',
+    label: 'Admin policy',
+    type: 'text',
+    description: 'Additional admin policy files or directories.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'extensions',
+    label: 'Extensions',
+    type: 'text',
+    description: 'Extensions to use.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'includeDirectories',
+    label: 'Include directories',
+    type: 'text',
+    description: 'Additional directories to include in the workspace.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'allowedMcpServerNames',
+    label: 'Allowed MCP servers',
+    type: 'text',
+    description: 'Allowed MCP server names.',
+    defaultValue: '',
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'outputFormat',
+    label: 'Output format',
+    type: 'select',
+    description: 'Gemini CLI output format.',
+    defaultValue: '',
+    options: ['', 'text', 'json', 'stream-json'],
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'screenReader',
+    label: 'Screen reader',
+    type: 'boolean',
+    description: 'Enable screen reader mode.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'rawOutput',
+    label: 'Raw output',
+    type: 'boolean',
+    description: 'Disable output sanitization.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+  defineTerminalCommandField({
+    id: 'acceptRawOutputRisk',
+    label: 'Accept raw output risk',
+    type: 'boolean',
+    description: 'Suppress the raw-output security warning.',
+    defaultValue: false,
+    required: false,
+    advanced: true,
+  }),
+]
+
+export const BUILTIN_TERMINAL_SPAWN_COMMANDS: readonly TerminalSpawnCommand[] = [
+  defineTerminalSpawnCommand({
+    id: 'builtin:claude',
+    label: 'Claude',
+    description: 'Create a terminal and invoke Claude with an optional prompt.',
+    command: 'claude',
+    args: [
+      {
+        kind: 'booleanFlag',
+        fieldId: 'dangerouslySkipPermissions',
+        flag: '--dangerously-skip-permissions',
+      },
+      {
+        kind: 'booleanFlag',
+        fieldId: 'allowDangerouslySkipPermissions',
+        flag: '--allow-dangerously-skip-permissions',
+      },
+      { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+    ],
+    fields: CLAUDE_COMMAND_FIELDS,
+    builder: {
+      kind: 'argv',
+      parts: [
+        { kind: 'literal', value: 'claude' },
+        { kind: 'field', fieldId: 'model', prefix: '--model=', omitWhenEmpty: true },
+        {
+          kind: 'field',
+          fieldId: 'permissionMode',
+          prefix: '--permission-mode=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'field', fieldId: 'effort', prefix: '--effort=', omitWhenEmpty: true },
+        { kind: 'booleanFlag', fieldId: 'continueLatest', flag: '--continue' },
+        { kind: 'field', fieldId: 'resumeSession', prefix: '--resume=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'name', prefix: '--name=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'addDir', prefix: '--add-dir=', omitWhenEmpty: true },
+        {
+          kind: 'field',
+          fieldId: 'appendSystemPrompt',
+          prefix: '--append-system-prompt=',
+          omitWhenEmpty: true,
+        },
+        {
+          kind: 'field',
+          fieldId: 'allowedTools',
+          prefix: '--allowed-tools=',
+          omitWhenEmpty: true,
+        },
+        {
+          kind: 'field',
+          fieldId: 'disallowedTools',
+          prefix: '--disallowed-tools=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'booleanFlag', fieldId: 'print', flag: '--print' },
+        { kind: 'field', fieldId: 'outputFormat', prefix: '--output-format=', omitWhenEmpty: true },
+        {
+          kind: 'booleanFlag',
+          fieldId: 'dangerouslySkipPermissions',
+          flag: '--dangerously-skip-permissions',
+        },
+        {
+          kind: 'booleanFlag',
+          fieldId: 'allowDangerouslySkipPermissions',
+          flag: '--allow-dangerously-skip-permissions',
+        },
+        { kind: 'booleanFlag', fieldId: 'bare', flag: '--bare' },
+        { kind: 'booleanFlag', fieldId: 'verbose', flag: '--verbose' },
+        { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+      ],
+    },
+  }),
+  defineTerminalSpawnCommand({
+    id: 'builtin:codex',
+    label: 'Codex',
+    description: 'Create a terminal and invoke Codex with an optional prompt.',
+    command: 'codex',
+    args: [
+      {
+        kind: 'booleanFlag',
+        fieldId: 'dangerouslyBypassApprovalsAndSandbox',
+        flag: '--dangerously-bypass-approvals-and-sandbox',
+      },
+      { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+    ],
+    fields: CODEX_COMMAND_FIELDS,
+    builder: {
+      kind: 'argv',
+      parts: [
+        { kind: 'literal', value: 'codex' },
+        { kind: 'field', fieldId: 'model', prefix: '--model=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'profile', prefix: '--profile=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'sandbox', prefix: '--sandbox=', omitWhenEmpty: true },
+        {
+          kind: 'field',
+          fieldId: 'approvalPolicy',
+          prefix: '--ask-for-approval=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'booleanFlag', fieldId: 'search', flag: '--search' },
+        { kind: 'field', fieldId: 'cd', prefix: '--cd=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'addDir', prefix: '--add-dir=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'config', prefix: '--config=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'enableFeature', prefix: '--enable=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'disableFeature', prefix: '--disable=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'image', prefix: '--image=', omitWhenEmpty: true },
+        { kind: 'booleanFlag', fieldId: 'oss', flag: '--oss' },
+        {
+          kind: 'field',
+          fieldId: 'localProvider',
+          prefix: '--local-provider=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'booleanFlag', fieldId: 'noAltScreen', flag: '--no-alt-screen' },
+        {
+          kind: 'booleanFlag',
+          fieldId: 'dangerouslyBypassApprovalsAndSandbox',
+          flag: '--dangerously-bypass-approvals-and-sandbox',
+        },
+        { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+      ],
+    },
+  }),
+  defineTerminalSpawnCommand({
+    id: 'builtin:gemini',
+    label: 'Gemini',
+    description: 'Create a terminal and invoke Gemini with an optional prompt.',
+    command: 'gemini',
+    args: [
+      { kind: 'booleanFlag', fieldId: 'yolo', flag: '--yolo' },
+      { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+    ],
+    fields: GEMINI_COMMAND_FIELDS,
+    builder: {
+      kind: 'argv',
+      parts: [
+        { kind: 'literal', value: 'gemini' },
+        { kind: 'booleanFlag', fieldId: 'debug', flag: '--debug' },
+        { kind: 'field', fieldId: 'model', prefix: '--model=', omitWhenEmpty: true },
+        {
+          kind: 'field',
+          fieldId: 'approvalMode',
+          prefix: '--approval-mode=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'booleanFlag', fieldId: 'sandbox', flag: '--sandbox' },
+        { kind: 'field', fieldId: 'worktree', prefix: '--worktree=', omitWhenEmpty: true },
+        { kind: 'booleanFlag', fieldId: 'yolo', flag: '--yolo' },
+        { kind: 'field', fieldId: 'policy', prefix: '--policy=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'adminPolicy', prefix: '--admin-policy=', omitWhenEmpty: true },
+        { kind: 'field', fieldId: 'extensions', prefix: '--extensions=', omitWhenEmpty: true },
+        {
+          kind: 'field',
+          fieldId: 'includeDirectories',
+          prefix: '--include-directories=',
+          omitWhenEmpty: true,
+        },
+        {
+          kind: 'field',
+          fieldId: 'allowedMcpServerNames',
+          prefix: '--allowed-mcp-server-names=',
+          omitWhenEmpty: true,
+        },
+        { kind: 'field', fieldId: 'outputFormat', prefix: '--output-format=', omitWhenEmpty: true },
+        { kind: 'booleanFlag', fieldId: 'screenReader', flag: '--screen-reader' },
+        { kind: 'booleanFlag', fieldId: 'rawOutput', flag: '--raw-output' },
+        {
+          kind: 'booleanFlag',
+          fieldId: 'acceptRawOutputRisk',
+          flag: '--accept-raw-output-risk',
+        },
+        { kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+      ],
+    },
+  }),
+]
+
+function fieldToJsonSchemaProperty(field: TerminalCommandField): TerminalCommandJsonSchemaProperty {
+  const base: Pick<TerminalCommandJsonSchemaProperty, 'title' | 'description'> = {
+    title: field.label,
+  }
+  const description = field.description ?? field.placeholder
+  if (description) {
+    base.description = description
+  }
+  if (field.type === 'boolean') {
+    return {
+      ...base,
+      type: 'boolean',
+      default: typeof field.defaultValue === 'boolean' ? field.defaultValue : false,
+    }
+  }
+  if (field.type === 'select') {
+    return {
+      ...base,
+      type: 'string',
+      enum: field.options,
+      default: typeof field.defaultValue === 'string' ? field.defaultValue : field.options[0],
+    }
+  }
+  return {
+    ...base,
+    type: 'string',
+    default: typeof field.defaultValue === 'string' ? field.defaultValue : '',
+  }
+}
+
+export function fieldsToTerminalCommandParameters(
+  fields: readonly TerminalCommandField[]
+): TerminalCommandParameters {
+  const properties: Record<string, TerminalCommandJsonSchemaProperty> = {}
+  const uiSchema: Record<string, Record<string, unknown>> = {}
+  const required: string[] = []
+  for (const field of fields) {
+    properties[field.id] = fieldToJsonSchemaProperty(field)
+    if (field.required) required.push(field.id)
+    if (field.type === 'textarea') {
+      uiSchema[field.id] = {
+        'ui:widget': 'textarea',
+      }
+    }
+    if (field.advanced) {
+      const current = uiSchema[field.id] ?? {}
+      uiSchema[field.id] = {
+        ...current,
+        'ui:advanced': true,
+      }
+    }
+  }
+  return {
+    schema: {
+      type: 'object',
+      properties,
+      required,
+    },
+    uiSchema,
+  }
+}
+
+export function getTerminalCommandParameters(
+  command: TerminalSpawnCommand
+): TerminalCommandParameters {
+  return command.parameters ?? fieldsToTerminalCommandParameters(command.fields)
+}
+
+export function getTerminalCommandDefaultValues(
+  command: TerminalSpawnCommand,
+  presetValues: TerminalCommandFieldValues = {}
+): TerminalCommandFieldValues {
+  const values: TerminalCommandFieldValues = {}
+  const parameters = getTerminalCommandParameters(command)
+  for (const [fieldId, property] of Object.entries(parameters.schema.properties)) {
+    const preset = presetValues[fieldId]
+    if (typeof preset === 'string' || typeof preset === 'boolean') {
+      values[fieldId] = preset
+      continue
+    }
+    const defaultValue = getJsonSchemaDefaultValue(property)
+    if (defaultValue !== undefined) {
+      values[fieldId] = defaultValue
+      continue
+    }
+    values[fieldId] = getJsonSchemaPropertyType(property) === 'boolean' ? false : ''
+  }
+  return values
+}
+
+function stringifyFieldValue(value: TerminalCommandFieldValue | undefined): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  return value ?? ''
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getJsonSchemaDefaultValue(property: unknown): TerminalCommandFieldValue | undefined {
+  if (!isRecord(property)) return undefined
+  const defaultValue = property.default
+  if (typeof defaultValue === 'string' || typeof defaultValue === 'boolean') return defaultValue
+  return undefined
+}
+
+function getJsonSchemaPropertyType(property: unknown): string | undefined {
+  if (!isRecord(property)) return undefined
+  return typeof property.type === 'string' ? property.type : undefined
+}
+
+export function renderTerminalCommandArgs(
+  command: TerminalSpawnCommand,
+  values: TerminalCommandFieldValues
+): string[] {
+  const args: string[] = []
+  for (const arg of command.args) {
+    if (arg.kind === 'literal') {
+      args.push(arg.value)
+      continue
+    }
+    if (arg.kind === 'booleanFlag') {
+      if (values[arg.fieldId] === true) {
+        args.push(arg.flag)
+      }
+      continue
+    }
+    const value = stringifyFieldValue(values[arg.fieldId]).trim()
+    if (!value && arg.omitWhenEmpty) continue
+    args.push(`${arg.prefix}${value}`)
+  }
+  return args
+}
+
+function renderTerminalCommandBuilderParts(
+  parts: readonly TerminalCommandBuilderPart[],
+  values: TerminalCommandFieldValues
+): string[] {
+  const argv: string[] = []
+  for (const part of parts) {
+    if (part.kind === 'literal') {
+      if (part.value.trim().length > 0) {
+        argv.push(part.value)
+      }
+      continue
+    }
+    if (part.kind === 'booleanFlag') {
+      if (values[part.fieldId] === true) {
+        argv.push(part.flag)
+      }
+      continue
+    }
+    const value = stringifyFieldValue(values[part.fieldId]).trim()
+    if (!value && part.omitWhenEmpty) continue
+    argv.push(`${part.prefix}${value}`)
+  }
+  return argv
+}
+
+function renderTemplateString(template: string, values: TerminalCommandFieldValues): string {
+  return template.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (_match, fieldId: string) =>
+    stringifyFieldValue(values[fieldId])
+  )
+}
+
+export function renderTerminalSpawnCommand(options: {
+  command: TerminalSpawnCommand
+  values: TerminalCommandFieldValues
+}): TerminalCommandRenderResult {
+  const builder = options.command.builder
+  if (!builder) {
+    return {
+      kind: 'argv',
+      argv: [
+        options.command.command,
+        ...renderTerminalCommandArgs(options.command, options.values),
+      ],
+    }
+  }
+  if (builder.kind === 'shellLine') {
+    return {
+      kind: 'shellLine',
+      commandLine: renderTemplateString(builder.template, options.values).trim(),
+    }
+  }
+  return {
+    kind: 'argv',
+    argv: renderTerminalCommandBuilderParts(builder.parts, options.values),
+  }
+}
+
+function quotePosix(value: string): string {
+  if (value.length === 0) return "''"
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function quoteCmd(value: string): string {
+  if (value.length === 0) return '""'
+  if (!/[\s"&|<>^()%!]/.test(value)) return value
+  return `"${value.replace(/(["^&|<>])/g, '^$1')}"`
+}
+
+function quotePowerShell(value: string): string {
+  if (value.length === 0) return "''"
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) return value
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+export function quoteTerminalShellArg(value: string, quoteStyle: TerminalShellQuoteStyle): string {
+  if (quoteStyle === 'cmd') return quoteCmd(value)
+  if (quoteStyle === 'powershell') return quotePowerShell(value)
+  return quotePosix(value)
+}
+
+export function renderTerminalSpawnCommandLine(options: {
+  command: TerminalSpawnCommand
+  values: TerminalCommandFieldValues
+  quoteStyle: TerminalShellQuoteStyle
+}): string {
+  const result = renderTerminalSpawnCommand(options)
+  if (result.kind === 'shellLine') return result.commandLine
+  return result.argv.map((part) => quoteTerminalShellArg(part, options.quoteStyle)).join(' ')
+}

--- a/packages/server/src/pty-manager.test.ts
+++ b/packages/server/src/pty-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolvePtyCommand, type PtyPlatform } from './pty-manager.js'
+import { resolvePtyCommand, resolvePtyShellDefaults, type PtyPlatform } from './pty-manager.js'
 
 describe('resolvePtyCommand', () => {
   it('uses explicit command and args when provided', () => {
@@ -72,5 +72,20 @@ describe('resolvePtyCommand', () => {
       command: '/bin/sh',
       args: [],
     })
+  })
+})
+
+describe('resolvePtyShellDefaults', () => {
+  it('exposes the effective unix shell and builtin shell profiles', () => {
+    const defaults = resolvePtyShellDefaults({
+      platform: 'common',
+      env: { SHELL: '/bin/fish' },
+    })
+
+    expect(defaults.effectiveDefaultShell.command).toBe('/bin/fish')
+    expect(defaults.builtinShellProfiles.map((profile) => profile.command)).toEqual([
+      '/bin/sh',
+      '/bin/fish',
+    ])
   })
 })

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1,4 +1,5 @@
 import * as pty from '@lydell/node-pty'
+import { resolveTerminalShellDefaults, type TerminalShellDefaults } from '@openspecui/core'
 import { EventEmitter } from 'events'
 
 const DEFAULT_SCROLLBACK = 1000
@@ -36,6 +37,19 @@ function resolveDefaultShell(platform: PtyPlatform, env: NodeJS.ProcessEnv): str
     return env.ComSpec?.trim() || 'cmd.exe'
   }
   return env.SHELL?.trim() || '/bin/sh'
+}
+
+export function resolvePtyShellDefaults(opts: {
+  platform: PtyPlatform
+  env: NodeJS.ProcessEnv
+}): TerminalShellDefaults {
+  return resolveTerminalShellDefaults({
+    platform: opts.platform,
+    env: {
+      SHELL: opts.env.SHELL,
+      ComSpec: opts.env.ComSpec,
+    },
+  })
 }
 
 export function resolvePtyCommand(opts: {
@@ -225,6 +239,13 @@ export class PtyManager {
 
   constructor(private defaultCwd: string) {
     this.platform = detectPtyPlatform()
+  }
+
+  getShellDefaults(): TerminalShellDefaults {
+    return resolvePtyShellDefaults({
+      platform: this.platform,
+      env: process.env,
+    })
   }
 
   create(opts: {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -25,6 +25,7 @@ import {
   getWatcherRuntimeStatus,
   GitConfigSchema,
   OpsxConfigSchema,
+  resolveTerminalShellDefaults,
   sniffGlobalCli,
   subscribeWatcherRuntimeStatus,
   TerminalConfigSchema,
@@ -748,6 +749,18 @@ export const configRouter = router({
   // Reactive subscription
   subscribe: publicProcedure.subscription(({ ctx }) => {
     return createReactiveSubscription(() => ctx.configManager.readConfig())
+  }),
+
+  getTerminalShellDefaults: publicProcedure.query(async () => {
+    const platform =
+      process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'macos' : 'common'
+    return resolveTerminalShellDefaults({
+      platform,
+      env: {
+        SHELL: process.env.SHELL,
+        ComSpec: process.env.ComSpec,
+      },
+    })
   }),
 })
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -87,6 +87,9 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@fsegurai/codemirror-theme-bundle": "^6.3.1",
+    "@rjsf/core": "^6.5.2",
+    "@rjsf/utils": "^6.5.2",
+    "@rjsf/validator-ajv8": "^6.5.2",
     "view-transitions-toolkit": "1.0.0"
   }
 }

--- a/packages/web/src/components/context-menu.test.ts
+++ b/packages/web/src/components/context-menu.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { clampWithinBounds, resolveAnchorPosition, type ContextMenuAnchor } from './context-menu'
+import {
+  clampWithinBounds,
+  resolveAnchorPosition,
+  resolveMenuPosition,
+  type ContextMenuAnchor,
+} from './context-menu'
 
 function createRect(rect: Partial<DOMRect>): DOMRect {
   return {
@@ -53,6 +58,21 @@ describe('context menu anchor math', () => {
     expect(clampWithinBounds(raw, menuRect, boundaryRect)).toEqual({
       x: 112,
       y: 62,
+    })
+  })
+
+  it('aligns a bottom-end target menu by the target and menu right edges', () => {
+    const anchor: ContextMenuAnchor = {
+      type: 'target',
+      element: null,
+      placement: 'bottom-end',
+    }
+    const anchorPosition = { x: 180, y: 88 }
+    const menuRect = createRect({ width: 120, height: 80 })
+
+    expect(resolveMenuPosition(anchor, anchorPosition, menuRect)).toEqual({
+      x: 60,
+      y: 88,
     })
   })
 })

--- a/packages/web/src/components/context-menu.tsx
+++ b/packages/web/src/components/context-menu.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type HTMLAttributes,
   type ReactNode,
 } from 'react'
@@ -84,26 +83,33 @@ export function clampWithinBounds(
   }
 }
 
-function toLocalPointStyle(
-  point: { x: number; y: number },
-  wrapperElement?: HTMLElement | null
-): CSSProperties {
-  if (!wrapperElement) {
-    return { position: 'fixed', left: point.x, top: point.y }
-  }
-  const rect = wrapperElement.getBoundingClientRect()
-  return {
-    position: 'absolute',
-    left: point.x - rect.left + wrapperElement.scrollLeft,
-    top: point.y - rect.top + wrapperElement.scrollTop,
+export function resolveMenuPosition(
+  anchor: ContextMenuAnchor | null,
+  anchorPosition: { x: number; y: number },
+  menuRect: DOMRect
+): { x: number; y: number } {
+  if (anchor?.type !== 'target') return anchorPosition
+
+  const placement = anchor.placement ?? 'bottom-start'
+  switch (placement) {
+    case 'bottom-end':
+      return { x: anchorPosition.x - menuRect.width, y: anchorPosition.y }
+    case 'top-start':
+      return { x: anchorPosition.x, y: anchorPosition.y - menuRect.height }
+    case 'top-end':
+      return { x: anchorPosition.x - menuRect.width, y: anchorPosition.y - menuRect.height }
+    case 'bottom-start':
+    default:
+      return anchorPosition
   }
 }
 
-function getPlacement(
-  anchor: ContextMenuAnchor | null
-): 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end' {
-  if (anchor?.type === 'target') return anchor.placement ?? 'bottom-start'
-  return 'bottom-start'
+function isPopoverOpen(element: Element): boolean {
+  try {
+    return element.matches(':popover-open')
+  } catch {
+    return false
+  }
 }
 
 export function ContextMenu({
@@ -126,12 +132,27 @@ export function ContextMenu({
   const [adjustedPosition, setAdjustedPosition] = useState<{ x: number; y: number } | null>(null)
 
   const menuId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
-  const anchorName = `--context-menu-anchor-${menuId}`
   const menuDataId = `context-menu-${menuId}`
-  const placement = getPlacement(activeAnchor)
 
   const visibleItems = useMemo(() => items.filter((item) => item.label.length > 0), [items])
   const shouldRender = open && !!anchorPosition && visibleItems.length > 0
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current as
+      | (HTMLDivElement & {
+          showPopover?: () => void
+          hidePopover?: () => void
+        })
+      | null
+    if (!menu) return
+    if (shouldRender) {
+      if (!isPopoverOpen(menu)) {
+        menu.showPopover?.()
+      }
+    } else if (isPopoverOpen(menu)) {
+      menu.hidePopover?.()
+    }
+  }, [shouldRender])
 
   useLayoutEffect(() => {
     if (!open || !anchorPosition) {
@@ -146,9 +167,11 @@ export function ContextMenu({
     }
 
     const boundaryRect = hostElement?.getBoundingClientRect() ?? null
-    const clamped = clampWithinBounds(anchorPosition, menu.getBoundingClientRect(), boundaryRect)
+    const menuRect = menu.getBoundingClientRect()
+    const origin = resolveMenuPosition(activeAnchor, anchorPosition, menuRect)
+    const clamped = clampWithinBounds(origin, menuRect, boundaryRect)
     setAdjustedPosition(clamped)
-  }, [anchorPosition, hostElement, open])
+  }, [activeAnchor, anchorPosition, hostElement, open])
 
   useEffect(() => {
     const handleScroll = () => onClose()
@@ -191,18 +214,17 @@ export function ContextMenu({
   useEffect(() => {
     if (!open || activeAnchor?.type !== 'target' || !activeAnchor.element) return
     const target = activeAnchor.element
-    const previousAnchorName = target.style.getPropertyValue('anchor-name')
-    const previousPriority = target.style.getPropertyPriority('anchor-name')
-    target.style.setProperty('anchor-name', anchorName)
+    const previousActive = target.getAttribute('data-context-menu-active')
+    target.setAttribute('data-context-menu-active', 'true')
 
     return () => {
-      if (previousAnchorName) {
-        target.style.setProperty('anchor-name', previousAnchorName, previousPriority)
+      if (previousActive === null) {
+        target.removeAttribute('data-context-menu-active')
       } else {
-        target.style.removeProperty('anchor-name')
+        target.setAttribute('data-context-menu-active', previousActive)
       }
     }
-  }, [activeAnchor, anchorName, open])
+  }, [activeAnchor, open])
 
   const resolvedPosition = adjustedPosition ?? anchorPosition
   const fallbackStyle =
@@ -210,108 +232,23 @@ export function ContextMenu({
       ? { left: 0, top: 0 }
       : { left: resolvedPosition.x, top: resolvedPosition.y }
 
-  const syntheticAnchorStyle =
-    activeAnchor?.type === 'point' && anchorPosition
-      ? toLocalPointStyle(anchorPosition, hostElement)
-      : null
-
-  useEffect(() => {
-    const menu = menuRef.current as
-      | (HTMLDivElement & {
-          showPopover?: () => void
-          hidePopover?: () => void
-        })
-      | null
-    if (!menu) return
-    if (shouldRender) {
-      if (!menu.matches(':popover-open')) {
-        menu.showPopover?.()
-      }
-    } else if (menu.matches(':popover-open')) {
-      menu.hidePopover?.()
-    }
-  }, [shouldRender])
-
   if (!shouldRender) return null
 
   const styles = String.raw
 
-  const anchorPlacementCSS =
-    placement === 'top-start'
-      ? 'bottom: anchor(top); left: anchor(left); top: auto; right: auto;'
-      : placement === 'top-end'
-        ? 'bottom: anchor(top); left: anchor(right); top: auto; right: auto;'
-        : placement === 'bottom-end'
-          ? 'top: anchor(bottom); left: anchor(right); bottom: auto; right: auto;'
-          : 'top: anchor(bottom); left: anchor(left); bottom: auto; right: auto;'
-
   return (
     <>
       <style>{styles`
-        .context-menu-anchor[data-context-menu-id='${menuDataId}'] {
-          width: 1px;
-          height: 1px;
-          pointer-events: none;
-          z-index: 50;
-          anchor-name: ${anchorName};
-        }
         .context-menu-popover[data-context-menu-id='${menuDataId}'] {
           position: absolute;
           inset: auto;
         }
-        @supports (position-anchor: ${anchorName}) {
-          .context-menu-popover[data-context-menu-id='${menuDataId}'] {
-            position-anchor: ${anchorName};
-            ${anchorPlacementCSS}
-          }
-        }
-        @supports (position-try-fallbacks: --context-menu-right-bottom) {
-          @position-try --context-menu-right-bottom {
-            top: anchor(bottom);
-            left: anchor(right);
-            right: auto;
-            bottom: auto;
-          }
-          @position-try --context-menu-left-bottom {
-            top: anchor(bottom);
-            right: anchor(left);
-            left: auto;
-            bottom: auto;
-          }
-          @position-try --context-menu-left-top {
-            bottom: anchor(top);
-            right: anchor(left);
-            left: auto;
-            top: auto;
-          }
-          @position-try --context-menu-right-top {
-            bottom: anchor(top);
-            left: anchor(right);
-            right: auto;
-            top: auto;
-          }
-          .context-menu-popover[data-context-menu-id='${menuDataId}'] {
-            position-try-fallbacks:
-              --context-menu-right-bottom,
-              --context-menu-left-bottom,
-              --context-menu-left-top,
-              --context-menu-right-top;
-          }
-        }
       `}</style>
-      {syntheticAnchorStyle && (
-        <div
-          data-context-menu-id={menuDataId}
-          className="context-menu-anchor"
-          style={syntheticAnchorStyle}
-          aria-hidden
-        />
-      )}
       <div
         ref={menuRef}
         popover="manual"
         data-context-menu-id={menuDataId}
-        className="context-menu-popover border-border bg-card text-foreground z-50 min-w-[180px] rounded-md border p-1 shadow-lg"
+        className="context-menu-popover border-border bg-card text-foreground scrollbar-thin scrollbar-track-transparent z-50 max-h-[min(420px,calc(100vh-2rem))] min-w-[180px] max-w-[min(420px,calc(100vw-2rem))] overflow-auto rounded-md border p-1 shadow-lg"
         style={fallbackStyle}
       >
         {visibleItems.map((item) => {
@@ -328,14 +265,14 @@ export function ContextMenu({
                 onClose()
               }}
               disabled={isDisabled}
-              className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition ${
+              className={`flex w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition ${
                 isDisabled
                   ? 'text-muted-foreground cursor-not-allowed'
                   : `hover:bg-muted ${toneClass}`
               }`}
             >
               {item.icon && <span className="h-3.5 w-3.5">{item.icon}</span>}
-              <span className="flex-1">{item.label}</span>
+              <span className="min-w-0 flex-1 truncate">{item.label}</span>
             </button>
           )
         })}

--- a/packages/web/src/components/dialog.test.tsx
+++ b/packages/web/src/components/dialog.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import { Dialog } from './dialog'
 
 describe('Dialog', () => {
@@ -32,5 +32,18 @@ describe('Dialog', () => {
     expect(
       document.head.querySelectorAll('[data-head-style="dialog:openspec-dialog"]')
     ).toHaveLength(1)
+  })
+
+  it('does not close when a child click reports zero coordinates', () => {
+    const onClose = vi.fn()
+    const { getByText } = render(
+      <Dialog open title="Dialog title" onClose={onClose}>
+        <button type="button">Inner action</button>
+      </Dialog>
+    )
+
+    fireEvent.click(getByText('Inner action'), { clientX: 0, clientY: 0 })
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/dialog.tsx
+++ b/packages/web/src/components/dialog.tsx
@@ -87,6 +87,9 @@ export function Dialog({
     const handleClick = (event: MouseEvent) => {
       const panel = panelRef.current
       if (!panel) return
+      if (event.target instanceof Node && panel.contains(event.target)) {
+        return
+      }
       const rect = panel.getBoundingClientRect()
       const isInDialog =
         event.clientX >= rect.left &&

--- a/packages/web/src/components/global-archive-modal.tsx
+++ b/packages/web/src/components/global-archive-modal.tsx
@@ -5,6 +5,7 @@ import { Archive, CheckCircle, Loader2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { CliTerminal } from './cli-terminal'
 import { Dialog } from './dialog'
+import { Switch } from './switch'
 
 /**
  * 全局 Archive Modal（单一对话框，点击 Archive 后直接串行 validate -> archive）
@@ -174,36 +175,34 @@ export function GlobalArchiveModal() {
         <div className="space-y-3">
           <p className="text-sm font-medium">Options</p>
 
-          <label className="flex cursor-pointer items-start gap-3">
-            <input
-              type="checkbox"
-              checked={skipSpecs}
-              onChange={(e) => setSkipSpecs(e.target.checked)}
-              className="border-border mt-1 h-4 w-4 rounded"
-              disabled={hasStarted}
-            />
+          <label className="flex cursor-pointer items-start justify-between gap-3">
             <div>
               <p className="text-sm font-medium">Skip specs update</p>
               <p className="text-muted-foreground text-xs">
                 Don't update spec files with delta changes (--skip-specs)
               </p>
             </div>
-          </label>
-
-          <label className="flex cursor-pointer items-start gap-3">
-            <input
-              type="checkbox"
-              checked={noValidate}
-              onChange={(e) => setNoValidate(e.target.checked)}
-              className="border-border mt-1 h-4 w-4 rounded"
+            <Switch
+              checked={skipSpecs}
+              onCheckedChange={setSkipSpecs}
+              ariaLabel="Skip specs update"
               disabled={hasStarted}
             />
+          </label>
+
+          <label className="flex cursor-pointer items-start justify-between gap-3">
             <div>
               <p className="text-sm font-medium">Skip validation</p>
               <p className="text-muted-foreground text-xs">
                 Don't validate the change before archiving (--no-validate)
               </p>
             </div>
+            <Switch
+              checked={noValidate}
+              onCheckedChange={setNoValidate}
+              ariaLabel="Skip validation"
+              disabled={hasStarted}
+            />
           </label>
         </div>
       </div>

--- a/packages/web/src/components/select.test.tsx
+++ b/packages/web/src/components/select.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
-import { describe, expect, it } from 'vitest'
-import { Select, type SelectOption } from './select'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Select, type SelectOption, type SelectOptionGroup } from './select'
 
 const OPTIONS: SelectOption<'30s' | '5min' | 'none'>[] = [
   { value: '30s', label: '30s' },
@@ -20,7 +20,22 @@ function SelectHarness() {
   )
 }
 
+const GROUPS: SelectOptionGroup<'shell:zsh' | 'create:claude'>[] = [
+  {
+    label: 'Shell Instances',
+    options: [{ value: 'shell:zsh', label: 'zsh' }],
+  },
+  {
+    label: 'Create Shell Instance',
+    options: [{ value: 'create:claude', label: 'Create Claude' }],
+  },
+]
+
 describe('Select', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it('updates the selected value after choosing an item', async () => {
     render(<SelectHarness />)
 
@@ -30,5 +45,25 @@ describe('Select', () => {
     fireEvent.click(option)
 
     expect(screen.getByTestId('selected-value').textContent).toBe('5min')
+  })
+
+  it('renders the shared form-control trigger style by default', () => {
+    render(<SelectHarness />)
+
+    const trigger = screen.getByRole('combobox', { name: 'Auto refresh' })
+
+    expect(trigger.className).toContain('bg-background')
+    expect(trigger.className).toContain('border')
+    expect(trigger.className).toContain('h-9')
+  })
+
+  it('renders grouped options with accessible group labels', async () => {
+    render(<Select value="shell:zsh" groups={GROUPS} onValueChange={() => {}} ariaLabel="Target" />)
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Target' }))
+
+    expect(await screen.findByRole('group', { name: 'Shell Instances' })).toBeTruthy()
+    expect(screen.getByRole('group', { name: 'Create Shell Instance' })).toBeTruthy()
+    expect(screen.getByRole('option', { name: 'Create Claude' })).toBeTruthy()
   })
 })

--- a/packages/web/src/components/select.tsx
+++ b/packages/web/src/components/select.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import { Select as BaseSelect } from '@base-ui/react/select'
 import { Check, ChevronDown } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { useCallback, useState, type FocusEventHandler, type ReactNode } from 'react'
 
 export interface SelectOption<T extends string> {
   value: T
@@ -9,11 +9,24 @@ export interface SelectOption<T extends string> {
   disabled?: boolean
 }
 
+export interface SelectOptionGroup<T extends string> {
+  label: ReactNode
+  options: readonly SelectOption<T>[]
+}
+
 interface SelectProps<T extends string> {
   value: T
-  options: readonly SelectOption<T>[]
+  options?: readonly SelectOption<T>[]
+  groups?: readonly SelectOptionGroup<T>[]
   onValueChange: (value: T) => void
   ariaLabel?: string
+  id?: string
+  name?: string
+  required?: boolean
+  disabled?: boolean
+  onBlur?: FocusEventHandler<HTMLButtonElement>
+  onFocus?: FocusEventHandler<HTMLButtonElement>
+  'data-testid'?: string
   placeholder?: ReactNode
   renderTrigger?: (args: { selectedOption: SelectOption<T> | undefined }) => ReactNode
   className?: string
@@ -27,9 +40,17 @@ interface SelectProps<T extends string> {
 
 export function Select<T extends string>({
   value,
-  options,
+  options = [],
+  groups,
   onValueChange,
   ariaLabel,
+  id,
+  name,
+  required,
+  disabled,
+  onBlur,
+  onFocus,
+  'data-testid': dataTestId,
   placeholder = 'Select…',
   renderTrigger,
   className,
@@ -40,11 +61,25 @@ export function Select<T extends string>({
   sideOffset = 8,
   modal = false,
 }: SelectProps<T>) {
-  const selectedOption = options.find((option) => option.value === value)
+  const optionGroups = groups ?? [{ label: null, options }]
+  const selectedOption = optionGroups
+    .flatMap((group) => group.options)
+    .find((option) => option.value === value)
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null)
+  const handleTriggerRef = useCallback((node: HTMLButtonElement | null) => {
+    const nextContainer = node?.closest('dialog') ?? null
+    setPortalContainer((currentContainer) =>
+      currentContainer === nextContainer ? currentContainer : nextContainer
+    )
+  }, [])
 
   return (
     <BaseSelect.Root
+      id={id}
+      name={name}
       value={value}
+      required={required}
+      disabled={disabled}
       modal={modal}
       onValueChange={(nextValue) => {
         if (nextValue !== null) {
@@ -53,12 +88,17 @@ export function Select<T extends string>({
       }}
     >
       <BaseSelect.Trigger
+        ref={handleTriggerRef}
         aria-label={ariaLabel}
+        data-testid={dataTestId}
+        onBlur={onBlur}
+        onFocus={onFocus}
         className={(state) =>
           cn(
-            'text-foreground inline-flex min-w-0 items-center gap-1.5 text-xs outline-none transition-colors',
-            'focus-visible:ring-ring/60 focus-visible:ring-2',
-            state.open ? 'bg-muted/40' : '',
+            'bg-background border-border text-foreground inline-flex h-9 min-w-0 items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm outline-none transition-colors',
+            'hover:bg-muted/30 focus-visible:ring-primary focus-visible:ring-1',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            state.open ? 'bg-muted/40 ring-primary ring-1' : '',
             className
           )
         }
@@ -73,50 +113,64 @@ export function Select<T extends string>({
               {() => selectedOption?.label ?? placeholder}
             </BaseSelect.Value>
             <BaseSelect.Icon className="text-muted-foreground flex shrink-0">
-              <ChevronDown className="h-3.5 w-3.5" />
+              <ChevronDown className="h-4 w-4" />
             </BaseSelect.Icon>
           </>
         )}
       </BaseSelect.Trigger>
 
-      <BaseSelect.Portal>
+      <BaseSelect.Portal container={portalContainer ?? undefined}>
         <BaseSelect.Positioner
           sideOffset={sideOffset}
           className={cn('z-50 select-none outline-none', positionerClassName)}
         >
           <BaseSelect.Popup
             className={cn(
-              'bg-card text-foreground border-border w-max min-w-28 rounded-md border p-1 shadow-lg',
+              'bg-card text-foreground border-border min-w-(--anchor-width) max-w-[min(24rem,calc(100vw-2rem))] rounded-md border p-1 shadow-lg',
               'origin-(--transform-origin) transition-[transform,opacity] duration-150',
               'data-[ending-style]:translate-y-0.5 data-[ending-style]:opacity-0',
               'data-[starting-style]:translate-y-0.5 data-[starting-style]:opacity-0',
               popupClassName
             )}
           >
-            <BaseSelect.List className={cn('max-h-64 overflow-y-auto py-0.5', listClassName)}>
-              {options.map((option) => (
-                <BaseSelect.Item
-                  key={option.value}
-                  value={option.value}
-                  disabled={option.disabled}
-                  label={typeof option.label === 'string' ? option.label : undefined}
-                  className={(state) =>
-                    cn(
-                      'grid cursor-default grid-cols-[0.8rem_minmax(0,1fr)] items-center gap-1.5 rounded-sm px-2 py-1.5 text-xs outline-none',
-                      state.highlighted && 'bg-muted text-foreground',
-                      state.selected && 'text-foreground',
-                      state.disabled && 'opacity-50',
-                      itemClassName
-                    )
-                  }
-                >
-                  <BaseSelect.ItemIndicator className="text-primary flex h-3.5 w-3.5 items-center justify-center">
-                    <Check className="h-3.5 w-3.5" />
-                  </BaseSelect.ItemIndicator>
-                  <BaseSelect.ItemText className="whitespace-nowrap">
-                    {option.label}
-                  </BaseSelect.ItemText>
-                </BaseSelect.Item>
+            <BaseSelect.List
+              className={cn(
+                'scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[color-mix(in_srgb,currentColor,transparent_78%)] max-h-[min(18rem,var(--available-height))] overflow-x-auto overflow-y-auto py-0.5',
+                listClassName
+              )}
+            >
+              {optionGroups.map((group, groupIndex) => (
+                <BaseSelect.Group key={groupIndex} className={cn(groupIndex > 0 && 'mt-1')}>
+                  {group.label && (
+                    <BaseSelect.GroupLabel className="text-muted-foreground px-2 py-1 text-[11px] font-medium uppercase tracking-wide">
+                      {group.label}
+                    </BaseSelect.GroupLabel>
+                  )}
+                  {group.options.map((option) => (
+                    <BaseSelect.Item
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      label={typeof option.label === 'string' ? option.label : undefined}
+                      className={(state) =>
+                        cn(
+                          'grid cursor-default grid-cols-[1rem_minmax(0,1fr)] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
+                          state.highlighted && 'bg-muted text-foreground',
+                          state.selected && 'text-foreground',
+                          state.disabled && 'opacity-50',
+                          itemClassName
+                        )
+                      }
+                    >
+                      <BaseSelect.ItemIndicator className="text-primary flex h-4 w-4 items-center justify-center">
+                        <Check className="h-4 w-4" />
+                      </BaseSelect.ItemIndicator>
+                      <BaseSelect.ItemText className="whitespace-nowrap">
+                        {option.label}
+                      </BaseSelect.ItemText>
+                    </BaseSelect.Item>
+                  ))}
+                </BaseSelect.Group>
               ))}
             </BaseSelect.List>
           </BaseSelect.Popup>

--- a/packages/web/src/components/switch.test.tsx
+++ b/packages/web/src/components/switch.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Switch } from './switch'
+
+function SwitchHarness() {
+  const [checked, setChecked] = useState(false)
+
+  return (
+    <>
+      <Switch checked={checked} onCheckedChange={setChecked} ariaLabel="Enable option" />
+      <div data-testid="switch-state">{String(checked)}</div>
+    </>
+  )
+}
+
+describe('Switch', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('updates checked state after toggling', () => {
+    render(<SwitchHarness />)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Enable option' }))
+
+    expect(screen.getByTestId('switch-state').textContent).toBe('true')
+  })
+
+  it('renders the shared checkbox style', () => {
+    render(<SwitchHarness />)
+
+    const trigger = screen.getByRole('checkbox', { name: 'Enable option' })
+
+    expect(trigger.className).toContain('h-5')
+    expect(trigger.className).toContain('w-5')
+    expect(trigger.className).toContain('border')
+    expect(trigger.firstElementChild?.className).toContain('opacity-0')
+  })
+})

--- a/packages/web/src/components/switch.tsx
+++ b/packages/web/src/components/switch.tsx
@@ -1,0 +1,74 @@
+import { cn } from '@/lib/utils'
+import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox'
+import { Check } from 'lucide-react'
+import type { FocusEventHandler } from 'react'
+
+interface SwitchProps {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+  ariaLabel?: string
+  id?: string
+  name?: string
+  required?: boolean
+  disabled?: boolean
+  readOnly?: boolean
+  onBlur?: FocusEventHandler<HTMLElement>
+  onFocus?: FocusEventHandler<HTMLElement>
+  className?: string
+  thumbClassName?: string
+}
+
+/**
+ * Shared boolean control for settings and command options.
+ */
+export function Switch({
+  checked,
+  onCheckedChange,
+  ariaLabel,
+  id,
+  name,
+  required,
+  disabled,
+  readOnly,
+  onBlur,
+  onFocus,
+  className,
+  thumbClassName,
+}: SwitchProps) {
+  return (
+    <BaseCheckbox.Root
+      id={id}
+      name={name}
+      checked={checked}
+      required={required}
+      disabled={disabled}
+      readOnly={readOnly}
+      aria-label={ariaLabel}
+      onCheckedChange={onCheckedChange}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      className={(state) =>
+        cn(
+          'bg-background border-border text-background inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-sm border outline-none transition-colors',
+          'focus-visible:ring-primary focus-visible:ring-1',
+          state.checked ? 'border-primary bg-primary text-primary-foreground' : 'hover:bg-muted/40',
+          state.disabled && 'cursor-not-allowed opacity-50',
+          className
+        )
+      }
+    >
+      <BaseCheckbox.Indicator
+        keepMounted
+        className={(state) =>
+          cn(
+            'flex h-full w-full items-center justify-center transition-opacity',
+            state.checked ? 'opacity-100' : 'opacity-0',
+            thumbClassName
+          )
+        }
+      >
+        <Check className="h-3.5 w-3.5 stroke-[3]" />
+      </BaseCheckbox.Indicator>
+    </BaseCheckbox.Root>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-command-form.tsx
+++ b/packages/web/src/components/terminal/terminal-command-form.tsx
@@ -1,0 +1,202 @@
+import { Select, type SelectOption } from '@/components/select'
+import { Switch } from '@/components/switch'
+import type {
+  TerminalCommandFieldValues,
+  TerminalCommandJsonSchema,
+} from '@openspecui/core/terminal-invocation'
+import Form from '@rjsf/core'
+import type {
+  EnumOptionsType,
+  FieldTemplateProps,
+  ObjectFieldTemplateProps,
+  RJSFSchema,
+  UiSchema,
+  WidgetProps,
+} from '@rjsf/utils'
+import validator from '@rjsf/validator-ajv8'
+import { useMemo } from 'react'
+
+interface TerminalCommandFormProps {
+  schema: TerminalCommandJsonSchema
+  uiSchema?: UiSchema
+  values: TerminalCommandFieldValues
+  onChange: (values: TerminalCommandFieldValues) => void
+}
+
+const inputClassName =
+  'bg-background border-border text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1'
+
+function toTerminalValues(value: unknown): TerminalCommandFieldValues {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {}
+  const result: TerminalCommandFieldValues = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'string' || typeof item === 'boolean') {
+      result[key] = item
+    }
+  }
+  return result
+}
+
+function TextWidget(props: WidgetProps) {
+  return (
+    <input
+      id={props.id}
+      type="text"
+      value={typeof props.value === 'string' ? props.value : ''}
+      required={props.required}
+      disabled={props.disabled || props.readonly}
+      placeholder={props.placeholder}
+      onChange={(event) => props.onChange(event.target.value)}
+      onBlur={() => props.onBlur(props.id, props.value)}
+      onFocus={() => props.onFocus(props.id, props.value)}
+      className={inputClassName}
+    />
+  )
+}
+
+function TextareaWidget(props: WidgetProps) {
+  return (
+    <textarea
+      id={props.id}
+      value={typeof props.value === 'string' ? props.value : ''}
+      required={props.required}
+      disabled={props.disabled || props.readonly}
+      placeholder={props.placeholder}
+      rows={5}
+      onChange={(event) => props.onChange(event.target.value)}
+      onBlur={() => props.onBlur(props.id, props.value)}
+      onFocus={() => props.onFocus(props.id, props.value)}
+      className={inputClassName}
+    />
+  )
+}
+
+function CheckboxWidget(props: WidgetProps) {
+  return (
+    <label className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+      <span className="text-sm font-medium">{props.label}</span>
+      <Switch
+        id={props.id}
+        checked={props.value === true}
+        required={props.required}
+        disabled={props.disabled || props.readonly}
+        onCheckedChange={(checked) => props.onChange(checked)}
+        onBlur={() => props.onBlur(props.id, props.value)}
+        onFocus={() => props.onFocus(props.id, props.value)}
+      />
+    </label>
+  )
+}
+
+function SelectWidget(props: WidgetProps) {
+  const options =
+    (props.options.enumOptions as EnumOptionsType[] | undefined)?.map<SelectOption<string>>(
+      (option) => ({
+        value: String(option.value),
+        label: option.label,
+      })
+    ) ?? []
+
+  return (
+    <Select
+      id={props.id}
+      value={typeof props.value === 'string' ? props.value : ''}
+      options={options}
+      required={props.required}
+      disabled={props.disabled || props.readonly}
+      onValueChange={(value) => props.onChange(value)}
+      onBlur={() => props.onBlur(props.id, props.value)}
+      onFocus={() => props.onFocus(props.id, props.value)}
+      ariaLabel={props.label}
+      className={inputClassName}
+    />
+  )
+}
+
+function FieldTemplate(props: FieldTemplateProps) {
+  if (props.hidden) {
+    return <div className="hidden">{props.children}</div>
+  }
+  const isBoolean = props.schema.type === 'boolean'
+  if (isBoolean) {
+    return (
+      <div className="space-y-1">
+        {props.children}
+        {props.rawDescription && (
+          <p className="text-muted-foreground text-xs">{props.rawDescription}</p>
+        )}
+        {props.errors}
+      </div>
+    )
+  }
+  return (
+    <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+      <span>
+        {props.label}
+        {props.required && <span className="text-destructive ml-1">*</span>}
+      </span>
+      {props.children}
+      {props.rawDescription && (
+        <span className="text-muted-foreground text-xs">{props.rawDescription}</span>
+      )}
+      {props.errors}
+    </label>
+  )
+}
+
+function ObjectFieldTemplate(props: ObjectFieldTemplateProps) {
+  return (
+    <div className="space-y-3">
+      {props.properties.map((property: ObjectFieldTemplateProps['properties'][number]) => (
+        <div key={property.name}>{property.content}</div>
+      ))}
+    </div>
+  )
+}
+
+function ErrorListTemplate() {
+  return null
+}
+
+export function TerminalCommandForm({
+  schema,
+  uiSchema,
+  values,
+  onChange,
+}: TerminalCommandFormProps) {
+  const templates = useMemo(
+    () => ({
+      FieldTemplate,
+      ObjectFieldTemplate,
+      ErrorListTemplate,
+      ButtonTemplates: {
+        SubmitButton: () => null,
+      },
+    }),
+    []
+  )
+
+  const widgets = useMemo(
+    () => ({
+      TextWidget,
+      TextareaWidget,
+      CheckboxWidget,
+      SelectWidget,
+    }),
+    []
+  )
+
+  return (
+    <Form
+      schema={schema as RJSFSchema}
+      uiSchema={uiSchema}
+      formData={values}
+      validator={validator}
+      liveValidate={false}
+      omitExtraData
+      templates={templates}
+      widgets={widgets}
+      onChange={(event) => onChange(toTerminalValues(event.formData))}
+    />
+  )
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings.test.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/trpc', () => ({
+  trpcClient: {
+    config: {
+      getTerminalShellDefaults: {
+        query: vi.fn().mockResolvedValue({
+          platform: 'macos',
+          effectiveDefaultShell: {
+            id: 'builtin:env-shell',
+            label: 'SHELL (/bin/zsh)',
+            command: '/bin/zsh',
+            args: [],
+            source: 'builtin',
+            quoteStyle: 'posix',
+          },
+          builtinShellProfiles: [
+            {
+              id: 'builtin:sh',
+              label: '/bin/sh',
+              command: '/bin/sh',
+              args: [],
+              source: 'builtin',
+              quoteStyle: 'posix',
+            },
+            {
+              id: 'builtin:env-shell',
+              label: 'SHELL (/bin/zsh)',
+              command: '/bin/zsh',
+              args: [],
+              source: 'builtin',
+              quoteStyle: 'posix',
+            },
+          ],
+        }),
+      },
+    },
+  },
+}))
+
+describe('TerminalInvocationSettings', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/settings')
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('keeps settings compact and persists custom shell profiles and spawn commands from dialogs', async () => {
+    const { TerminalInvocationSettings } = await import('./terminal-invocation-settings')
+    render(<TerminalInvocationSettings />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Effective platform default:/).textContent).toContain('/bin/zsh')
+    })
+
+    expect(screen.queryByLabelText('Default Shell')).toBeNull()
+    expect(screen.queryByPlaceholderText('Shell label')).toBeNull()
+    expect(screen.queryByPlaceholderText('Command label')).toBeNull()
+    expect(screen.getAllByText('Default').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByRole('button', { name: 'Default' }).length).toBeGreaterThanOrEqual(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Shell' }))
+    fireEvent.change(screen.getByPlaceholderText('Shell label'), {
+      target: { value: 'Git Bash' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('/bin/zsh'), {
+      target: { value: '/usr/bin/bash' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Shell label')).toBeNull()
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: 'Default' }).at(-1)!)
+
+    expect(
+      JSON.parse(localStorage.getItem('terminal-invocation-settings') ?? '{}') as {
+        defaultShellProfileId?: string
+      }
+    ).toMatchObject({
+      defaultShellProfileId: expect.stringContaining('git-bash'),
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Git Bash' }))
+    expect(screen.getByText('Edit Shell')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Command' }))
+    expect(screen.getByText('Parameter 1')).toBeTruthy()
+    expect(screen.getByText('Builder Part 1')).toBeTruthy()
+    const fieldInput = screen.getByLabelText('Field')
+    expect(fieldInput).toBeTruthy()
+    fieldInput.focus()
+    fireEvent.change(fieldInput, {
+      target: { value: 'promptBody' },
+    })
+    expect(document.activeElement).toBe(fieldInput)
+    expect(screen.getByLabelText('Title')).toBeTruthy()
+    expect(screen.getAllByLabelText('Description').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('Default Value').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByLabelText('Default Value')).toBeInstanceOf(HTMLTextAreaElement)
+    expect(screen.queryByLabelText('Select Options')).toBeNull()
+    fireEvent.click(screen.getByRole('combobox', { name: 'Control Type for Prompt' }))
+    const booleanOption = await screen.findByRole('option', { name: 'Boolean' })
+    fireEvent.mouseMove(booleanOption)
+    fireEvent.click(booleanOption)
+    expect(screen.getByRole('combobox', { name: 'Default Value for Prompt' })).toBeTruthy()
+    expect(screen.queryByLabelText('Select Options')).toBeNull()
+    fireEvent.click(screen.getByRole('combobox', { name: 'Control Type for Prompt' }))
+    const selectOption = await screen.findByRole('option', { name: 'Select' })
+    fireEvent.mouseMove(selectOption)
+    fireEvent.click(selectOption)
+    expect(screen.getByLabelText('Select Options')).toBeTruthy()
+    expect(screen.getByLabelText('Literal Value')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Add Parameter' }).className).toContain('bg-primary')
+    expect(screen.getByRole('button', { name: 'Add Literal' }).className).toContain('bg-primary')
+    expect(screen.getByRole('button', { name: 'Remove Prompt' }).className).toContain('bg-red-600')
+    fireEvent.change(screen.getByPlaceholderText('Command label'), {
+      target: { value: 'Claude Safe' },
+    })
+    fireEvent.click(screen.getByRole('combobox', { name: 'Control Type for Prompt' }))
+    const textareaOption = await screen.findByRole('option', { name: 'Textarea' })
+    fireEvent.mouseMove(textareaOption)
+    fireEvent.click(textareaOption)
+    fireEvent.click(screen.getByRole('button', { name: 'Add Boolean Flag' }))
+    expect(screen.getByLabelText('Flag Token')).toBeTruthy()
+    fireEvent.change(screen.getByPlaceholderText('--flag'), {
+      target: { value: '--dangerously-skip-permissions' },
+    })
+    fireEvent.change(screen.getAllByDisplayValue('Flag Enabled')[0]!, {
+      target: { value: 'Skip permissions' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Command label')).toBeNull()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Claude' }))
+    expect(screen.getByText('Edit Command')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    const stored = JSON.parse(localStorage.getItem('terminal-invocation-settings') ?? '{}') as {
+      customShellProfiles?: Array<{ label: string; command: string }>
+      customSpawnCommands?: Array<{
+        label: string
+        command: string
+        builder?: {
+          kind: string
+          parts?: Array<{ kind: string; fieldId?: string; flag?: string; value?: string }>
+        }
+        args: Array<{ kind: string; fieldId?: string; flag?: string }>
+        fields: Array<{ id: string; label: string; type: string; defaultValue?: unknown }>
+      }>
+    }
+
+    expect(stored.customShellProfiles?.[0]).toMatchObject({
+      label: 'Git Bash',
+      command: '/usr/bin/bash',
+    })
+    expect(stored.customSpawnCommands?.[0]).toMatchObject({
+      label: 'Claude Safe',
+      command: 'claude',
+    })
+    expect(stored.customSpawnCommands?.[0]?.builder?.parts).toContainEqual(
+      expect.objectContaining({
+        kind: 'booleanFlag',
+        flag: '--dangerously-skip-permissions',
+      })
+    )
+    expect(stored.customSpawnCommands?.[0]?.fields).toContainEqual(
+      expect.objectContaining({
+        label: 'Skip permissions',
+        type: 'boolean',
+        defaultValue: false,
+      })
+    )
+  })
+})

--- a/packages/web/src/components/terminal/terminal-invocation-settings/helpers.ts
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/helpers.ts
@@ -1,0 +1,54 @@
+import type { TerminalSpawnCommand } from '@openspecui/core/terminal-invocation'
+
+let customIdCounter = 0
+
+export function createCustomId(kind: string, label: string): string {
+  customIdCounter += 1
+  const slug = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  return `custom:${kind}:${slug || 'item'}:${Date.now()}:${customIdCounter}`
+}
+
+export function parseCommaList(input: string): string[] {
+  return input
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+export function formatCommaList(values: readonly string[]): string {
+  return values.join(', ')
+}
+
+export function toFieldId(input: string): string {
+  const slug = input
+    .trim()
+    .replace(/^-+/, '')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  return slug || 'value'
+}
+
+export function formatBuilderSummary(command: TerminalSpawnCommand): string {
+  if (command.builder?.kind === 'shellLine') {
+    return command.builder.template || command.command
+  }
+  if (command.builder?.kind === 'argv') {
+    return command.builder.parts
+      .map((part) => {
+        if (part.kind === 'literal') return part.value
+        if (part.kind === 'booleanFlag') return `${part.flag} when {{${part.fieldId}}}`
+        return `${part.prefix}{{${part.fieldId}}}`
+      })
+      .join(' ')
+  }
+  return [
+    command.command,
+    ...command.args.map((arg) => (arg.kind === 'literal' ? arg.value : `{{${arg.fieldId}}}`)),
+  ]
+    .join(' ')
+    .trim()
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings/index.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/index.tsx
@@ -1,0 +1,21 @@
+import { useTerminalInvocationConfig } from '@/lib/use-terminal-invocation-config'
+import { ShellProfileSettings } from './shell-profile-settings'
+import { SpawnCommandSettings } from './spawn-command-settings'
+
+export function TerminalInvocationSettings() {
+  const terminalInvocation = useTerminalInvocationConfig()
+
+  return (
+    <div className="border-border/70 space-y-4 rounded-md border p-3">
+      <ShellProfileSettings
+        shellDefaults={terminalInvocation.shellDefaults}
+        shellProfiles={terminalInvocation.shellProfiles}
+        defaultShellProfile={terminalInvocation.defaultShellProfile}
+      />
+      <SpawnCommandSettings
+        spawnCommands={terminalInvocation.spawnCommands}
+        shellProfiles={terminalInvocation.shellProfiles}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings/shell-profile-dialog.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/shell-profile-dialog.tsx
@@ -1,0 +1,142 @@
+import { Dialog } from '@/components/dialog'
+import { Select, type SelectOption } from '@/components/select'
+import type {
+  TerminalShellDefaults,
+  TerminalShellProfile,
+  TerminalShellQuoteStyle,
+} from '@openspecui/core/terminal-invocation'
+import { TERMINAL_SHELL_QUOTE_STYLE_VALUES } from '@openspecui/core/terminal-invocation'
+import { Plus, Save } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { createCustomId, formatCommaList, parseCommaList } from './helpers'
+
+const QUOTE_STYLE_OPTIONS: SelectOption<TerminalShellQuoteStyle>[] =
+  TERMINAL_SHELL_QUOTE_STYLE_VALUES.map((style) => ({
+    value: style,
+    label: style,
+  }))
+
+interface ShellProfileDialogProps {
+  open: boolean
+  shell: TerminalShellProfile | null
+  shellDefaults: TerminalShellDefaults
+  onClose: () => void
+  onSave: (shell: TerminalShellProfile) => void
+}
+
+export function ShellProfileDialog({
+  open,
+  shell,
+  shellDefaults,
+  onClose,
+  onSave,
+}: ShellProfileDialogProps) {
+  const [label, setLabel] = useState('')
+  const [command, setCommand] = useState('')
+  const [args, setArgs] = useState('')
+  const [quoteStyle, setQuoteStyle] = useState<TerminalShellQuoteStyle>('posix')
+
+  useEffect(() => {
+    if (!open) return
+    setLabel(shell?.label ?? '')
+    setCommand(shell?.command ?? '')
+    setArgs(formatCommaList(shell?.args ?? []))
+    setQuoteStyle(shell?.quoteStyle ?? 'posix')
+  }, [open, shell])
+
+  const handleSave = () => {
+    const trimmedCommand = command.trim()
+    if (!trimmedCommand) return
+    const trimmedLabel = label.trim() || trimmedCommand
+    onSave({
+      id: shell?.id ?? createCustomId('shell', trimmedLabel),
+      label: trimmedLabel,
+      command: trimmedCommand,
+      args: parseCommaList(args),
+      source: 'custom',
+      quoteStyle,
+    })
+    onClose()
+  }
+
+  if (!open) return null
+
+  return (
+    <Dialog
+      open={open}
+      title={
+        <>
+          {shell ? (
+            <Save className="text-primary h-4 w-4" />
+          ) : (
+            <Plus className="text-primary h-4 w-4" />
+          )}
+          <span>{shell ? 'Edit Shell' : 'Add Shell'}</span>
+        </>
+      }
+      onClose={onClose}
+      className="max-w-2xl"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border-border hover:bg-muted rounded-md border px-3 py-1.5 text-xs"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!command.trim()}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {shell ? <Save className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+            {shell ? 'Save' : 'Add'}
+          </button>
+        </>
+      }
+    >
+      <div className="grid gap-4">
+        <label className="flex flex-col gap-1 text-xs font-medium">
+          Label
+          <input
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Shell label"
+            className="bg-background border-border text-foreground focus:ring-primary rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium">
+          Command
+          <input
+            value={command}
+            onChange={(event) => setCommand(event.target.value)}
+            placeholder={shellDefaults.effectiveDefaultShell.command}
+            className="bg-background border-border text-foreground focus:ring-primary rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
+          />
+        </label>
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
+          <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+            Args
+            <input
+              value={args}
+              onChange={(event) => setArgs(event.target.value)}
+              placeholder="Shell args"
+              className="bg-background border-border text-foreground focus:ring-primary rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium">
+            Quote Style
+            <Select
+              value={quoteStyle}
+              options={QUOTE_STYLE_OPTIONS}
+              onValueChange={setQuoteStyle}
+              ariaLabel="Quote Style"
+            />
+          </label>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings/shell-profile-settings.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/shell-profile-settings.tsx
@@ -1,0 +1,126 @@
+import { terminalInvocationConfigStore } from '@/lib/terminal-invocation-config'
+import type {
+  TerminalShellDefaults,
+  TerminalShellProfile,
+} from '@openspecui/core/terminal-invocation'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { ShellProfileDialog } from './shell-profile-dialog'
+
+interface ShellProfileSettingsProps {
+  shellDefaults: TerminalShellDefaults
+  shellProfiles: TerminalShellProfile[]
+  defaultShellProfile: TerminalShellProfile
+}
+
+export function ShellProfileSettings({
+  shellDefaults,
+  shellProfiles,
+  defaultShellProfile,
+}: ShellProfileSettingsProps) {
+  const [editingShell, setEditingShell] = useState<TerminalShellProfile | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const openAddDialog = () => {
+    setEditingShell(null)
+    setDialogOpen(true)
+  }
+
+  const editShell = (shell: TerminalShellProfile) => {
+    setEditingShell(shell)
+    setDialogOpen(true)
+  }
+
+  const saveShell = (shell: TerminalShellProfile) => {
+    terminalInvocationConfigStore.upsertCustomShellProfile(shell)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium">Shells</h3>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Effective platform default: <code>{shellDefaults.effectiveDefaultShell.command}</code>
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openAddDialog}
+          className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium hover:opacity-90"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add Shell
+        </button>
+      </div>
+
+      <div className="border-border divide-border overflow-hidden rounded-md border">
+        {shellProfiles.map((shell) => {
+          const isDefault = shell.id === defaultShellProfile.id
+          return (
+            <div
+              key={shell.id}
+              className="flex min-w-0 items-center justify-between gap-3 border-b px-3 py-2 last:border-b-0"
+            >
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-sm font-medium">{shell.label}</span>
+                  <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[10px] uppercase">
+                    {shell.source}
+                  </span>
+                </div>
+                <div className="text-muted-foreground truncate text-xs">
+                  {shell.command}
+                  {shell.args.length > 0 ? ` ${shell.args.join(' ')}` : ''}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {isDefault ? (
+                  <span className="bg-primary/10 text-primary rounded px-2 py-1 text-[11px] font-medium">
+                    Default
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => terminalInvocationConfigStore.setDefaultShellProfileId(shell.id)}
+                    className="border-border hover:bg-muted rounded border px-2 py-1 text-[11px] font-medium"
+                  >
+                    Default
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => editShell(shell)}
+                  className="hover:bg-muted rounded p-1"
+                  aria-label={`Edit ${shell.label}`}
+                  title={`Edit ${shell.label}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+                {shell.source === 'custom' && (
+                  <button
+                    type="button"
+                    onClick={() => terminalInvocationConfigStore.removeCustomShellProfile(shell.id)}
+                    className="inline-flex items-center justify-center rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:outline-none focus:ring-1 focus:ring-red-500"
+                    aria-label={`Remove ${shell.label}`}
+                    title={`Remove ${shell.label}`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <ShellProfileDialog
+        open={dialogOpen}
+        shell={editingShell}
+        shellDefaults={shellDefaults}
+        onClose={() => setDialogOpen(false)}
+        onSave={saveShell}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings/spawn-command-config-dialog.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/spawn-command-config-dialog.tsx
@@ -1,0 +1,900 @@
+import { Dialog } from '@/components/dialog'
+import { Select, type SelectOption } from '@/components/select'
+import { Switch } from '@/components/switch'
+import {
+  fieldsToTerminalCommandParameters,
+  getTerminalCommandDefaultValues,
+  renderTerminalSpawnCommandLine,
+  type TerminalCommandBuilder,
+  type TerminalCommandBuilderPart,
+  type TerminalCommandField,
+  type TerminalCommandFieldValue,
+  type TerminalShellProfile,
+  type TerminalSpawnCommand,
+} from '@openspecui/core/terminal-invocation'
+import { Plus, Save, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { createCustomId, formatBuilderSummary, toFieldId } from './helpers'
+
+interface SpawnCommandConfigDialogProps {
+  open: boolean
+  command: TerminalSpawnCommand | null
+  shellProfiles: readonly TerminalShellProfile[]
+  onClose: () => void
+  onSave: (command: TerminalSpawnCommand) => void
+}
+
+type EditableFieldType = TerminalCommandField['type']
+
+interface EditableField {
+  key: string
+  id: string
+  label: string
+  type: EditableFieldType
+  description: string
+  defaultValue: string | boolean
+  options: string
+  required: boolean
+  advanced: boolean
+}
+
+interface EditableBuilderPart {
+  key: string
+  kind: TerminalCommandBuilderPart['kind']
+  value: string
+  fieldId: string
+  flag: string
+  prefix: string
+  omitWhenEmpty: boolean
+}
+
+const inputClassName =
+  'bg-background border-border text-foreground focus:ring-primary rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1'
+const fieldLabelClassName = 'flex min-w-0 flex-col gap-1 text-xs font-medium'
+const primaryButtonClassName =
+  'bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
+const destructiveButtonClassName =
+  'inline-flex h-8 w-8 items-center justify-center rounded-md bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-1 focus:ring-red-500 disabled:cursor-not-allowed disabled:opacity-50'
+
+const FIELD_TYPE_OPTIONS: SelectOption<EditableFieldType>[] = [
+  { value: 'text', label: 'Text' },
+  { value: 'textarea', label: 'Textarea' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'select', label: 'Select' },
+]
+
+const BUILDER_PART_OPTIONS: SelectOption<EditableBuilderPart['kind']>[] = [
+  { value: 'literal', label: 'Literal' },
+  { value: 'field', label: 'Field' },
+  { value: 'booleanFlag', label: 'Boolean Flag' },
+]
+
+let editableKeyCounter = 0
+
+function createEditableKey(prefix: string): string {
+  editableKeyCounter += 1
+  return `${prefix}:${editableKeyCounter}`
+}
+
+function fieldToEditable(field: TerminalCommandField): EditableField {
+  return {
+    key: createEditableKey('field'),
+    id: field.id,
+    label: field.label,
+    type: field.type,
+    description: field.description ?? field.placeholder ?? '',
+    defaultValue:
+      typeof field.defaultValue === 'boolean'
+        ? field.defaultValue
+        : typeof field.defaultValue === 'string'
+          ? field.defaultValue
+          : field.type === 'boolean'
+            ? false
+            : '',
+    options: field.options.join(', '),
+    required: field.required,
+    advanced: field.advanced,
+  }
+}
+
+function editableToField(field: EditableField): TerminalCommandField {
+  const options = field.options
+    .split(',')
+    .map((option) => option.trim())
+    .filter(Boolean)
+  return {
+    id: toFieldId(field.id || field.label),
+    label: field.label.trim() || field.id,
+    type: field.type,
+    description: field.description.trim() || undefined,
+    defaultValue:
+      field.type === 'boolean'
+        ? field.defaultValue === true
+        : typeof field.defaultValue === 'string'
+          ? field.defaultValue
+          : '',
+    options,
+    required: field.required,
+    advanced: field.advanced,
+  }
+}
+
+function builderPartToEditable(part: TerminalCommandBuilderPart): EditableBuilderPart {
+  if (part.kind === 'literal') {
+    return {
+      key: createEditableKey('part'),
+      kind: 'literal',
+      value: part.value,
+      fieldId: '',
+      flag: '',
+      prefix: '',
+      omitWhenEmpty: true,
+    }
+  }
+  if (part.kind === 'booleanFlag') {
+    return {
+      key: createEditableKey('part'),
+      kind: 'booleanFlag',
+      value: '',
+      fieldId: part.fieldId,
+      flag: part.flag,
+      prefix: '',
+      omitWhenEmpty: true,
+    }
+  }
+  return {
+    key: createEditableKey('part'),
+    kind: 'field',
+    value: '',
+    fieldId: part.fieldId,
+    flag: '',
+    prefix: part.prefix,
+    omitWhenEmpty: part.omitWhenEmpty,
+  }
+}
+
+function editableToBuilderPart(part: EditableBuilderPart): TerminalCommandBuilderPart | null {
+  if (part.kind === 'literal') {
+    const value = part.value.trim()
+    return value ? { kind: 'literal', value } : null
+  }
+  if (part.kind === 'booleanFlag') {
+    const fieldId = part.fieldId.trim()
+    const flag = part.flag.trim()
+    return fieldId && flag ? { kind: 'booleanFlag', fieldId, flag } : null
+  }
+  const fieldId = part.fieldId.trim()
+  return fieldId
+    ? { kind: 'field', fieldId, prefix: part.prefix, omitWhenEmpty: part.omitWhenEmpty }
+    : null
+}
+
+function makeDefaultFields(command: TerminalSpawnCommand | null): EditableField[] {
+  if (command?.fields.length) return command.fields.map(fieldToEditable)
+  return [
+    {
+      key: createEditableKey('field'),
+      id: 'prompt',
+      label: 'Prompt',
+      type: 'textarea',
+      description: 'Prompt',
+      defaultValue: '',
+      options: '',
+      required: false,
+      advanced: false,
+    },
+  ]
+}
+
+function makeDefaultBuilderParts(command: TerminalSpawnCommand | null): EditableBuilderPart[] {
+  if (command?.builder?.kind === 'argv') {
+    return command.builder.parts.map(builderPartToEditable)
+  }
+  if (command?.builder?.kind === 'shellLine') return []
+  if (command) {
+    return [
+      builderPartToEditable({ kind: 'literal', value: command.command }),
+      ...command.args.map((arg) => builderPartToEditable(arg)),
+    ]
+  }
+  return [
+    builderPartToEditable({ kind: 'literal', value: 'claude' }),
+    builderPartToEditable({ kind: 'field', fieldId: 'prompt', prefix: '', omitWhenEmpty: true }),
+  ]
+}
+
+function makeSampleValues(
+  fields: readonly TerminalCommandField[]
+): Record<string, TerminalCommandFieldValue> {
+  const values: Record<string, TerminalCommandFieldValue> = {}
+  for (const field of fields) {
+    if (field.type === 'boolean') {
+      values[field.id] = field.defaultValue === true
+    } else if (typeof field.defaultValue === 'string' && field.defaultValue.length > 0) {
+      values[field.id] = field.defaultValue
+    } else if (field.type === 'select') {
+      values[field.id] = field.options[0] ?? ''
+    } else {
+      values[field.id] = field.id === 'prompt' ? 'Example prompt' : `example-${field.id}`
+    }
+  }
+  return values
+}
+
+export function SpawnCommandConfigDialog({
+  open,
+  command,
+  shellProfiles,
+  onClose,
+  onSave,
+}: SpawnCommandConfigDialogProps) {
+  const [label, setLabel] = useState('')
+  const [description, setDescription] = useState('')
+  const [shellProfileId, setShellProfileId] = useState('')
+  const [builderKind, setBuilderKind] = useState<TerminalCommandBuilder['kind']>('argv')
+  const [shellLineTemplate, setShellLineTemplate] = useState('')
+  const [fields, setFields] = useState<EditableField[]>(makeDefaultFields(null))
+  const [parts, setParts] = useState<EditableBuilderPart[]>(makeDefaultBuilderParts(null))
+
+  useEffect(() => {
+    if (!open) return
+    setLabel(command?.label ?? '')
+    setDescription(command?.description ?? '')
+    setShellProfileId(command?.shellProfileId ?? '')
+    setBuilderKind(command?.builder?.kind ?? 'argv')
+    setShellLineTemplate(command?.builder?.kind === 'shellLine' ? command.builder.template : '')
+    setFields(makeDefaultFields(command))
+    setParts(makeDefaultBuilderParts(command))
+  }, [command, open])
+
+  const normalizedFields = useMemo(() => fields.map(editableToField), [fields])
+  const parameters = useMemo(
+    () => fieldsToTerminalCommandParameters(normalizedFields),
+    [normalizedFields]
+  )
+  const builder = useMemo<TerminalCommandBuilder>(() => {
+    if (builderKind === 'shellLine') {
+      return { kind: 'shellLine', template: shellLineTemplate }
+    }
+    return {
+      kind: 'argv',
+      parts: parts.map(editableToBuilderPart).filter((part) => part !== null),
+    }
+  }, [builderKind, parts, shellLineTemplate])
+  const executable = useMemo(() => {
+    if (builder.kind === 'argv') {
+      const literal = builder.parts.find((part) => part.kind === 'literal')
+      return literal?.kind === 'literal' ? literal.value : 'command'
+    }
+    return shellLineTemplate.trim().split(/\s+/)[0] || 'command'
+  }, [builder, shellLineTemplate])
+  const selectedShell = useMemo(
+    () => shellProfiles.find((shell) => shell.id === shellProfileId),
+    [shellProfileId, shellProfiles]
+  )
+  const shellOptions = useMemo<SelectOption<string>[]>(
+    () => [
+      { value: '', label: 'Default shell' },
+      ...shellProfiles.map((shell) => ({
+        value: shell.id,
+        label: shell.label,
+      })),
+    ],
+    [shellProfiles]
+  )
+  const fieldOptions = useMemo<SelectOption<string>[]>(
+    () =>
+      normalizedFields.map((field) => ({
+        value: field.id,
+        label: field.label,
+      })),
+    [normalizedFields]
+  )
+  const isBuilderValid =
+    builder.kind === 'argv' ? builder.parts.length > 0 : builder.template.trim().length > 0
+  const previewCommand = useMemo<TerminalSpawnCommand>(
+    () => ({
+      id: command?.id ?? 'preview',
+      label: label.trim() || executable,
+      description: description.trim() || undefined,
+      command: executable,
+      args: [],
+      fields: normalizedFields,
+      parameters,
+      builder,
+      shellProfileId: shellProfileId || undefined,
+      source: 'custom',
+    }),
+    [
+      builder,
+      command?.id,
+      description,
+      executable,
+      label,
+      normalizedFields,
+      parameters,
+      shellProfileId,
+    ]
+  )
+  const previewLine = useMemo(() => {
+    const values = {
+      ...getTerminalCommandDefaultValues(previewCommand),
+      ...makeSampleValues(normalizedFields),
+    }
+    return renderTerminalSpawnCommandLine({
+      command: previewCommand,
+      values,
+      quoteStyle: selectedShell?.quoteStyle ?? 'posix',
+    })
+  }, [normalizedFields, previewCommand, selectedShell?.quoteStyle])
+
+  const addField = () => {
+    const nextIndex = fields.length + 1
+    setFields((current) => [
+      ...current,
+      {
+        key: createEditableKey('field'),
+        id: `arg${nextIndex}`,
+        label: `Arg ${nextIndex}`,
+        type: 'text',
+        description: '',
+        defaultValue: '',
+        options: '',
+        required: false,
+        advanced: false,
+      },
+    ])
+  }
+
+  const addPart = (kind: EditableBuilderPart['kind']) => {
+    if (kind === 'booleanFlag') {
+      const existingBooleanField = normalizedFields.find((field) => field.type === 'boolean')
+      const fieldId = existingBooleanField?.id ?? `flag${fields.length + 1}`
+      if (!existingBooleanField) {
+        setFields((current) => [
+          ...current,
+          {
+            key: createEditableKey('field'),
+            id: fieldId,
+            label: 'Flag Enabled',
+            type: 'boolean',
+            description: '',
+            defaultValue: false,
+            options: '',
+            required: false,
+            advanced: false,
+          },
+        ])
+      }
+      setParts((current) => [
+        ...current,
+        {
+          key: createEditableKey('part'),
+          kind,
+          value: '',
+          fieldId,
+          flag: '--flag',
+          prefix: '',
+          omitWhenEmpty: true,
+        },
+      ])
+      return
+    }
+    setParts((current) => [
+      ...current,
+      {
+        key: createEditableKey('part'),
+        kind,
+        value: kind === 'literal' ? 'literal' : '',
+        fieldId: normalizedFields[0]?.id ?? '',
+        flag: '',
+        prefix: '',
+        omitWhenEmpty: true,
+      },
+    ])
+  }
+
+  const handleSave = () => {
+    const trimmedLabel = label.trim() || executable
+    if (!trimmedLabel || !isBuilderValid) return
+    onSave({
+      id: command?.id ?? createCustomId('command', trimmedLabel),
+      label: trimmedLabel,
+      description: description.trim() || undefined,
+      command: executable,
+      args: [],
+      fields: normalizedFields,
+      parameters,
+      builder,
+      shellProfileId: shellProfileId || undefined,
+      source: 'custom',
+    })
+    onClose()
+  }
+
+  if (!open) return null
+
+  return (
+    <Dialog
+      open={open}
+      title={
+        <>
+          {command ? (
+            <Save className="text-primary h-4 w-4" />
+          ) : (
+            <Plus className="text-primary h-4 w-4" />
+          )}
+          <span>{command ? 'Edit Command' : 'Add Command'}</span>
+        </>
+      }
+      onClose={onClose}
+      className="max-w-4xl"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border-border hover:bg-muted rounded-md border px-3 py-1.5 text-xs"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!isBuilderValid}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {command ? <Save className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+            {command ? 'Save' : 'Add'}
+          </button>
+        </>
+      }
+    >
+      <div className="grid gap-5">
+        <section className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px]">
+          <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+            Label
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="Command label"
+              className={inputClassName}
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+            Shell
+            <Select
+              value={shellProfileId}
+              options={shellOptions}
+              onValueChange={setShellProfileId}
+              ariaLabel="Shell"
+              className={inputClassName}
+            />
+          </label>
+          <label className="flex min-w-0 flex-col gap-1 text-xs font-medium md:col-span-2">
+            Description
+            <input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Optional description"
+              className={inputClassName}
+            />
+          </label>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-medium">Parameters</h3>
+            <button type="button" onClick={addField} className={primaryButtonClassName}>
+              <Plus className="h-3.5 w-3.5" />
+              Add Parameter
+            </button>
+          </div>
+          <div className="space-y-2">
+            {fields.map((field, index) => (
+              <div key={field.key} className="border-border rounded-md border p-3">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div className="text-muted-foreground text-[11px] font-medium uppercase">
+                    Parameter {index + 1}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <label className="flex items-center gap-2 text-xs">
+                      <Switch
+                        checked={field.advanced}
+                        onCheckedChange={(checked) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, advanced: checked } : item
+                            )
+                          )
+                        }
+                      />
+                      Advanced
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setFields((current) =>
+                          current.filter((_item, itemIndex) => itemIndex !== index)
+                        )
+                      }
+                      className={destructiveButtonClassName}
+                      aria-label={`Remove ${field.label || field.id}`}
+                      title={`Remove ${field.label || field.id}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-[150px_minmax(0,1fr)]">
+                  <label className={fieldLabelClassName}>
+                    Field
+                    <input
+                      value={field.id}
+                      onChange={(event) => {
+                        const previousFieldId = toFieldId(field.id || field.label)
+                        const nextRawFieldId = event.target.value
+                        const nextFieldId = toFieldId(nextRawFieldId || field.label)
+                        setFields((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index ? { ...item, id: nextRawFieldId } : item
+                          )
+                        )
+                        if (previousFieldId !== nextFieldId) {
+                          setParts((current) =>
+                            current.map((item) =>
+                              item.fieldId === previousFieldId
+                                ? { ...item, fieldId: nextFieldId }
+                                : item
+                            )
+                          )
+                        }
+                      }}
+                      placeholder="fieldId"
+                      className={inputClassName}
+                    />
+                  </label>
+                  <label className={fieldLabelClassName}>
+                    Title
+                    <input
+                      value={field.label}
+                      onChange={(event) =>
+                        setFields((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index ? { ...item, label: event.target.value } : item
+                          )
+                        )
+                      }
+                      placeholder="Label"
+                      className={inputClassName}
+                    />
+                  </label>
+                  <label className={`${fieldLabelClassName} md:col-span-2`}>
+                    Description
+                    <input
+                      value={field.description}
+                      onChange={(event) =>
+                        setFields((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index
+                              ? { ...item, description: event.target.value }
+                              : item
+                          )
+                        )
+                      }
+                      placeholder="Shown below the rendered field"
+                      className={inputClassName}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-3 grid gap-3 md:grid-cols-[180px_minmax(0,1fr)_160px]">
+                  <label className={fieldLabelClassName}>
+                    Control Type
+                    <Select
+                      value={field.type}
+                      options={FIELD_TYPE_OPTIONS}
+                      onValueChange={(nextType) =>
+                        setFields((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index
+                              ? {
+                                  ...item,
+                                  type: nextType,
+                                  defaultValue:
+                                    nextType === 'boolean' ? false : String(item.defaultValue),
+                                }
+                              : item
+                          )
+                        )
+                      }
+                      ariaLabel={`Control Type for ${field.label || field.id}`}
+                      className={inputClassName}
+                    />
+                  </label>
+                  {field.type === 'textarea' ? (
+                    <label className={fieldLabelClassName}>
+                      Default Value
+                      <textarea
+                        value={typeof field.defaultValue === 'string' ? field.defaultValue : ''}
+                        onChange={(event) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index
+                                ? { ...item, defaultValue: event.target.value }
+                                : item
+                            )
+                          )
+                        }
+                        placeholder="Default text"
+                        rows={3}
+                        className={inputClassName}
+                      />
+                    </label>
+                  ) : field.type === 'boolean' ? (
+                    <label className={fieldLabelClassName}>
+                      Default Value
+                      <Select
+                        value={field.defaultValue === true ? 'true' : 'false'}
+                        options={[
+                          { value: 'false', label: 'false' },
+                          { value: 'true', label: 'true' },
+                        ]}
+                        onValueChange={(nextValue) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index
+                                ? { ...item, defaultValue: nextValue === 'true' }
+                                : item
+                            )
+                          )
+                        }
+                        ariaLabel={`Default Value for ${field.label || field.id}`}
+                        className={inputClassName}
+                      />
+                    </label>
+                  ) : (
+                    <label className={fieldLabelClassName}>
+                      Default Value
+                      <input
+                        value={typeof field.defaultValue === 'string' ? field.defaultValue : ''}
+                        onChange={(event) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index
+                                ? { ...item, defaultValue: event.target.value }
+                                : item
+                            )
+                          )
+                        }
+                        placeholder={field.type === 'select' ? 'Default option' : 'Default value'}
+                        className={inputClassName}
+                      />
+                    </label>
+                  )}
+                  <label className={fieldLabelClassName}>
+                    Required
+                    <span className="border-border flex min-h-9 items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
+                      <span>Required</span>
+                      <Switch
+                        checked={field.required}
+                        onCheckedChange={(checked) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, required: checked } : item
+                            )
+                          )
+                        }
+                      />
+                    </span>
+                  </label>
+                </div>
+
+                {field.type === 'select' && (
+                  <div className="mt-3">
+                    <label className={fieldLabelClassName}>
+                      Select Options
+                      <input
+                        value={field.options}
+                        onChange={(event) =>
+                          setFields((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, options: event.target.value } : item
+                            )
+                          )
+                        }
+                        placeholder="Option A, Option B"
+                        className={inputClassName}
+                      />
+                    </label>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h3 className="text-sm font-medium">Builder</h3>
+            <div className="inline-flex rounded-md border">
+              <button
+                type="button"
+                onClick={() => setBuilderKind('argv')}
+                className={`px-2 py-1 text-xs ${builderKind === 'argv' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
+              >
+                argv
+              </button>
+              <button
+                type="button"
+                onClick={() => setBuilderKind('shellLine')}
+                className={`border-l px-2 py-1 text-xs ${builderKind === 'shellLine' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}
+              >
+                shellLine
+              </button>
+            </div>
+          </div>
+
+          {builderKind === 'shellLine' ? (
+            <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+              Template
+              <textarea
+                value={shellLineTemplate}
+                onChange={(event) => setShellLineTemplate(event.target.value)}
+                placeholder="claude {{prompt}}"
+                rows={4}
+                className={inputClassName}
+              />
+            </label>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => addPart('literal')}
+                  className={primaryButtonClassName}
+                >
+                  Add Literal
+                </button>
+                <button
+                  type="button"
+                  onClick={() => addPart('field')}
+                  className={primaryButtonClassName}
+                >
+                  Add Field
+                </button>
+                <button
+                  type="button"
+                  onClick={() => addPart('booleanFlag')}
+                  className={primaryButtonClassName}
+                >
+                  Add Boolean Flag
+                </button>
+              </div>
+              {parts.map((part, index) => (
+                <div
+                  key={part.key}
+                  className="border-border grid items-end gap-3 rounded-md border p-3 md:grid-cols-[150px_minmax(0,1fr)_minmax(0,1fr)_auto]"
+                >
+                  <div className="text-muted-foreground text-[11px] font-medium uppercase md:col-span-4">
+                    Builder Part {index + 1}
+                  </div>
+                  <label className={fieldLabelClassName}>
+                    Part Type
+                    <Select
+                      value={part.kind}
+                      options={BUILDER_PART_OPTIONS}
+                      onValueChange={(nextKind) =>
+                        setParts((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index
+                              ? {
+                                  ...item,
+                                  kind: nextKind,
+                                }
+                              : item
+                          )
+                        )
+                      }
+                      ariaLabel={`Part Type for builder part ${index + 1}`}
+                      className={inputClassName}
+                    />
+                  </label>
+                  {part.kind === 'literal' ? (
+                    <label className={fieldLabelClassName}>
+                      Literal Value
+                      <input
+                        value={part.value}
+                        onChange={(event) =>
+                          setParts((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, value: event.target.value } : item
+                            )
+                          )
+                        }
+                        placeholder="claude"
+                        className={inputClassName}
+                      />
+                    </label>
+                  ) : (
+                    <label className={fieldLabelClassName}>
+                      Source Field
+                      <Select
+                        value={part.fieldId}
+                        options={fieldOptions}
+                        onValueChange={(fieldId) =>
+                          setParts((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, fieldId } : item
+                            )
+                          )
+                        }
+                        ariaLabel={`Source Field for builder part ${index + 1}`}
+                        className={inputClassName}
+                      />
+                    </label>
+                  )}
+                  {part.kind === 'booleanFlag' ? (
+                    <label className={fieldLabelClassName}>
+                      Flag Token
+                      <input
+                        value={part.flag}
+                        onChange={(event) =>
+                          setParts((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, flag: event.target.value } : item
+                            )
+                          )
+                        }
+                        placeholder="--flag"
+                        className={inputClassName}
+                      />
+                    </label>
+                  ) : part.kind === 'field' ? (
+                    <label className={fieldLabelClassName}>
+                      Prefix
+                      <input
+                        value={part.prefix}
+                        onChange={(event) =>
+                          setParts((current) =>
+                            current.map((item, itemIndex) =>
+                              itemIndex === index ? { ...item, prefix: event.target.value } : item
+                            )
+                          )
+                        }
+                        placeholder="Prefix"
+                        className={inputClassName}
+                      />
+                    </label>
+                  ) : (
+                    <div />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setParts((current) =>
+                        current.filter((_item, itemIndex) => itemIndex !== index)
+                      )
+                    }
+                    className={destructiveButtonClassName}
+                    aria-label={`Remove builder part ${index + 1}`}
+                    title={`Remove builder part ${index + 1}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <div className="bg-muted/30 border-border rounded-md border px-3 py-2 text-xs">
+          <span className="text-muted-foreground mr-1">Preview:</span>
+          <code className="whitespace-pre-wrap break-words">{previewLine}</code>
+          <div className="text-muted-foreground mt-1">{formatBuilderSummary(previewCommand)}</div>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-invocation-settings/spawn-command-settings.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings/spawn-command-settings.tsx
@@ -1,0 +1,106 @@
+import { terminalInvocationConfigStore } from '@/lib/terminal-invocation-config'
+import type {
+  TerminalShellProfile,
+  TerminalSpawnCommand,
+} from '@openspecui/core/terminal-invocation'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { formatBuilderSummary } from './helpers'
+import { SpawnCommandConfigDialog } from './spawn-command-config-dialog'
+
+interface SpawnCommandSettingsProps {
+  spawnCommands: TerminalSpawnCommand[]
+  shellProfiles: readonly TerminalShellProfile[]
+}
+
+export function SpawnCommandSettings({ spawnCommands, shellProfiles }: SpawnCommandSettingsProps) {
+  const [editingCommand, setEditingCommand] = useState<TerminalSpawnCommand | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const openAddDialog = () => {
+    setEditingCommand(null)
+    setDialogOpen(true)
+  }
+
+  const editCommand = (command: TerminalSpawnCommand) => {
+    setEditingCommand(command)
+    setDialogOpen(true)
+  }
+
+  const saveCommand = (command: TerminalSpawnCommand) => {
+    terminalInvocationConfigStore.upsertCustomSpawnCommand(command)
+  }
+
+  return (
+    <div className="border-border/60 space-y-2 border-t pt-4">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium">Spawn Commands</h3>
+        <button
+          type="button"
+          onClick={openAddDialog}
+          className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium hover:opacity-90"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add Command
+        </button>
+      </div>
+
+      <div className="border-border divide-border overflow-hidden rounded-md border">
+        {spawnCommands.map((command) => {
+          const selectedShell = shellProfiles.find((shell) => shell.id === command.shellProfileId)
+          return (
+            <div
+              key={command.id}
+              className="flex min-w-0 items-center justify-between gap-3 border-b px-3 py-2 last:border-b-0"
+            >
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-sm font-medium">{command.label}</span>
+                  <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-[10px] uppercase">
+                    {command.source}
+                  </span>
+                </div>
+                <div className="text-muted-foreground truncate text-xs">
+                  {formatBuilderSummary(command)}
+                  {selectedShell ? ` · ${selectedShell.label}` : ' · Default shell'}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => editCommand(command)}
+                  className="hover:bg-muted rounded p-1"
+                  aria-label={`Edit ${command.label}`}
+                  title={`Edit ${command.label}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+                {command.source === 'custom' && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      terminalInvocationConfigStore.removeCustomSpawnCommand(command.id)
+                    }
+                    className="inline-flex items-center justify-center rounded bg-red-600 p-1 text-white hover:bg-red-700 focus:outline-none focus:ring-1 focus:ring-red-500"
+                    aria-label={`Remove ${command.label}`}
+                    title={`Remove ${command.label}`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <SpawnCommandConfigDialog
+        open={dialogOpen}
+        command={editingCommand}
+        shellProfiles={shellProfiles}
+        onClose={() => setDialogOpen(false)}
+        onSave={saveCommand}
+      />
+    </div>
+  )
+}

--- a/packages/web/src/components/terminal/terminal-panel.test.tsx
+++ b/packages/web/src/components/terminal/terminal-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TerminalPanel } from './terminal-panel'
@@ -14,6 +14,8 @@ const {
   subscribeMock,
   setInputPanelMountTargetMock,
   setInputPanelDefaultLayoutMock,
+  useTerminalInvocationConfigMock,
+  createShellSessionMock,
 } = vi.hoisted(() => ({
   useTerminalContextMock: vi.fn(),
   useNavLayoutMock: vi.fn(),
@@ -23,6 +25,8 @@ const {
   subscribeMock: vi.fn<() => typeof noopUnsubscribe>(() => noopUnsubscribe),
   setInputPanelMountTargetMock: vi.fn(),
   setInputPanelDefaultLayoutMock: vi.fn(),
+  useTerminalInvocationConfigMock: vi.fn(),
+  createShellSessionMock: vi.fn(),
 }))
 
 vi.mock('@/lib/terminal-context', () => ({
@@ -31,6 +35,10 @@ vi.mock('@/lib/terminal-context', () => ({
 
 vi.mock('@/lib/use-nav-controller', () => ({
   useNavLayout: () => useNavLayoutMock(),
+}))
+
+vi.mock('@/lib/use-terminal-invocation-config', () => ({
+  useTerminalInvocationConfig: () => useTerminalInvocationConfigMock(),
 }))
 
 vi.mock('@/lib/nav-controller', () => ({
@@ -90,9 +98,40 @@ describe('TerminalPanel', () => {
       ],
       activeSessionId: 'shell-1',
       setActiveSession: vi.fn(),
-      createSession: vi.fn(),
+      createShellSession: createShellSessionMock,
       closeSession: vi.fn(),
       setCustomTitle: vi.fn(),
+    })
+    createShellSessionMock.mockReset()
+    useTerminalInvocationConfigMock.mockReturnValue({
+      shellProfiles: [
+        {
+          id: 'builtin:sh',
+          label: '/bin/sh',
+          command: '/bin/sh',
+          args: [],
+          source: 'builtin',
+          quoteStyle: 'posix',
+        },
+      ],
+      spawnCommands: [
+        {
+          id: 'builtin:claude',
+          label: 'Claude',
+          command: 'claude',
+          args: [],
+          fields: [],
+          source: 'builtin',
+        },
+      ],
+      defaultShellProfile: {
+        id: 'builtin:sh',
+        label: '/bin/sh',
+        command: '/bin/sh',
+        args: [],
+        source: 'builtin',
+        quoteStyle: 'posix',
+      },
     })
     useNavLayoutMock.mockReturnValue({
       bottomTabs: ['/terminal'],
@@ -117,5 +156,43 @@ describe('TerminalPanel', () => {
     const wrapper = tabs.parentElement
     expect(wrapper?.style.getPropertyValue('--terminal')).toBe('#fdf6e3')
     expect(wrapper?.style.getPropertyValue('--terminal-foreground')).toBe('#586e75')
+  })
+
+  it('creates the default shell when clicking the terminal add button', () => {
+    const { getAllByTitle } = render(<TerminalPanel />)
+
+    fireEvent.click(getAllByTitle('New terminal')[0]!)
+
+    expect(createShellSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'builtin:sh', command: '/bin/sh' })
+    )
+  })
+
+  it('creates the default shell from the empty terminal state', () => {
+    useTerminalContextMock.mockReturnValue({
+      sessions: [],
+      activeSessionId: null,
+      setActiveSession: vi.fn(),
+      createShellSession: createShellSessionMock,
+      closeSession: vi.fn(),
+      setCustomTitle: vi.fn(),
+    })
+
+    const { getByText } = render(<TerminalPanel />)
+
+    fireEvent.click(getByText('+'))
+
+    expect(createShellSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'builtin:sh', command: '/bin/sh' })
+    )
+  })
+
+  it('opens shell and command creation choices from the terminal options button', () => {
+    const { getAllByTitle, getByText } = render(<TerminalPanel />)
+
+    fireEvent.click(getAllByTitle('New terminal options')[0]!)
+
+    expect(getByText('/bin/sh')).toBeTruthy()
+    expect(getByText('Claude')).toBeTruthy()
   })
 })

--- a/packages/web/src/components/terminal/terminal-panel.tsx
+++ b/packages/web/src/components/terminal/terminal-panel.tsx
@@ -1,12 +1,29 @@
+import {
+  ContextMenu,
+  type ContextMenuAnchor,
+  type ContextMenuItem,
+} from '@/components/context-menu'
 import type { Tab } from '@/components/tabs'
 import { navController } from '@/lib/nav-controller'
 import { useTerminalContext } from '@/lib/terminal-context'
 import { terminalController } from '@/lib/terminal-controller'
 import { useNavLayout } from '@/lib/use-nav-controller'
+import { useTerminalInvocationConfig } from '@/lib/use-terminal-invocation-config'
 import '@/styles/terminal-effects.css'
-import { Keyboard, PanelBottomClose, PanelTopClose, Plus, X } from 'lucide-react'
+import type { TerminalSpawnCommand } from '@openspecui/core/terminal-invocation'
+import {
+  ChevronDown,
+  Keyboard,
+  PanelBottomClose,
+  PanelTopClose,
+  Plus,
+  Rocket,
+  Terminal,
+  X,
+} from 'lucide-react'
 import {
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -15,6 +32,7 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react'
+import { TerminalSpawnCommandDialog } from './terminal-spawn-command-dialog'
 import { TerminalTabs } from './terminal-tabs'
 import { XtermTerminal } from './xterm-terminal'
 
@@ -103,10 +121,15 @@ export function TerminalPanel({ className }: { className?: string }) {
     sessions,
     activeSessionId,
     setActiveSession,
-    createSession,
+    createShellSession,
     closeSession,
     setCustomTitle,
   } = useTerminalContext()
+  const { shellProfiles, spawnCommands, defaultShellProfile } = useTerminalInvocationConfig()
+  const [menuAnchor, setMenuAnchor] = useState<ContextMenuAnchor | null>(null)
+  const [selectedSpawnCommand, setSelectedSpawnCommand] = useState<TerminalSpawnCommand | null>(
+    null
+  )
 
   const wrapperRef = useRef<HTMLDivElement>(null)
   const terminalSnapshot = useSyncExternalStore(
@@ -179,20 +202,76 @@ export function TerminalPanel({ className }: { className?: string }) {
     terminalController.openInputPanel(activeSessionId ?? undefined)
   }, [activeSessionId])
 
+  const handleCreateDefaultShell = useCallback(() => {
+    createShellSession(defaultShellProfile)
+  }, [createShellSession, defaultShellProfile])
+
+  const handleOpenCreateMenu = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    const element = event.currentTarget
+    setMenuAnchor((current) =>
+      current?.type === 'target' && current.element === element
+        ? null
+        : { type: 'target', element, placement: 'bottom-end' }
+    )
+  }, [])
+
+  const menuItems = useMemo<ContextMenuItem[]>(() => {
+    const shellItems: ContextMenuItem[] = shellProfiles.map((shell) => ({
+      id: `shell:${shell.id}`,
+      label: shell.label,
+      icon: <Terminal className="h-3.5 w-3.5" />,
+      onSelect: () => {
+        createShellSession(shell)
+        setMenuAnchor(null)
+      },
+    }))
+    const commandItems: ContextMenuItem[] = spawnCommands.map((command) => ({
+      id: `command:${command.id}`,
+      label: command.label,
+      icon: <Rocket className="h-3.5 w-3.5" />,
+      onSelect: () => {
+        setSelectedSpawnCommand(command)
+        setMenuAnchor(null)
+      },
+    }))
+    return [
+      ...shellItems,
+      ...(shellItems.length > 0 && commandItems.length > 0
+        ? [{ id: 'separator', label: '', disabled: true, onSelect: () => {} }]
+        : []),
+      ...commandItems,
+    ]
+  }, [createShellSession, shellProfiles, spawnCommands])
+
   const addButton = (
     <button
       type="button"
-      onClick={() => createSession()}
+      onClick={handleCreateDefaultShell}
       className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
+      aria-label="New terminal"
       title="New terminal"
     >
       <Plus className="h-3.5 w-3.5" />
     </button>
   )
 
+  const createMenuButton = (
+    <button
+      type="button"
+      onClick={handleOpenCreateMenu}
+      className="text-terminal-foreground/72 hover:bg-terminal-foreground/10 hover:text-terminal-foreground shrink-0 rounded-md p-1.5 transition"
+      aria-label="New terminal options"
+      title="New terminal options"
+    >
+      <ChevronDown className="h-3.5 w-3.5" />
+    </button>
+  )
+
   const areaActions = (
     <div className="ml-auto flex items-center">
       {addButton}
+      {createMenuButton}
       <button
         type="button"
         onClick={handleOpenInputPanel}
@@ -237,12 +316,13 @@ export function TerminalPanel({ className }: { className?: string }) {
           <span>No terminal sessions. Click</span>
           <button
             type="button"
-            onClick={() => createSession()}
+            onClick={handleCreateDefaultShell}
             className="bg-primary text-primary-foreground mx-2 px-2 text-lg font-bold"
+            aria-label="New terminal"
           >
             +
-          </button>{' '}
-          <span>to create one.</span>
+          </button>
+          {createMenuButton} <span>to create one.</span>
         </div>
       ) : (
         <TerminalTabs
@@ -250,10 +330,22 @@ export function TerminalPanel({ className }: { className?: string }) {
           selectedTab={activeSessionId ?? undefined}
           onTabChange={setActiveSession}
           onTabClose={closeSession}
-          onTabBarDoubleClick={() => createSession()}
+          onTabBarDoubleClick={handleCreateDefaultShell}
           actions={areaActions}
         />
       )}
+      <ContextMenu
+        open={menuAnchor !== null}
+        anchor={menuAnchor}
+        items={menuItems}
+        wrapperElement={wrapperRef.current}
+        onClose={() => setMenuAnchor(null)}
+      />
+      <TerminalSpawnCommandDialog
+        open={selectedSpawnCommand !== null}
+        command={selectedSpawnCommand}
+        onClose={() => setSelectedSpawnCommand(null)}
+      />
     </div>
   )
 }

--- a/packages/web/src/components/terminal/terminal-spawn-command-dialog.test.tsx
+++ b/packages/web/src/components/terminal/terminal-spawn-command-dialog.test.tsx
@@ -1,0 +1,162 @@
+import { fieldsToTerminalCommandParameters } from '@openspecui/core/terminal-invocation'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerminalSpawnCommandDialog } from './terminal-spawn-command-dialog'
+
+const { createShellSessionMock, useTerminalInvocationConfigMock } = vi.hoisted(() => ({
+  createShellSessionMock: vi.fn(),
+  useTerminalInvocationConfigMock: vi.fn(),
+}))
+
+vi.mock('@/lib/terminal-context', () => ({
+  useTerminalContext: () => ({
+    createShellSession: createShellSessionMock,
+  }),
+}))
+
+vi.mock('@/lib/use-terminal-invocation-config', () => ({
+  useTerminalInvocationConfig: () => useTerminalInvocationConfigMock(),
+}))
+
+describe('TerminalSpawnCommandDialog', () => {
+  const shell = {
+    id: 'builtin:sh',
+    label: '/bin/sh',
+    command: '/bin/sh',
+    args: [],
+    source: 'builtin' as const,
+    quoteStyle: 'posix' as const,
+  }
+
+  const command = {
+    id: 'builtin:claude',
+    label: 'Claude',
+    command: 'claude',
+    args: [
+      {
+        kind: 'booleanFlag' as const,
+        fieldId: 'dangerouslySkipPermissions',
+        flag: '--dangerously-skip-permissions',
+      },
+      {
+        kind: 'field' as const,
+        fieldId: 'prompt',
+        prefix: '',
+        omitWhenEmpty: true,
+      },
+    ],
+    fields: [
+      {
+        id: 'prompt',
+        label: 'Prompt',
+        type: 'textarea' as const,
+        options: [],
+        defaultValue: '',
+        required: false,
+        advanced: false,
+      },
+      {
+        id: 'dangerouslySkipPermissions',
+        label: 'Skip permissions',
+        type: 'boolean' as const,
+        options: [],
+        defaultValue: false,
+        required: false,
+        advanced: true,
+      },
+    ],
+    parameters: fieldsToTerminalCommandParameters([
+      {
+        id: 'prompt',
+        label: 'Prompt',
+        type: 'textarea' as const,
+        options: [],
+        defaultValue: '',
+        required: false,
+        advanced: false,
+      },
+      {
+        id: 'dangerouslySkipPermissions',
+        label: 'Skip permissions',
+        type: 'boolean' as const,
+        options: [],
+        defaultValue: false,
+        required: false,
+        advanced: true,
+      },
+    ]),
+    builder: {
+      kind: 'argv' as const,
+      parts: [
+        { kind: 'literal' as const, value: 'claude' },
+        {
+          kind: 'booleanFlag' as const,
+          fieldId: 'dangerouslySkipPermissions',
+          flag: '--dangerously-skip-permissions',
+        },
+        { kind: 'field' as const, fieldId: 'prompt', prefix: '', omitWhenEmpty: true },
+      ],
+    },
+    source: 'builtin' as const,
+  }
+
+  beforeEach(() => {
+    createShellSessionMock.mockReset()
+    createShellSessionMock.mockReturnValue('term-1')
+    useTerminalInvocationConfigMock.mockReturnValue({
+      shellProfiles: [shell],
+      defaultShellProfile: shell,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('prefills prompt values and keeps dangerous flags disabled by default', () => {
+    const { getByDisplayValue } = render(
+      <TerminalSpawnCommandDialog
+        open
+        command={command}
+        presetValues={{ prompt: 'draft prompt' }}
+        onClose={() => {}}
+      />
+    )
+
+    expect(getByDisplayValue('draft prompt')).toBeTruthy()
+    expect(screen.getByRole('checkbox', { name: 'Show advanced options' })).toBeTruthy()
+    expect(screen.queryByRole('checkbox', { name: /Skip permissions/ })).toBeNull()
+    expect(document.body.textContent).toContain("claude 'draft prompt'")
+    expect(document.body.textContent).not.toContain('--dangerously-skip-permissions')
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Show advanced options' }))
+
+    expect(screen.getByRole('checkbox', { name: /Skip permissions/ })).toBeTruthy()
+  })
+
+  it('creates one shell session with rendered initial input', () => {
+    const onClose = vi.fn()
+    const { getByText } = render(
+      <TerminalSpawnCommandDialog
+        open
+        command={command}
+        presetValues={{ prompt: 'run checks' }}
+        onClose={onClose}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Show advanced options' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Skip permissions/ }))
+    fireEvent.click(getByText('Create'))
+
+    expect(createShellSessionMock).toHaveBeenCalledTimes(1)
+    expect(createShellSessionMock).toHaveBeenCalledWith(
+      shell,
+      expect.objectContaining({
+        label: 'Claude',
+        initialInput: "claude --dangerously-skip-permissions 'run checks'\n",
+      })
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/components/terminal/terminal-spawn-command-dialog.tsx
+++ b/packages/web/src/components/terminal/terminal-spawn-command-dialog.tsx
@@ -1,0 +1,224 @@
+import { Dialog } from '@/components/dialog'
+import { Select, type SelectOption } from '@/components/select'
+import { Switch } from '@/components/switch'
+import { useTerminalContext } from '@/lib/terminal-context'
+import { useTerminalInvocationConfig } from '@/lib/use-terminal-invocation-config'
+import {
+  getTerminalCommandDefaultValues,
+  getTerminalCommandParameters,
+  renderTerminalSpawnCommandLine,
+  type TerminalCommandFieldValues,
+  type TerminalCommandJsonSchema,
+  type TerminalCommandJsonSchemaProperty,
+  type TerminalCommandParameters,
+  type TerminalShellProfile,
+  type TerminalSpawnCommand,
+} from '@openspecui/core/terminal-invocation'
+import { Rocket } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { TerminalCommandForm } from './terminal-command-form'
+
+interface TerminalSpawnCommandDialogProps {
+  open: boolean
+  command: TerminalSpawnCommand | null
+  presetValues?: TerminalCommandFieldValues
+  onClose: () => void
+  onCreated?: (sessionId: string) => void
+}
+
+function getShellById(
+  shellProfiles: readonly TerminalShellProfile[],
+  defaultShellProfile: TerminalShellProfile,
+  id: string | undefined
+): TerminalShellProfile {
+  return shellProfiles.find((profile) => profile.id === id) ?? defaultShellProfile
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isAdvancedField(uiSchemaEntry: unknown): boolean {
+  return isRecord(uiSchemaEntry) && uiSchemaEntry['ui:advanced'] === true
+}
+
+function filterTerminalCommandParameters(
+  parameters: TerminalCommandParameters,
+  includeAdvanced: boolean
+): TerminalCommandParameters {
+  if (includeAdvanced) return parameters
+
+  const properties: Record<string, TerminalCommandJsonSchemaProperty> = {}
+  const uiSchema: Record<string, Record<string, unknown>> = {}
+  for (const [fieldId, property] of Object.entries(parameters.schema.properties)) {
+    if (isAdvancedField(parameters.uiSchema[fieldId])) continue
+    properties[fieldId] = property
+    const fieldUiSchema = parameters.uiSchema[fieldId]
+    if (isRecord(fieldUiSchema)) {
+      uiSchema[fieldId] = fieldUiSchema
+    }
+  }
+
+  return {
+    schema: {
+      ...parameters.schema,
+      properties,
+      required: parameters.schema.required.filter((fieldId) => fieldId in properties),
+    } satisfies TerminalCommandJsonSchema,
+    uiSchema,
+  }
+}
+
+function hasAdvancedFields(parameters: TerminalCommandParameters): boolean {
+  return Object.values(parameters.uiSchema).some(isAdvancedField)
+}
+
+export function TerminalSpawnCommandDialog({
+  open,
+  command,
+  presetValues,
+  onClose,
+  onCreated,
+}: TerminalSpawnCommandDialogProps) {
+  const { createShellSession } = useTerminalContext()
+  const { shellProfiles, defaultShellProfile } = useTerminalInvocationConfig()
+  const [values, setValues] = useState<TerminalCommandFieldValues>({})
+  const [shellProfileId, setShellProfileId] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+
+  useEffect(() => {
+    if (!command) return
+    setValues(getTerminalCommandDefaultValues(command, presetValues))
+    setShellProfileId(command.shellProfileId ?? '')
+    setShowAdvanced(false)
+  }, [command, presetValues])
+
+  const selectedShell = useMemo(
+    () =>
+      getShellById(shellProfiles, defaultShellProfile, shellProfileId || command?.shellProfileId),
+    [command?.shellProfileId, defaultShellProfile, shellProfileId, shellProfiles]
+  )
+
+  const commandLine = useMemo(() => {
+    if (!command) return ''
+    return renderTerminalSpawnCommandLine({
+      command,
+      values,
+      quoteStyle: selectedShell.quoteStyle,
+    })
+  }, [command, selectedShell.quoteStyle, values])
+
+  const parameters = useMemo(() => {
+    if (!command) return null
+    return getTerminalCommandParameters(command)
+  }, [command])
+  const hasAdvancedParameters = useMemo(
+    () => (parameters ? hasAdvancedFields(parameters) : false),
+    [parameters]
+  )
+  const visibleParameters = useMemo(
+    () => (parameters ? filterTerminalCommandParameters(parameters, showAdvanced) : null),
+    [parameters, showAdvanced]
+  )
+
+  const shellOptions = useMemo<SelectOption<string>[]>(
+    () => [
+      { value: '', label: `Default (${defaultShellProfile.label})` },
+      ...shellProfiles.map((shell) => ({
+        value: shell.id,
+        label: shell.label,
+      })),
+    ],
+    [defaultShellProfile.label, shellProfiles]
+  )
+
+  const handleCreate = () => {
+    if (!command) return
+    const sessionId = createShellSession(selectedShell, {
+      label: command.label,
+      initialInput: `${commandLine}\n`,
+    })
+    if (!sessionId) return
+    onCreated?.(sessionId)
+    onClose()
+  }
+
+  if (!command) {
+    return (
+      <Dialog open={open} title="Create terminal" onClose={onClose}>
+        <div className="text-muted-foreground text-sm">Select a command first.</div>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      title={
+        <>
+          <Rocket className="text-primary h-4 w-4" />
+          <span>Create {command.label}</span>
+        </>
+      }
+      onClose={onClose}
+      className="max-w-xl"
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="border-border hover:bg-muted rounded-md border px-3 py-1.5 text-xs"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleCreate}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs"
+          >
+            <Rocket className="h-3.5 w-3.5" />
+            Create
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <label className="flex flex-col gap-1 text-xs font-medium">
+          Shell
+          <Select
+            value={shellProfileId}
+            options={shellOptions}
+            onValueChange={setShellProfileId}
+            ariaLabel="Shell"
+          />
+        </label>
+
+        {hasAdvancedParameters && (
+          <label className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
+            <span className="font-medium">Show advanced options</span>
+            <Switch checked={showAdvanced} onCheckedChange={setShowAdvanced} />
+          </label>
+        )}
+
+        {visibleParameters && (
+          <TerminalCommandForm
+            schema={visibleParameters.schema}
+            uiSchema={visibleParameters.uiSchema}
+            values={values}
+            onChange={(nextValues) =>
+              setValues((currentValues) => ({
+                ...currentValues,
+                ...nextValues,
+              }))
+            }
+          />
+        )}
+
+        <div className="bg-muted/30 border-border rounded-md border px-3 py-2 text-xs">
+          <span className="text-muted-foreground mr-1">Command:</span>
+          <code className="whitespace-pre-wrap break-words">{commandLine}</code>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/web/src/lib/terminal-context.tsx
+++ b/packages/web/src/lib/terminal-context.tsx
@@ -1,3 +1,4 @@
+import type { TerminalShellProfile } from '@openspecui/core/terminal-invocation'
 import {
   createContext,
   useCallback,
@@ -35,15 +36,25 @@ interface TerminalContextValue {
   activeSessionId: string | null
   createSession: (opts?: {
     label?: string
+    customTitle?: string | null
     command?: string
     args?: string[]
     closeTip?: string
     closeCallbackUrl?: string | Record<string, string>
+    initialInput?: string
   }) => string
+  createShellSession: (
+    shell: TerminalShellProfile,
+    opts?: { label?: string; initialInput?: string }
+  ) => string
   createDedicatedSession: (
     command: string,
     args: string[],
-    opts?: { closeTip?: string; closeCallbackUrl?: string | Record<string, string> }
+    opts?: {
+      closeTip?: string
+      closeCallbackUrl?: string | Record<string, string>
+      initialInput?: string
+    }
   ) => string
   closeSession: (id: string) => void
   setActiveSession: (id: string) => void
@@ -71,13 +82,32 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
   const createSession = useCallback(
     (opts?: {
       label?: string
+      customTitle?: string | null
       command?: string
       args?: string[]
       closeTip?: string
       closeCallbackUrl?: string | Record<string, string>
+      initialInput?: string
     }) => {
       if (isStatic) return ''
       const id = terminalController.createSession(opts)
+      setActiveSessionId(id)
+      return id
+    },
+    [isStatic]
+  )
+
+  const createShellSession = useCallback(
+    (shell: TerminalShellProfile, opts?: { label?: string; initialInput?: string }) => {
+      if (isStatic) return ''
+      const label = opts?.label ?? shell.label
+      const id = terminalController.createSession({
+        label,
+        customTitle: label,
+        command: shell.command,
+        args: shell.args,
+        initialInput: opts?.initialInput,
+      })
       setActiveSessionId(id)
       return id
     },
@@ -88,7 +118,11 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
     (
       command: string,
       args: string[],
-      opts?: { closeTip?: string; closeCallbackUrl?: string | Record<string, string> }
+      opts?: {
+        closeTip?: string
+        closeCallbackUrl?: string | Record<string, string>
+        initialInput?: string
+      }
     ) => {
       if (isStatic) return ''
       const label = `${command} ${args.join(' ')}`.trim()
@@ -99,6 +133,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
         isDedicated: true,
         closeTip: opts?.closeTip,
         closeCallbackUrl: opts?.closeCallbackUrl,
+        initialInput: opts?.initialInput,
       })
       setActiveSessionId(id)
       return id
@@ -187,6 +222,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
       sessions,
       activeSessionId: resolvedActiveSessionId,
       createSession,
+      createShellSession,
       createDedicatedSession,
       closeSession,
       setActiveSession,
@@ -197,6 +233,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
       sessions,
       resolvedActiveSessionId,
       createSession,
+      createShellSession,
       createDedicatedSession,
       closeSession,
       setActiveSession,

--- a/packages/web/src/lib/terminal-controller.ts
+++ b/packages/web/src/lib/terminal-controller.ts
@@ -295,11 +295,13 @@ class TerminalController {
 
   createSession(opts?: {
     label?: string
+    customTitle?: string | null
     command?: string
     args?: string[]
     isDedicated?: boolean
     closeTip?: string
     closeCallbackUrl?: string | Record<string, string>
+    initialInput?: string
   }): string {
     const id = `term-${++this.idCounter}`
     const label = opts?.label ?? `Shell ${this.idCounter}`
@@ -311,6 +313,8 @@ class TerminalController {
       isDedicated: opts?.isDedicated ?? false,
       closeTip: opts?.closeTip,
       closeCallbackUrl: opts?.closeCallbackUrl,
+      initialInput: opts?.initialInput,
+      customTitle: opts?.customTitle ?? null,
       restored: false,
       serverSessionId: null,
       platform: DEFAULT_PTY_PLATFORM,
@@ -348,8 +352,23 @@ class TerminalController {
       this.ensureWsConnected()
     }
 
+    if (opts?.initialInput) {
+      this.scheduleInitialInput(id, opts.initialInput)
+    }
+
     this.notify()
     return id
+  }
+
+  private scheduleInitialInput(localSessionId: string, input: string): void {
+    let attempts = 0
+    const write = () => {
+      if (this.writeToSession(localSessionId, input)) return
+      attempts += 1
+      if (attempts > 75) return
+      globalThis.setTimeout(write, 80)
+    }
+    globalThis.setTimeout(write, 80)
   }
 
   private createTerminalInstance(
@@ -361,6 +380,8 @@ class TerminalController {
       isDedicated: boolean
       closeTip?: string
       closeCallbackUrl?: string | Record<string, string>
+      initialInput?: string
+      customTitle: string | null
       restored: boolean
       serverSessionId: string | null
       platform: PtyPlatform
@@ -379,7 +400,7 @@ class TerminalController {
       inputPanelAddon,
       isConnected: false,
       label: opts.label,
-      customTitle: null,
+      customTitle: opts.customTitle,
       processTitle: null,
       isDedicated: opts.isDedicated,
       isExited: false,
@@ -1357,6 +1378,8 @@ class TerminalController {
           isDedicated: false,
           closeTip: serverSession.closeTip,
           closeCallbackUrl: serverSession.closeCallbackUrl,
+          initialInput: undefined,
+          customTitle: null,
           restored: true,
           serverSessionId: serverSession.id,
           platform: serverSession.platform ?? DEFAULT_PTY_PLATFORM,

--- a/packages/web/src/lib/terminal-invocation-config.ts
+++ b/packages/web/src/lib/terminal-invocation-config.ts
@@ -1,0 +1,202 @@
+import { getHostedScopedStorageKey } from '@/lib/hosted-session'
+import { trpcClient } from '@/lib/trpc'
+import {
+  BUILTIN_TERMINAL_SPAWN_COMMANDS,
+  TerminalInvocationSettingsSchema,
+  resolveTerminalShellDefaults,
+  type TerminalInvocationSettings,
+  type TerminalShellDefaults,
+  type TerminalShellProfile,
+  type TerminalSpawnCommand,
+} from '@openspecui/core/terminal-invocation'
+
+const STORAGE_KEY = 'terminal-invocation-settings'
+
+interface TerminalInvocationConfigSnapshot {
+  settings: TerminalInvocationSettings
+  shellDefaults: TerminalShellDefaults
+  shellProfiles: TerminalShellProfile[]
+  spawnCommands: TerminalSpawnCommand[]
+  defaultShellProfile: TerminalShellProfile
+}
+
+function defaultSettings(): TerminalInvocationSettings {
+  return TerminalInvocationSettingsSchema.parse({})
+}
+
+function getStorageKey(): string {
+  return getHostedScopedStorageKey(STORAGE_KEY, window.location)
+}
+
+function readSettings(): TerminalInvocationSettings {
+  if (typeof window === 'undefined') return defaultSettings()
+  try {
+    const raw = localStorage.getItem(getStorageKey())
+    if (!raw) return defaultSettings()
+    return TerminalInvocationSettingsSchema.parse(JSON.parse(raw) as unknown)
+  } catch {
+    return defaultSettings()
+  }
+}
+
+function writeSettings(settings: TerminalInvocationSettings): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(getStorageKey(), JSON.stringify(settings))
+}
+
+function uniqById<T extends { id: string }>(items: readonly T[]): T[] {
+  const indexById = new Map<string, number>()
+  const result: T[] = []
+  for (const item of items) {
+    const existingIndex = indexById.get(item.id)
+    if (existingIndex !== undefined) {
+      result[existingIndex] = item
+      continue
+    }
+    indexById.set(item.id, result.length)
+    result.push(item)
+  }
+  return result
+}
+
+function getFallbackDefaults(): TerminalShellDefaults {
+  const platform =
+    typeof navigator === 'undefined'
+      ? 'common'
+      : navigator.platform.toLowerCase().includes('win')
+        ? 'windows'
+        : 'common'
+  return resolveTerminalShellDefaults({
+    platform,
+  })
+}
+
+class TerminalInvocationConfigStore {
+  private listeners = new Set<() => void>()
+  private settings: TerminalInvocationSettings = defaultSettings()
+  private shellDefaults: TerminalShellDefaults | null = null
+  private loadingDefaults: Promise<void> | null = null
+  private snapshot: TerminalInvocationConfigSnapshot | null = null
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.settings = readSettings()
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    void this.ensureShellDefaults()
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getSnapshot(): TerminalInvocationConfigSnapshot {
+    if (this.snapshot) return this.snapshot
+
+    const shellDefaults = this.shellDefaults ?? getFallbackDefaults()
+    const shellProfiles = uniqById([
+      ...shellDefaults.builtinShellProfiles,
+      ...this.settings.customShellProfiles,
+    ])
+    const defaultShellProfile =
+      shellProfiles.find((profile) => profile.id === this.settings.defaultShellProfileId) ??
+      shellDefaults.effectiveDefaultShell
+    const snapshot: TerminalInvocationConfigSnapshot = {
+      settings: this.settings,
+      shellDefaults,
+      shellProfiles,
+      spawnCommands: uniqById([
+        ...BUILTIN_TERMINAL_SPAWN_COMMANDS,
+        ...this.settings.customSpawnCommands,
+      ]),
+      defaultShellProfile,
+    }
+    this.snapshot = snapshot
+    return snapshot
+  }
+
+  updateSettings(
+    updater: (current: TerminalInvocationSettings) => TerminalInvocationSettings
+  ): void {
+    const next = TerminalInvocationSettingsSchema.parse(updater(this.settings))
+    this.settings = next
+    this.snapshot = null
+    writeSettings(next)
+    this.notify()
+  }
+
+  setDefaultShellProfileId(id: string): void {
+    this.updateSettings((current) => ({ ...current, defaultShellProfileId: id }))
+  }
+
+  upsertCustomShellProfile(profile: TerminalShellProfile): void {
+    const parsed = { ...profile, source: 'custom' as const }
+    this.updateSettings((current) => ({
+      ...current,
+      customShellProfiles: [
+        ...current.customShellProfiles.filter((item) => item.id !== parsed.id),
+        parsed,
+      ],
+    }))
+  }
+
+  removeCustomShellProfile(id: string): void {
+    this.updateSettings((current) => ({
+      ...current,
+      defaultShellProfileId:
+        current.defaultShellProfileId === id ? undefined : current.defaultShellProfileId,
+      customShellProfiles: current.customShellProfiles.filter((profile) => profile.id !== id),
+      customSpawnCommands: current.customSpawnCommands.map((command) =>
+        command.shellProfileId === id ? { ...command, shellProfileId: undefined } : command
+      ),
+    }))
+  }
+
+  upsertCustomSpawnCommand(command: TerminalSpawnCommand): void {
+    const parsed = { ...command, source: 'custom' as const }
+    this.updateSettings((current) => ({
+      ...current,
+      customSpawnCommands: [
+        ...current.customSpawnCommands.filter((item) => item.id !== parsed.id),
+        parsed,
+      ],
+    }))
+  }
+
+  removeCustomSpawnCommand(id: string): void {
+    this.updateSettings((current) => ({
+      ...current,
+      customSpawnCommands: current.customSpawnCommands.filter((command) => command.id !== id),
+    }))
+  }
+
+  private async ensureShellDefaults(): Promise<void> {
+    if (this.shellDefaults || this.loadingDefaults) return this.loadingDefaults ?? Promise.resolve()
+    this.loadingDefaults = trpcClient.config.getTerminalShellDefaults
+      .query()
+      .then((defaults) => {
+        this.shellDefaults = defaults
+        this.snapshot = null
+        this.notify()
+      })
+      .catch(() => {
+        this.shellDefaults = getFallbackDefaults()
+        this.snapshot = null
+        this.notify()
+      })
+      .finally(() => {
+        this.loadingDefaults = null
+      })
+    return this.loadingDefaults
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+}
+
+export const terminalInvocationConfigStore = new TerminalInvocationConfigStore()

--- a/packages/web/src/lib/use-terminal-invocation-config.ts
+++ b/packages/web/src/lib/use-terminal-invocation-config.ts
@@ -1,0 +1,10 @@
+import { useSyncExternalStore } from 'react'
+import { terminalInvocationConfigStore } from './terminal-invocation-config'
+
+export function useTerminalInvocationConfig() {
+  return useSyncExternalStore(
+    (listener) => terminalInvocationConfigStore.subscribe(listener),
+    () => terminalInvocationConfigStore.getSnapshot(),
+    () => terminalInvocationConfigStore.getSnapshot()
+  )
+}

--- a/packages/web/src/routes/config.tsx
+++ b/packages/web/src/routes/config.tsx
@@ -16,6 +16,8 @@ import {
 } from '@/components/file-explorer'
 import { MarkdownViewer } from '@/components/markdown-viewer'
 import { useViewportConstrainedHeight } from '@/components/scroll-spy'
+import { Select, type SelectOption } from '@/components/select'
+import { Switch } from '@/components/switch'
 import { Tabs, type Tab } from '@/components/tabs'
 import { navController } from '@/lib/nav-controller'
 import { isStaticMode } from '@/lib/static-mode'
@@ -60,6 +62,12 @@ type SchemaCreateMode = 'init' | 'fork'
 type ProfileEditMode = 'both' | 'delivery' | 'workflows'
 type DeliveryMode = 'both' | 'skills' | 'commands'
 type GlobalConfigTab = 'preview' | 'editor' | 'profile'
+
+const DELIVERY_MODE_OPTIONS: SelectOption<DeliveryMode>[] = [
+  { value: 'both', label: 'both' },
+  { value: 'skills', label: 'skills' },
+  { value: 'commands', label: 'commands' },
+]
 
 const DEFAULT_CONFIG_TEMPLATE = `schema: spec-driven\n\ncontext: |\n  \n\nrules:\n  proposal:\n    - \n`
 const CORE_WORKFLOWS = ['propose', 'explore', 'apply', 'archive'] as const
@@ -455,6 +463,14 @@ export function Config() {
   const selectedSchemaInfo = useMemo(
     () => schemas?.find((schema) => schema.name === selectedSchema),
     [schemas, selectedSchema]
+  )
+  const schemaSourceOptions = useMemo<SelectOption<string>[]>(
+    () =>
+      schemas?.map((schema) => ({
+        value: schema.name,
+        label: schema.name,
+      })) ?? [],
+    [schemas]
   )
 
   const schemaPreviewSource = useMemo(() => {
@@ -1981,26 +1997,25 @@ export function Config() {
                 {(profileEditMode === 'both' || profileEditMode === 'delivery') && (
                   <label className="space-y-1">
                     <div className="text-muted-foreground text-xs">Delivery</div>
-                    <select
+                    <Select
                       value={profileDelivery}
-                      onChange={(event) => setProfileDelivery(event.target.value as DeliveryMode)}
-                      className="border-border bg-background w-full rounded-md border px-3 py-2 text-sm"
-                    >
-                      <option value="both">both</option>
-                      <option value="skills">skills</option>
-                      <option value="commands">commands</option>
-                    </select>
+                      options={DELIVERY_MODE_OPTIONS}
+                      onValueChange={setProfileDelivery}
+                      ariaLabel="Delivery"
+                      className="w-full"
+                    />
                   </label>
                 )}
 
-                <label className="inline-flex items-center gap-2 text-xs">
-                  <input
-                    type="checkbox"
-                    className="accent-primary"
+                <label className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
+                  <span>
+                    Run <code>openspec update</code> automatically after apply
+                  </span>
+                  <Switch
                     checked={autoUpdateAfterProfileChange}
-                    onChange={(event) => setAutoUpdateAfterProfileChange(event.target.checked)}
+                    onCheckedChange={setAutoUpdateAfterProfileChange}
+                    ariaLabel="Run openspec update automatically after apply"
                   />
-                  Run <code>openspec update</code> automatically after apply
                 </label>
               </div>
             </section>
@@ -2165,17 +2180,13 @@ export function Config() {
           {newSchemaMode === 'fork' && (
             <label className="space-y-1">
               <div className="text-xs font-medium">Fork from</div>
-              <select
+              <Select
                 value={newSchemaSource}
-                onChange={(event) => setNewSchemaSource(event.target.value)}
-                className="border-border bg-card w-full rounded-md border px-3 py-2 text-sm"
-              >
-                {schemas?.map((schema) => (
-                  <option key={schema.name} value={schema.name}>
-                    {schema.name}
-                  </option>
-                ))}
-              </select>
+                options={schemaSourceOptions}
+                onValueChange={setNewSchemaSource}
+                ariaLabel="Fork from"
+                className="w-full"
+              />
             </label>
           )}
 

--- a/packages/web/src/routes/opsx-compose.tsx
+++ b/packages/web/src/routes/opsx-compose.tsx
@@ -1,5 +1,6 @@
 import { CodeEditor } from '@/components/code-editor'
 import { usePopAreaConfigContext, usePopAreaLifecycleContext } from '@/components/layout/pop-area'
+import { Select, type SelectOption } from '@/components/select'
 import {
   resolveOpsxInvocationMode,
   type OpsxAgentInvocationMode,
@@ -133,6 +134,16 @@ export function OpsxComposeRoute() {
   )
 
   const liveSessions = useMemo(() => sessions.filter((session) => !session.isExited), [sessions])
+  const targetOptions = useMemo<SelectOption<string>[]>(
+    () => [
+      ...(liveSessions.length === 0 ? [{ value: '', label: 'No live terminal' }] : []),
+      ...liveSessions.map((session) => ({
+        value: `terminal:${session.id}`,
+        label: `Terminal: ${session.displayTitle}`,
+      })),
+    ],
+    [liveSessions]
+  )
 
   const preferredTarget = useMemo<DispatchTarget | null>(() => {
     if (activeSessionId && liveSessions.some((session) => session.id === activeSessionId)) {
@@ -465,18 +476,15 @@ export function OpsxComposeRoute() {
         <div className="order-1 flex min-w-0 items-end gap-2 sm:order-2">
           <label className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-sm font-medium">Terminal</span>
-            <select
+            <Select
               value={target ?? ''}
-              onChange={(event) => setTarget((event.target.value || null) as DispatchTarget | null)}
-              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
-            >
-              {liveSessions.length === 0 && <option value="">No live terminal</option>}
-              {liveSessions.map((session) => (
-                <option key={session.id} value={`terminal:${session.id}`}>
-                  Terminal: {session.displayTitle}
-                </option>
-              ))}
-            </select>
+              options={targetOptions}
+              onValueChange={(nextTarget) =>
+                setTarget((nextTarget || null) as DispatchTarget | null)
+              }
+              ariaLabel="Terminal"
+              className="w-full"
+            />
           </label>
 
           <button

--- a/packages/web/src/routes/opsx-propose.test.tsx
+++ b/packages/web/src/routes/opsx-propose.test.tsx
@@ -1,0 +1,205 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OpsxProposeRoute } from './opsx-propose'
+
+const {
+  requestCloseMock,
+  setConfigMock,
+  writeToSessionMock,
+  useTerminalContextMock,
+  useTerminalInvocationConfigMock,
+} = vi.hoisted(() => ({
+  requestCloseMock: vi.fn(),
+  setConfigMock: vi.fn(),
+  writeToSessionMock: vi.fn(),
+  useTerminalContextMock: vi.fn(),
+  useTerminalInvocationConfigMock: vi.fn(),
+}))
+
+vi.mock('@/components/layout/pop-area', () => ({
+  usePopAreaConfigContext: () => ({
+    setConfig: setConfigMock,
+  }),
+  usePopAreaLifecycleContext: () => ({
+    requestClose: requestCloseMock,
+  }),
+}))
+
+vi.mock('@/components/code-editor', () => ({
+  CodeEditor: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string
+    onChange: (value: string) => void
+    placeholder?: string
+  }) => (
+    <textarea
+      aria-label="Idea"
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}))
+
+vi.mock('@/components/terminal/terminal-spawn-command-dialog', () => ({
+  TerminalSpawnCommandDialog: ({
+    open,
+    command,
+    presetValues,
+    onCreated,
+  }: {
+    open: boolean
+    command: { label: string } | null
+    presetValues?: Record<string, string | boolean>
+    onCreated?: (sessionId: string) => void
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Create terminal">
+        <span>Create {command?.label}</span>
+        <output>{String(presetValues?.prompt ?? '')}</output>
+        <button type="button" onClick={() => onCreated?.('term-created')}>
+          Create terminal
+        </button>
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/lib/nav-controller', () => ({
+  navController: {
+    activatePop: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/terminal-controller', () => ({
+  terminalController: {
+    writeToSession: writeToSessionMock,
+    addInputHistory: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock('@/lib/terminal-context', () => ({
+  useTerminalContext: () => useTerminalContextMock(),
+}))
+
+vi.mock('@/lib/use-terminal-invocation-config', () => ({
+  useTerminalInvocationConfig: () => useTerminalInvocationConfigMock(),
+}))
+
+vi.mock('@/lib/use-subscription', () => ({
+  useConfigSubscription: () => ({
+    data: { opsx: { agentInvocationMode: 'compose' } },
+  }),
+}))
+
+vi.mock('@/lib/trpc', () => ({
+  trpcClient: {
+    config: {
+      update: {
+        mutate: vi.fn().mockResolvedValue({}),
+      },
+    },
+  },
+}))
+
+vi.mock('@/lib/opsx-workflow-invocation', () => ({
+  prepareWorkflowInvocation: vi.fn().mockResolvedValue({
+    kind: 'agent-prompt',
+    text: 'prepared proposal prompt',
+    format: 'markdown',
+    mode: { requestedMode: 'compose', actualMode: 'compose', fallbackReason: null },
+  }),
+  stringifyWorkflowInvocation: vi.fn(() => 'prepared proposal prompt'),
+  workflowDiagnosticsToText: vi.fn(() => null),
+}))
+
+describe('OpsxProposeRoute terminal target', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    requestCloseMock.mockReset()
+    setConfigMock.mockReset()
+    writeToSessionMock.mockReset()
+    useTerminalContextMock.mockReturnValue({
+      sessions: [],
+      activeSessionId: null,
+    })
+    useTerminalInvocationConfigMock.mockReturnValue({
+      spawnCommands: [
+        {
+          id: 'builtin:claude',
+          label: 'Claude',
+          command: 'claude',
+          args: [],
+          fields: [],
+          source: 'builtin',
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    queryClient.clear()
+  })
+
+  it('opens the shared spawn dialog with prepared payload when target is create', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <OpsxProposeRoute />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByTestId('opsx-propose-target-select').textContent).toContain('Create Claude')
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Create terminal' })).toBeTruthy()
+    })
+
+    const dialog = screen.getByRole('dialog', { name: 'Create terminal' })
+    expect(within(dialog).getByText('Create Claude')).toBeTruthy()
+    expect(within(dialog).getByText('prepared proposal prompt')).toBeTruthy()
+    expect(writeToSessionMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create terminal' }))
+
+    expect(requestCloseMock).toHaveBeenCalled()
+  })
+
+  it('groups existing terminal targets separately from create targets', async () => {
+    useTerminalContextMock.mockReturnValue({
+      sessions: [
+        {
+          id: 'term-1',
+          displayTitle: 'dev shell',
+          isExited: false,
+        },
+      ],
+      activeSessionId: 'term-1',
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <OpsxProposeRoute />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Target' }))
+
+    const shellGroup = await screen.findByRole('group', { name: 'Shell Instances' })
+    const createGroup = screen.getByRole('group', { name: 'Create Shell Instance' })
+
+    expect(within(shellGroup).getByRole('option', { name: 'dev shell' })).toBeTruthy()
+    expect(within(createGroup).getByRole('option', { name: 'Create Claude' })).toBeTruthy()
+  })
+})

--- a/packages/web/src/routes/opsx-propose.tsx
+++ b/packages/web/src/routes/opsx-propose.tsx
@@ -1,6 +1,8 @@
 import { ButtonGroup } from '@/components/button-group'
 import { CodeEditor } from '@/components/code-editor'
 import { usePopAreaConfigContext, usePopAreaLifecycleContext } from '@/components/layout/pop-area'
+import { Select, type SelectOptionGroup } from '@/components/select'
+import { TerminalSpawnCommandDialog } from '@/components/terminal/terminal-spawn-command-dialog'
 import { navController } from '@/lib/nav-controller'
 import {
   OPSX_AGENT_INVOCATION_MODE_OPTIONS,
@@ -17,23 +19,38 @@ import { useTerminalContext } from '@/lib/terminal-context'
 import { terminalController } from '@/lib/terminal-controller'
 import { trpcClient } from '@/lib/trpc'
 import { useConfigSubscription } from '@/lib/use-subscription'
+import { useTerminalInvocationConfig } from '@/lib/use-terminal-invocation-config'
+import type {
+  TerminalCommandFieldValues,
+  TerminalSpawnCommand,
+} from '@openspecui/core/terminal-invocation'
 import { useMutation } from '@tanstack/react-query'
 import { ArrowRight, Copy, Save, Send, Sparkles } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
-type DispatchTarget = `terminal:${string}`
+type ExistingTerminalTarget = `terminal:${string}`
+type CreateTerminalTarget = `create:${string}`
+type DispatchTarget = ExistingTerminalTarget | CreateTerminalTarget
+type TargetSelectValue = DispatchTarget | ''
 
 const TERMINAL_TARGET_PREFIX = 'terminal:'
+const CREATE_TARGET_PREFIX = 'create:'
 
-function parseTerminalTarget(target: DispatchTarget): string | null {
-  if (!target.startsWith(TERMINAL_TARGET_PREFIX)) return null
+function parseTerminalTarget(target: string | null | undefined): string | null {
+  if (!target?.startsWith(TERMINAL_TARGET_PREFIX)) return null
   return target.slice(TERMINAL_TARGET_PREFIX.length)
+}
+
+function parseCreateTarget(target: string | null | undefined): string | null {
+  if (!target?.startsWith(CREATE_TARGET_PREFIX)) return null
+  return target.slice(CREATE_TARGET_PREFIX.length)
 }
 
 export function OpsxProposeRoute() {
   const { setConfig } = usePopAreaConfigContext()
   const { requestClose } = usePopAreaLifecycleContext()
   const { sessions, activeSessionId } = useTerminalContext()
+  const { spawnCommands } = useTerminalInvocationConfig()
   const { data: uiConfig } = useConfigSubscription()
   const liveSessions = useMemo(() => sessions.filter((session) => !session.isExited), [sessions])
   const [draft, setDraft] = useState('')
@@ -43,6 +60,47 @@ export function OpsxProposeRoute() {
   const [isSending, setIsSending] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
+  const [spawnDialogOpen, setSpawnDialogOpen] = useState(false)
+  const [spawnPresetValues, setSpawnPresetValues] = useState<TerminalCommandFieldValues>({})
+
+  const defaultSpawnCommand = spawnCommands[0] ?? null
+
+  const targetGroups = useMemo<SelectOptionGroup<TargetSelectValue>[]>(
+    () => [
+      {
+        label: 'Shell Instances',
+        options:
+          liveSessions.length > 0
+            ? liveSessions.map((session) => ({
+                value: `terminal:${session.id}` as ExistingTerminalTarget,
+                label: session.displayTitle,
+              }))
+            : [{ value: '', label: 'No shell instances available', disabled: true }],
+      },
+      {
+        label: 'Create Shell Instance',
+        options:
+          spawnCommands.length > 0
+            ? spawnCommands.map((command) => ({
+                value: `create:${command.id}` as CreateTerminalTarget,
+                label: `Create ${command.label}`,
+              }))
+            : [{ value: '', label: 'No spawn commands configured', disabled: true }],
+      },
+    ],
+    [liveSessions, spawnCommands]
+  )
+  const selectedSpawnCommand = useMemo<TerminalSpawnCommand | null>(() => {
+    if (!target) return defaultSpawnCommand
+    const commandId = parseCreateTarget(target)
+    if (!commandId) return defaultSpawnCommand
+    return spawnCommands.find((command) => command.id === commandId) ?? defaultSpawnCommand
+  }, [defaultSpawnCommand, spawnCommands, target])
+
+  const firstCreateTarget = useMemo<DispatchTarget | null>(
+    () => (defaultSpawnCommand ? `create:${defaultSpawnCommand.id}` : null),
+    [defaultSpawnCommand]
+  )
 
   const saveModeMutation = useMutation({
     mutationFn: (agentInvocationMode: OpsxAgentInvocationMode) =>
@@ -74,19 +132,25 @@ export function OpsxProposeRoute() {
     if (activeSessionId && liveSessions.some((session) => session.id === activeSessionId)) {
       return `terminal:${activeSessionId}`
     }
-    return liveSessions[0] ? `terminal:${liveSessions[0].id}` : null
-  }, [activeSessionId, liveSessions])
+    return liveSessions[0] ? `terminal:${liveSessions[0].id}` : firstCreateTarget
+  }, [activeSessionId, firstCreateTarget, liveSessions])
 
   useEffect(() => {
     setTarget((prev) => {
       if (!prev) return preferredTarget
+      if (
+        parseCreateTarget(prev) &&
+        spawnCommands.some((command) => `create:${command.id}` === prev)
+      ) {
+        return prev
+      }
       const sessionId = parseTerminalTarget(prev)
       if (sessionId && liveSessions.some((session) => session.id === sessionId)) {
         return prev
       }
       return preferredTarget
     })
-  }, [liveSessions, preferredTarget])
+  }, [liveSessions, preferredTarget, spawnCommands])
 
   const payload = useMemo(() => {
     if (mode === 'command') {
@@ -131,6 +195,13 @@ export function OpsxProposeRoute() {
     setSendError(null)
     setIsSending(true)
     try {
+      const createCommandId = parseCreateTarget(target)
+      if (createCommandId) {
+        const preparedPayload = await preparePayload()
+        setSpawnPresetValues({ prompt: preparedPayload })
+        setSpawnDialogOpen(true)
+        return
+      }
       const sessionId = parseTerminalTarget(target)
       if (!sessionId) throw new Error('Invalid terminal target.')
       const preparedPayload = await preparePayload()
@@ -227,22 +298,14 @@ export function OpsxProposeRoute() {
         <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end">
           <label className="flex min-w-0 flex-1 flex-col gap-1 sm:w-56 sm:flex-none">
             <span className="text-xs font-medium">Target</span>
-            <select
+            <Select
               value={target ?? ''}
-              onChange={(event) => setTarget((event.target.value || null) as DispatchTarget | null)}
-              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-1.5 text-xs focus:outline-none focus:ring-2"
-            >
-              {target === null && (
-                <option value="" disabled>
-                  No live terminal session
-                </option>
-              )}
-              {liveSessions.map((session) => (
-                <option key={session.id} value={`terminal:${session.id}`}>
-                  {session.displayTitle}
-                </option>
-              ))}
-            </select>
+              groups={targetGroups}
+              onValueChange={(nextTarget) => setTarget(nextTarget || null)}
+              ariaLabel="Target"
+              data-testid="opsx-propose-target-select"
+              className="h-8 w-full py-1.5 text-xs"
+            />
           </label>
           <div className="flex items-center justify-end gap-2">
             <button
@@ -259,11 +322,18 @@ export function OpsxProposeRoute() {
               className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Send className="h-3.5 w-3.5" />
-              {isSending ? 'Sending...' : 'Send'}
+              {isSending ? 'Sending...' : parseCreateTarget(target ?? '') ? 'Create' : 'Send'}
             </button>
           </div>
         </div>
       </div>
+      <TerminalSpawnCommandDialog
+        open={spawnDialogOpen}
+        command={selectedSpawnCommand}
+        presetValues={spawnPresetValues}
+        onClose={() => setSpawnDialogOpen(false)}
+        onCreated={requestClose}
+      />
     </div>
   )
 }

--- a/packages/web/src/routes/opsx-verify.tsx
+++ b/packages/web/src/routes/opsx-verify.tsx
@@ -1,5 +1,6 @@
 import { CliTerminal } from '@/components/cli-terminal'
 import { usePopAreaConfigContext, usePopAreaLifecycleContext } from '@/components/layout/pop-area'
+import { Switch } from '@/components/switch'
 import {
   prepareWorkflowInvocation,
   workflowDiagnosticsToText,
@@ -86,11 +87,10 @@ export function OpsxVerifyRoute() {
           <h2 className="font-nav text-base tracking-[0.04em]">Verify Change</h2>
         </div>
         <label className="flex items-center gap-2 text-xs">
-          <input
-            type="checkbox"
+          <Switch
             checked={strict}
-            onChange={(event) => setStrict(event.target.checked)}
-            className="border-border h-3.5 w-3.5 rounded"
+            onCheckedChange={setStrict}
+            ariaLabel="Strict"
             disabled={status === 'running'}
           />
           Strict

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -2,6 +2,8 @@ import { ButtonGroup } from '@/components/button-group'
 import { CliTerminal } from '@/components/cli-terminal'
 import { CopyablePath } from '@/components/copyable-path'
 import { Dialog } from '@/components/dialog'
+import { Select, type SelectOption } from '@/components/select'
+import { TerminalInvocationSettings } from '@/components/terminal/terminal-invocation-settings'
 import { getApiBaseUrl } from '@/lib/api-config'
 import {
   CODE_EDITOR_THEME_OPTIONS,
@@ -79,6 +81,18 @@ function formatExecutePath(command: string, args: readonly string[] = []): strin
   }
   return [command, ...args].map(quote).join(' ')
 }
+
+const INIT_TOOLS_MODE_OPTIONS: SelectOption<InitToolsMode>[] = [
+  { value: 'auto', label: 'Auto-detect tools (recommended)' },
+  { value: 'selected', label: 'Use selected tools' },
+  { value: 'all', label: 'Use all tools' },
+]
+
+const INIT_PROFILE_OVERRIDE_OPTIONS: SelectOption<InitProfileOverride>[] = [
+  { value: 'default', label: 'Use global default' },
+  { value: 'core', label: 'core' },
+  { value: 'custom', label: 'custom' },
+]
 
 function FontFamilyEditor({
   value,
@@ -569,6 +583,20 @@ export function Settings() {
   const [dashboardTrendPointLimit, setDashboardTrendPointLimit] = useState(100)
   const [gitDiffEagerLineBudget, setGitDiffEagerLineBudget] = useState(1000)
   const [termRendererError, setTermRendererError] = useState<string | null>(null)
+  const codeEditorThemeOptions = CODE_EDITOR_THEME_OPTIONS satisfies SelectOption<CodeEditorTheme>[]
+  const terminalThemeOptions = TERMINAL_THEME_OPTIONS satisfies SelectOption<TerminalThemeId>[]
+  const terminalRendererOptions = useMemo<SelectOption<string>[]>(
+    () => [
+      ...TERMINAL_RENDERER_ENGINES.map((engine) => ({
+        value: engine,
+        label: engine === 'ghostty' ? 'ghostty-web' : engine,
+      })),
+      ...(isTerminalRendererEngine(termRendererEngine)
+        ? []
+        : [{ value: termRendererEngine, label: `Invalid value: ${termRendererEngine}` }]),
+    ],
+    [termRendererEngine]
+  )
   const isRendererEngineValid = isTerminalRendererEngine(termRendererEngine)
 
   // Re-sync local state when controller config changes
@@ -807,25 +835,19 @@ export function Settings() {
           <div className="border-border/60 mt-4 border-t pt-4">
             <label className="mb-2 block text-sm font-medium">Code Editor Theme</label>
             <div className="flex items-center gap-2">
-              <select
+              <Select
                 value={codeEditorTheme}
-                onChange={(e) => {
-                  const nextTheme = e.target.value
-                  if (!isCodeEditorTheme(nextTheme)) return
+                options={codeEditorThemeOptions}
+                onValueChange={(nextTheme) => {
                   setCodeEditorTheme(nextTheme)
                   if (!inStaticMode) {
                     saveCodeEditorThemeMutation.mutate(nextTheme)
                   }
                 }}
-                className="bg-background border-border text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
+                ariaLabel="Code Editor Theme"
+                className="w-full"
                 disabled={inStaticMode || saveCodeEditorThemeMutation.isPending}
-              >
-                {CODE_EDITOR_THEME_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+              />
               {saveCodeEditorThemeMutation.isPending ? (
                 <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" />
               ) : saveCodeEditorThemeMutation.isSuccess ? (
@@ -867,6 +889,8 @@ export function Settings() {
               Terminal
             </h2>
             <div className="border-border space-y-4 rounded-lg border p-4">
+              <TerminalInvocationSettings />
+
               <div>
                 <label className="mb-2 block text-sm font-medium">Use Theme</label>
                 <div className="flex flex-wrap gap-2">
@@ -900,50 +924,38 @@ export function Settings() {
               <div className="grid gap-4 md:grid-cols-2">
                 <div>
                   <label className="mb-2 block text-sm font-medium">Light Theme</label>
-                  <select
+                  <Select
                     value={termLightTheme}
-                    onChange={(e) => {
-                      const next = e.target.value
-                      if (!isTerminalThemeId(next)) return
+                    options={terminalThemeOptions}
+                    onValueChange={(next) => {
                       setTermLightTheme(next)
                       applyTerminalConfig({ lightTheme: next })
                     }}
-                    className="bg-background border-border text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
-                  >
-                    {TERMINAL_THEME_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="Light Theme"
+                    className="w-full"
+                  />
                 </div>
                 <div>
                   <label className="mb-2 block text-sm font-medium">Dark Theme</label>
-                  <select
+                  <Select
                     value={termDarkTheme}
-                    onChange={(e) => {
-                      const next = e.target.value
-                      if (!isTerminalThemeId(next)) return
+                    options={terminalThemeOptions}
+                    onValueChange={(next) => {
                       setTermDarkTheme(next)
                       applyTerminalConfig({ darkTheme: next })
                     }}
-                    className="bg-background border-border text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
-                  >
-                    {TERMINAL_THEME_OPTIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="Dark Theme"
+                    className="w-full"
+                  />
                 </div>
               </div>
 
               <div>
                 <label className="mb-2 block text-sm font-medium">Renderer Engine</label>
-                <select
+                <Select
                   value={termRendererEngine}
-                  onChange={(e) => {
-                    const next = e.target.value
+                  options={terminalRendererOptions}
+                  onValueChange={(next) => {
                     setTermRendererEngine(next)
                     if (isTerminalRendererEngine(next)) {
                       void handleRendererEngineChange(next)
@@ -951,19 +963,9 @@ export function Settings() {
                       setTermRendererError(`Invalid renderer engine: ${next}`)
                     }
                   }}
-                  className="bg-background border-border text-foreground focus:ring-primary w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-1"
-                >
-                  {TERMINAL_RENDERER_ENGINES.map((engine) => (
-                    <option key={engine} value={engine}>
-                      {engine === 'ghostty' ? 'ghostty-web' : engine}
-                    </option>
-                  ))}
-                  {!isRendererEngineValid && (
-                    <option value={termRendererEngine}>
-                      {`Invalid value: ${termRendererEngine}`}
-                    </option>
-                  )}
-                </select>
+                  ariaLabel="Renderer Engine"
+                  className="w-full"
+                />
                 {termRendererError ? (
                   <p className="mt-2 text-xs text-red-500">{termRendererError}</p>
                 ) : (
@@ -1622,15 +1624,13 @@ export function Settings() {
               <div className="grid gap-3 md:grid-cols-2">
                 <label className="space-y-1.5">
                   <span className="text-sm font-medium">Init Mode</span>
-                  <select
+                  <Select
                     value={initToolsMode}
-                    onChange={(event) => setInitToolsMode(event.target.value as InitToolsMode)}
-                    className="border-border bg-background w-full rounded-md border px-2 py-2 text-sm"
-                  >
-                    <option value="auto">Auto-detect tools (recommended)</option>
-                    <option value="selected">Use selected tools</option>
-                    <option value="all">Use all tools</option>
-                  </select>
+                    options={INIT_TOOLS_MODE_OPTIONS}
+                    onValueChange={setInitToolsMode}
+                    ariaLabel="Init Mode"
+                    className="w-full"
+                  />
                   <p className="text-muted-foreground text-xs">
                     OpenSpec CLI can auto-detect existing tool directories. OpenSpecUI 3.x uses
                     OpenSpec CLI 1.3.x as the current tool line.
@@ -1639,17 +1639,13 @@ export function Settings() {
 
                 <label className="space-y-1.5">
                   <span className="text-sm font-medium">Profile Override</span>
-                  <select
+                  <Select
                     value={initProfileOverride}
-                    onChange={(event) =>
-                      setInitProfileOverride(event.target.value as InitProfileOverride)
-                    }
-                    className="border-border bg-background w-full rounded-md border px-2 py-2 text-sm"
-                  >
-                    <option value="default">Use global default</option>
-                    <option value="core">core</option>
-                    <option value="custom">custom</option>
-                  </select>
+                    options={INIT_PROFILE_OVERRIDE_OPTIONS}
+                    onValueChange={setInitProfileOverride}
+                    ariaLabel="Profile Override"
+                    className="w-full"
+                  />
                   <p className="text-muted-foreground text-xs">
                     Adds <code className="bg-muted rounded px-1">--profile</code> when set.
                   </p>

--- a/packages/web/src/test/setup.ts
+++ b/packages/web/src/test/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+
+if (typeof globalThis.PointerEvent === 'undefined') {
+  globalThis.PointerEvent = MouseEvent as typeof PointerEvent
+}

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -17,6 +17,7 @@
       "@openspecui/core/openspec-compat": ["../core/src/openspec-compat.ts"],
       "@openspecui/core/opsx-display-path": ["../core/src/opsx-display-path.ts"],
       "@openspecui/core/pty-protocol": ["../core/src/pty-protocol.ts"],
+      "@openspecui/core/terminal-invocation": ["../core/src/terminal-invocation.ts"],
       "@openspecui/core/terminal-theme": ["../core/src/terminal-theme.ts"],
       "@openspecui/search": ["../search/src/index.ts"],
       "@openspecui/search/node": ["../search/src/node.ts"],

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig(({ isSsrBuild }) => {
     '@openspecui/core/openspec-compat': resolve(__dirname, '../core/src/openspec-compat.ts'),
     '@openspecui/core/opsx-display-path': resolve(__dirname, '../core/src/opsx-display-path.ts'),
     '@openspecui/core/pty-protocol': resolve(__dirname, '../core/src/pty-protocol.ts'),
+    '@openspecui/core/terminal-invocation': resolve(
+      __dirname,
+      '../core/src/terminal-invocation.ts'
+    ),
     '@openspecui/search': resolve(__dirname, '../search/src'),
     '@openspecui/search/node': resolve(__dirname, '../search/src/node.ts'),
     '@openspecui/server': resolve(__dirname, '../server/src'),

--- a/packages/web/vitest.browser.config.ts
+++ b/packages/web/vitest.browser.config.ts
@@ -11,6 +11,7 @@ const alias = {
   '@openspecui/core/hosted-app': resolve(__dirname, '../core/src/hosted-app.ts'),
   '@openspecui/core/opsx-display-path': resolve(__dirname, '../core/src/opsx-display-path.ts'),
   '@openspecui/core/pty-protocol': resolve(__dirname, '../core/src/pty-protocol.ts'),
+  '@openspecui/core/terminal-invocation': resolve(__dirname, '../core/src/terminal-invocation.ts'),
   '@openspecui/search': resolve(__dirname, '../search/src'),
   '@openspecui/search/node': resolve(__dirname, '../search/src/node.ts'),
   '@openspecui/server': resolve(__dirname, '../server/src'),

--- a/packages/web/vitest.storybook.config.ts
+++ b/packages/web/vitest.storybook.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
       '@openspecui/core/hosted-app': resolve(__dirname, '../core/src/hosted-app.ts'),
       '@openspecui/core/opsx-display-path': resolve(__dirname, '../core/src/opsx-display-path.ts'),
       '@openspecui/core/pty-protocol': resolve(__dirname, '../core/src/pty-protocol.ts'),
+      '@openspecui/core/terminal-invocation': resolve(
+        __dirname,
+        '../core/src/terminal-invocation.ts'
+      ),
       '@openspecui/search': resolve(__dirname, '../search/src'),
       '@openspecui/search/node': resolve(__dirname, '../search/src/node.ts'),
       '@openspecui/server': resolve(__dirname, '../server/src'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,15 @@ importers:
       '@fsegurai/codemirror-theme-bundle':
         specifier: ^6.3.1
         version: 6.3.1(@codemirror/language@6.11.3)(@codemirror/state@6.5.2)(@codemirror/view@6.38.8)(@lezer/highlight@1.2.3)
+      '@rjsf/core':
+        specifier: ^6.5.2
+        version: 6.5.2(@rjsf/utils@6.5.2(react@19.2.0))(react@19.2.0)
+      '@rjsf/utils':
+        specifier: ^6.5.2
+        version: 6.5.2(react@19.2.0)
+      '@rjsf/validator-ajv8':
+        specifier: ^6.5.2
+        version: 6.5.2(@rjsf/utils@6.5.2(react@19.2.0))
       view-transitions-toolkit:
         specifier: 1.0.0
         version: 1.0.0
@@ -3382,6 +3391,34 @@ packages:
         integrity: sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==,
       }
 
+  '@rjsf/core@6.5.2':
+    resolution:
+      {
+        integrity: sha512-Fx+aVNQRYQyoY0vM8zYDZkuOiNe+5PLsxUySUdHfjljlT23mJnTCpPKMkxWJwh4UEWeSN0xjmknW9LfIwuQmOg==,
+      }
+    engines: { node: '>=20' }
+    peerDependencies:
+      '@rjsf/utils': ^6.5.x
+      react: '>=18'
+
+  '@rjsf/utils@6.5.2':
+    resolution:
+      {
+        integrity: sha512-qBVQ5qf9BKMOQy/DjMl/IjD5s6akRDx18cgiSYunKt/CYc+kPzHyCVA2TU0rXCsigNlhgnfM8piC3LEHye6vpA==,
+      }
+    engines: { node: '>=20' }
+    peerDependencies:
+      react: '>=18'
+
+  '@rjsf/validator-ajv8@6.5.2':
+    resolution:
+      {
+        integrity: sha512-MSyF0Q0lZhmByDV/eL3QF03g1K7RVGGAHMytlQ2ybuakvzJGODGzWKfTLcP320ixrrCqDq5rs8IJP+WJCRnhig==,
+      }
+    engines: { node: '>=20' }
+    peerDependencies:
+      '@rjsf/utils': ^6.5.x
+
   '@rolldown/binding-android-arm64@1.0.0-beta.51':
     resolution:
       {
@@ -4401,6 +4438,12 @@ packages:
         integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
       }
 
+  '@types/json-schema@7.0.15':
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
+
   '@types/mdast@4.0.4':
     resolution:
       {
@@ -4670,6 +4713,12 @@ packages:
         integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==,
       }
 
+  '@x0k/json-schema-merge@1.0.3':
+    resolution:
+      {
+        integrity: sha512-lerJC4sI9CNUQWdff3PnU1YJOqazD6TjMcvxZIPXUBjn4j1cUiXE0LvzhMnGYzKKr271TkvXJtH7gEwksrtn+w==,
+      }
+
   '@xmldom/xmldom@0.8.11':
     resolution:
       {
@@ -4734,6 +4783,17 @@ packages:
       }
     engines: { node: '>= 14' }
 
+  ajv-formats@2.1.1:
+    resolution:
+      {
+        integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==,
+      }
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution:
       {
@@ -4749,6 +4809,12 @@ packages:
     resolution:
       {
         integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
+      }
+
+  ajv@8.20.0:
+    resolution:
+      {
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   ansi-colors@4.1.3:
@@ -5854,6 +5920,13 @@ packages:
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
       }
 
+  fast-equals@6.0.0:
+    resolution:
+      {
+        integrity: sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==,
+      }
+    engines: { node: '>=6.0.0' }
+
   fast-glob@3.3.3:
     resolution:
       {
@@ -6667,6 +6740,13 @@ packages:
         integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==,
       }
 
+  jsonpointer@5.0.1:
+    resolution:
+      {
+        integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==,
+      }
+    engines: { node: '>=0.10.0' }
+
   kleur@3.0.3:
     resolution:
       {
@@ -6930,10 +7010,22 @@ packages:
       }
     engines: { node: '>=8' }
 
+  lodash-es@4.18.1:
+    resolution:
+      {
+        integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==,
+      }
+
   lodash.startcase@4.4.0:
     resolution:
       {
         integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
+      }
+
+  lodash@4.18.1:
+    resolution:
+      {
+        integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
 
   log-symbols@6.0.0:
@@ -6948,6 +7040,13 @@ packages:
       {
         integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
       }
+
+  loose-envify@1.4.0:
+    resolution:
+      {
+        integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
+      }
+    hasBin: true
 
   loupe@3.2.1:
     resolution:
@@ -7020,6 +7119,18 @@ packages:
       {
         integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
       }
+
+  markdown-to-jsx@8.0.0:
+    resolution:
+      {
+        integrity: sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA==,
+      }
+    engines: { node: '>= 10' }
+    peerDependencies:
+      react: '>= 0.14.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   marked@17.0.1:
     resolution:
@@ -8084,6 +8195,12 @@ packages:
       }
     engines: { node: '>= 6' }
 
+  prop-types@15.8.1:
+    resolution:
+      {
+        integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
+      }
+
   property-information@7.1.0:
     resolution:
       {
@@ -8151,10 +8268,22 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-is@16.13.1:
+    resolution:
+      {
+        integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
+      }
+
   react-is@17.0.2:
     resolution:
       {
         integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
+      }
+
+  react-is@18.3.1:
+    resolution:
+      {
+        integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==,
       }
 
   react-markdown@10.1.0:
@@ -11746,6 +11875,34 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  '@rjsf/core@6.5.2(@rjsf/utils@6.5.2(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@rjsf/utils': 6.5.2(react@19.2.0)
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      markdown-to-jsx: 8.0.0(react@19.2.0)
+      prop-types: 15.8.1
+      react: 19.2.0
+
+  '@rjsf/utils@6.5.2(react@19.2.0)':
+    dependencies:
+      '@x0k/json-schema-merge': 1.0.3
+      fast-equals: 6.0.0
+      fast-uri: 3.1.0
+      jsonpointer: 5.0.1
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      react: 19.2.0
+      react-is: 18.3.1
+
+  '@rjsf/validator-ajv8@6.5.2(@rjsf/utils@6.5.2(react@19.2.0))':
+    dependencies:
+      '@rjsf/utils': 6.5.2(react@19.2.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+
   '@rolldown/binding-android-arm64@1.0.0-beta.51':
     optional: true
 
@@ -12267,6 +12424,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -12465,6 +12624,10 @@ snapshots:
 
   '@webgpu/types@0.1.69': {}
 
+  '@x0k/json-schema-merge@1.0.3':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@xmldom/xmldom@0.8.11': {}
 
   '@xterm/addon-fit@0.12.0-beta.167(@xterm/xterm@6.1.0-beta.167)':
@@ -12492,11 +12655,22 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
   ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -13086,6 +13260,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-equals@6.0.0: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -13562,6 +13738,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonpointer@5.0.1: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -13688,7 +13866,11 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.18.1: {}
+
   lodash.startcase@4.4.0: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -13696,6 +13878,10 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   loupe@3.2.1: {}
 
@@ -13732,6 +13918,10 @@ snapshots:
       semver: 7.7.3
 
   markdown-table@3.0.4: {}
+
+  markdown-to-jsx@8.0.0(react@19.2.0):
+    optionalDependencies:
+      react: 19.2.0
 
   marked@17.0.1: {}
 
@@ -14482,6 +14672,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
@@ -14521,7 +14717,11 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-markdown@10.1.0(@types/react@19.2.7)(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Add terminal shell profiles with platform defaults, custom profiles, and default-shell selection for #98.
- Add data-driven spawn commands for Claude, Codex, and Gemini with JSON-schema/RJSF-backed forms, advanced-field grouping, and reusable create-terminal flows for #99.
- Update terminal target selectors to separate existing terminal instances from create-target commands, and add shared Select/Switch styling atoms.

## Verification

- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm typecheck`
- `pnpm test:ci`
- `pnpm test:browser:ci`
- Real browser QA with Playwright against source Vite at `http://localhost:13003`:
  - `/settings` -> Terminal -> Add Command
  - verified `fieldId` editing keeps focus
  - verified boolean default value uses Select
  - verified type-specific fields show/hide correctly
  - verified Edit Claude exposes advanced field markers
  - `/opsx-propose` -> Target -> Create Claude
  - verified Shell/Create optgroups and advanced options default collapsed, then expandable

## Notes

Browser plugin runtime was listed, but the Node/browser execution tool was not exposed in this session, so local Playwright was used for rendered validation.
