### PR TITLE
fix(web): harden terminal command dialogs

### DIFF
--- a/.changeset/smooth-terminal-advanced-dialog.md
+++ b/.changeset/smooth-terminal-advanced-dialog.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Collapse advanced terminal spawn command options by default, protect workflow dialogs from accidental outside dismiss, and render empty select options as accessible `none` labels.

--- a/packages/web/src/components/dialog.test.tsx
+++ b/packages/web/src/components/dialog.test.tsx
@@ -1,8 +1,12 @@
-import { fireEvent, render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Dialog } from './dialog'
 
 describe('Dialog', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it('mounts dialog styles in document head instead of rendering style text in the body', () => {
     const { container } = render(
       <Dialog open={false} title="Dialog title" onClose={() => {}}>
@@ -15,6 +19,16 @@ describe('Dialog', () => {
     const style = document.head.querySelector('[data-head-style="dialog:openspec-dialog"]')
     expect(style).not.toBeNull()
     expect(style?.textContent).toContain('dialog.openspec-dialog')
+  })
+
+  it('labels the native dialog from the visible title', () => {
+    const { getByRole } = render(
+      <Dialog open title="Dialog title" onClose={() => {}}>
+        <div>Dialog body</div>
+      </Dialog>
+    )
+
+    expect(getByRole('dialog', { name: 'Dialog title', hidden: true })).toBeTruthy()
   })
 
   it('reuses a single shared head style for multiple dialogs', () => {
@@ -45,5 +59,62 @@ describe('Dialog', () => {
     fireEvent.click(getByText('Inner action'), { clientX: 0, clientY: 0 })
 
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('uses the close handler for outside dismiss by default', () => {
+    const onClose = vi.fn()
+    const { getByRole } = render(
+      <Dialog open title="Dialog title" onClose={onClose}>
+        <div>Dialog body</div>
+      </Dialog>
+    )
+
+    const dialog = getByRole('dialog', { hidden: true })
+    fireEvent.click(dialog, { clientX: 1, clientY: 1 })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('can block outside dismiss with null', () => {
+    const onClose = vi.fn()
+    const { getByRole } = render(
+      <Dialog open title="Dialog title" onClose={onClose} onDismissRequest={null}>
+        <div>Dialog body</div>
+      </Dialog>
+    )
+
+    const dialog = getByRole('dialog', { hidden: true })
+    fireEvent.click(dialog, { clientX: 1, clientY: 1 })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('can handle outside dismiss with a custom request handler', () => {
+    const onClose = vi.fn()
+    const onDismissRequest = vi.fn()
+    const { getByRole } = render(
+      <Dialog open title="Dialog title" onClose={onClose} onDismissRequest={onDismissRequest}>
+        <div>Dialog body</div>
+      </Dialog>
+    )
+
+    const dialog = getByRole('dialog', { hidden: true })
+    fireEvent.click(dialog, { clientX: 1, clientY: 1 })
+
+    expect(onDismissRequest).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('keeps explicit close actions on the close handler', () => {
+    const onClose = vi.fn()
+    const { getByRole } = render(
+      <Dialog open title="Dialog title" onClose={onClose} onDismissRequest={null}>
+        <div>Dialog body</div>
+      </Dialog>
+    )
+
+    fireEvent.click(getByRole('button', { name: 'Close dialog' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/web/src/components/dialog.tsx
+++ b/packages/web/src/components/dialog.tsx
@@ -1,11 +1,18 @@
 import { X } from 'lucide-react'
-import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode } from 'react'
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useHeadStyle } from './use-head-style'
+
+export type DialogRequestHandler = (() => void) | null
 
 interface DialogProps {
   open: boolean
   title: ReactNode // can include icon / status chips etc.
   onClose: () => void
+  /**
+   * Handles non-explicit dismiss attempts such as backdrop click or ESC.
+   * undefined delegates to onClose, null blocks default dismissal.
+   */
+  onDismissRequest?: DialogRequestHandler
   onClosed?: () => void
   children: ReactNode
   footer?: ReactNode
@@ -26,6 +33,7 @@ export function Dialog({
   open,
   title,
   onClose,
+  onDismissRequest,
   onClosed,
   children,
   footer,
@@ -38,6 +46,8 @@ export function Dialog({
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
+  const titleId = useId()
+  const requestDismiss = onDismissRequest === undefined ? onClose : onDismissRequest
 
   // Close-complete callback from native dialog lifecycle
   useEffect(() => {
@@ -81,7 +91,7 @@ export function Dialog({
 
     const handleCancel = (event: Event) => {
       event.preventDefault()
-      onClose()
+      requestDismiss?.()
     }
 
     const handleClick = (event: MouseEvent) => {
@@ -98,7 +108,7 @@ export function Dialog({
         event.clientY <= rect.bottom
 
       if (!isInDialog) {
-        onClose()
+        requestDismiss?.()
       }
     }
 
@@ -109,7 +119,7 @@ export function Dialog({
       dialog.removeEventListener('cancel', handleCancel)
       dialog.removeEventListener('click', handleClick)
     }
-  }, [onClose])
+  }, [requestDismiss])
 
   const borderClass =
     borderVariant === 'error'
@@ -163,6 +173,7 @@ export function Dialog({
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby={titleId}
       className={`openspec-dialog m-0 h-dvh w-screen max-w-none border-0 bg-transparent p-0 ${dialogClassName}`}
     >
       <div
@@ -175,7 +186,9 @@ export function Dialog({
         >
           {/* Header (non-shrinking) */}
           <div className="border-border flex flex-none shrink-0 items-center justify-between border-b px-4 py-3">
-            <div className="flex items-center gap-2">{title}</div>
+            <div id={titleId} className="flex items-center gap-2">
+              {title}
+            </div>
             <button
               onClick={onClose}
               className="hover:bg-muted rounded p-1"

--- a/packages/web/src/components/global-archive-modal.test.tsx
+++ b/packages/web/src/components/global-archive-modal.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GlobalArchiveModal } from './global-archive-modal'
+
+const { closeArchiveModalMock } = vi.hoisted(() => ({
+  closeArchiveModalMock: vi.fn(),
+}))
+
+vi.mock('@/lib/archive-modal-context', () => ({
+  useArchiveModal: () => ({
+    state: {
+      open: true,
+      changeId: 'add-terminal-spawn-command',
+      changeName: 'Add Terminal Spawn Command',
+    },
+    closeArchiveModal: closeArchiveModalMock,
+  }),
+}))
+
+vi.mock('@/lib/use-cli-runner', () => ({
+  useCliRunner: () => ({
+    lines: [],
+    status: 'idle',
+    hasStarted: false,
+    commands: {
+      replaceAll: vi.fn(),
+      runAll: vi.fn(),
+    },
+    reset: vi.fn(),
+    cancel: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/view-transitions/navigation', () => ({
+  useVTHrefNavigate: () => vi.fn(),
+}))
+
+vi.mock('./cli-terminal', () => ({
+  CliTerminal: () => <div>terminal output</div>,
+}))
+
+describe('GlobalArchiveModal', () => {
+  afterEach(() => {
+    cleanup()
+    closeArchiveModalMock.mockReset()
+  })
+
+  it('blocks outside dismiss for archive workflow dialogs', () => {
+    render(<GlobalArchiveModal />)
+
+    fireEvent.click(screen.getByRole('dialog', { hidden: true }), { clientX: 1, clientY: 1 })
+
+    expect(closeArchiveModalMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/components/global-archive-modal.tsx
+++ b/packages/web/src/components/global-archive-modal.tsx
@@ -144,6 +144,7 @@ export function GlobalArchiveModal() {
     <Dialog
       open={open}
       onClose={handleClose}
+      onDismissRequest={null}
       title={
         <div className="flex items-center gap-2">
           {archiveStatus === 'success' ? (

--- a/packages/web/src/components/layout/pop-area.tsx
+++ b/packages/web/src/components/layout/pop-area.tsx
@@ -12,6 +12,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import type { DialogRequestHandler } from '../dialog'
 
 export function PopArea() {
   return <Outlet />
@@ -27,6 +28,7 @@ export interface PopAreaConfig {
   panelClassName: string
   bodyClassName: string
   maxHeight: string
+  onDismissRequest?: DialogRequestHandler
 }
 
 const DEFAULT_POP_AREA_CONFIG: PopAreaConfig = {
@@ -39,6 +41,7 @@ const DEFAULT_POP_AREA_CONFIG: PopAreaConfig = {
   panelClassName: '',
   bodyClassName: 'p-0',
   maxHeight: '90vh',
+  onDismissRequest: undefined,
 }
 
 interface PopAreaConfigContextValue {
@@ -60,7 +63,7 @@ function PopAreaConfigProvider({ children }: { children: ReactNode }) {
   const [closeRequestVersion, setCloseRequestVersion] = useState(0)
 
   const setConfig = useCallback((patch: Partial<PopAreaConfig>) => {
-    setConfigState((prev) => ({ ...prev, ...patch }))
+    setConfigState({ ...DEFAULT_POP_AREA_CONFIG, ...patch })
   }, [])
 
   const resetConfig = useCallback(() => {
@@ -196,6 +199,7 @@ function PopAreaDialog() {
         .join(' ')}
       bodyClassName={config.bodyClassName}
       maxHeight={config.maxHeight}
+      onDismissRequest={config.onDismissRequest}
     >
       <RouterProvider router={_popRouter} />
     </Dialog>

--- a/packages/web/src/components/select.test.tsx
+++ b/packages/web/src/components/select.test.tsx
@@ -31,6 +31,11 @@ const GROUPS: SelectOptionGroup<'shell:zsh' | 'create:claude'>[] = [
   },
 ]
 
+const EMPTY_OPTIONS: SelectOption<'' | 'model-a'>[] = [
+  { value: '', label: '' },
+  { value: 'model-a', label: 'Model A' },
+]
+
 describe('Select', () => {
   afterEach(() => {
     cleanup()
@@ -65,5 +70,19 @@ describe('Select', () => {
     expect(await screen.findByRole('group', { name: 'Shell Instances' })).toBeTruthy()
     expect(screen.getByRole('group', { name: 'Create Shell Instance' })).toBeTruthy()
     expect(screen.getByRole('option', { name: 'Create Claude' })).toBeTruthy()
+  })
+
+  it('renders empty options as accessible italic none labels', async () => {
+    render(<Select value="" options={EMPTY_OPTIONS} onValueChange={() => {}} ariaLabel="Model" />)
+
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('none')
+    expect(screen.getByRole('combobox', { name: 'Model' }).querySelector('i')?.textContent).toBe(
+      'none'
+    )
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Model' }))
+
+    const emptyOption = await screen.findByRole('option', { name: 'none' })
+    expect(emptyOption.querySelector('i')?.textContent).toBe('none')
   })
 })

--- a/packages/web/src/components/select.tsx
+++ b/packages/web/src/components/select.tsx
@@ -38,6 +38,22 @@ interface SelectProps<T extends string> {
   modal?: boolean
 }
 
+function isEmptyOptionLabel<T extends string>(option: SelectOption<T> | undefined): boolean {
+  return option?.value === '' && option.label === ''
+}
+
+function getOptionAccessibleLabel<T extends string>(option: SelectOption<T>): string | undefined {
+  if (isEmptyOptionLabel(option)) return 'none'
+  return typeof option.label === 'string' ? option.label : undefined
+}
+
+function renderOptionLabel<T extends string>(option: SelectOption<T>): ReactNode {
+  if (isEmptyOptionLabel(option)) {
+    return <i className="text-muted-foreground">none</i>
+  }
+  return option.label
+}
+
 export function Select<T extends string>({
   value,
   options = [],
@@ -110,7 +126,7 @@ export function Select<T extends string>({
         ) : (
           <>
             <BaseSelect.Value placeholder={placeholder} className="truncate">
-              {() => selectedOption?.label ?? placeholder}
+              {() => (selectedOption ? renderOptionLabel(selectedOption) : placeholder)}
             </BaseSelect.Value>
             <BaseSelect.Icon className="text-muted-foreground flex shrink-0">
               <ChevronDown className="h-4 w-4" />
@@ -151,7 +167,7 @@ export function Select<T extends string>({
                       key={option.value}
                       value={option.value}
                       disabled={option.disabled}
-                      label={typeof option.label === 'string' ? option.label : undefined}
+                      label={getOptionAccessibleLabel(option)}
                       className={(state) =>
                         cn(
                           'grid cursor-default grid-cols-[1rem_minmax(0,1fr)] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none',
@@ -166,7 +182,7 @@ export function Select<T extends string>({
                         <Check className="h-4 w-4" />
                       </BaseSelect.ItemIndicator>
                       <BaseSelect.ItemText className="whitespace-nowrap">
-                        {option.label}
+                        {renderOptionLabel(option)}
                       </BaseSelect.ItemText>
                     </BaseSelect.Item>
                   ))}

--- a/packages/web/src/components/terminal/terminal-command-form.test.tsx
+++ b/packages/web/src/components/terminal/terminal-command-form.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TerminalCommandForm } from './terminal-command-form'
+
+describe('TerminalCommandForm', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders empty select options as accessible none labels', async () => {
+    const onChange = vi.fn()
+    render(
+      <TerminalCommandForm
+        schema={{
+          type: 'object',
+          properties: {
+            model: {
+              type: 'string',
+              title: 'Model',
+              enum: ['', 'sonnet'],
+              default: '',
+            },
+          },
+          required: [],
+        }}
+        values={{ model: '' }}
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('none')
+    expect(screen.getByRole('combobox', { name: 'Model' }).querySelector('i')?.textContent).toBe(
+      'none'
+    )
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Model' }))
+
+    const emptyOption = await screen.findByRole('option', { name: 'none' })
+    expect(emptyOption.querySelector('i')?.textContent).toBe('none')
+  })
+
+  it('does not proxy field whitespace clicks to boolean controls', () => {
+    const onChange = vi.fn()
+    const { container } = render(
+      <TerminalCommandForm
+        schema={{
+          type: 'object',
+          properties: {
+            skipPermissions: {
+              type: 'boolean',
+              title: 'Skip permissions',
+              default: false,
+            },
+            prompt: {
+              type: 'string',
+              title: 'Prompt',
+              default: '',
+            },
+          },
+          required: [],
+        }}
+        values={{ skipPermissions: false, prompt: '' }}
+        onChange={onChange}
+      />
+    )
+
+    const objectField = container.querySelector('.space-y-3')
+    expect(objectField).not.toBeNull()
+
+    fireEvent.click(objectField!)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('checkbox', { name: 'Skip permissions' })).not.toBeChecked()
+  })
+})

--- a/packages/web/src/components/terminal/terminal-command-form.tsx
+++ b/packages/web/src/components/terminal/terminal-command-form.tsx
@@ -73,8 +73,10 @@ function TextareaWidget(props: WidgetProps) {
 
 function CheckboxWidget(props: WidgetProps) {
   return (
-    <label className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2">
-      <span className="text-sm font-medium">{props.label}</span>
+    <div className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+      <label htmlFor={props.id} className="text-sm font-medium">
+        {props.label}
+      </label>
       <Switch
         id={props.id}
         checked={props.value === true}
@@ -84,7 +86,7 @@ function CheckboxWidget(props: WidgetProps) {
         onBlur={() => props.onBlur(props.id, props.value)}
         onFocus={() => props.onFocus(props.id, props.value)}
       />
-    </label>
+    </div>
   )
 }
 
@@ -130,17 +132,17 @@ function FieldTemplate(props: FieldTemplateProps) {
     )
   }
   return (
-    <label className="flex min-w-0 flex-col gap-1 text-xs font-medium">
-      <span>
+    <div className="flex min-w-0 flex-col gap-1 text-xs font-medium">
+      <label htmlFor={props.id}>
         {props.label}
         {props.required && <span className="text-destructive ml-1">*</span>}
-      </span>
+      </label>
       {props.children}
       {props.rawDescription && (
         <span className="text-muted-foreground text-xs">{props.rawDescription}</span>
       )}
       {props.errors}
-    </label>
+    </div>
   )
 }
 

--- a/packages/web/src/components/terminal/terminal-invocation-settings.test.tsx
+++ b/packages/web/src/components/terminal/terminal-invocation-settings.test.tsx
@@ -51,13 +51,17 @@ describe('TerminalInvocationSettings', () => {
     localStorage.clear()
   })
 
-  it('keeps settings compact and persists custom shell profiles and spawn commands from dialogs', async () => {
+  async function renderSettings() {
     const { TerminalInvocationSettings } = await import('./terminal-invocation-settings')
     render(<TerminalInvocationSettings />)
 
     await waitFor(() => {
       expect(screen.getByText(/Effective platform default:/).textContent).toContain('/bin/zsh')
     })
+  }
+
+  it('keeps settings compact and persists custom shell profiles from dialogs', async () => {
+    await renderSettings()
 
     expect(screen.queryByLabelText('Default Shell')).toBeNull()
     expect(screen.queryByPlaceholderText('Shell label')).toBeNull()
@@ -90,6 +94,10 @@ describe('TerminalInvocationSettings', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit Git Bash' }))
     expect(screen.getByText('Edit Shell')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  })
+
+  it('adapts command parameter fields without rebuilding the edited field input', async () => {
+    await renderSettings()
 
     fireEvent.click(screen.getByRole('button', { name: 'Add Command' }))
     expect(screen.getByText('Parameter 1')).toBeTruthy()
@@ -128,6 +136,15 @@ describe('TerminalInvocationSettings', () => {
     const textareaOption = await screen.findByRole('option', { name: 'Textarea' })
     fireEvent.mouseMove(textareaOption)
     fireEvent.click(textareaOption)
+  })
+
+  it('persists custom spawn commands with boolean flag builder parts', async () => {
+    await renderSettings()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Command' }))
+    fireEvent.change(screen.getByPlaceholderText('Command label'), {
+      target: { value: 'Claude Safe' },
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Add Boolean Flag' }))
     expect(screen.getByLabelText('Flag Token')).toBeTruthy()
     fireEvent.change(screen.getByPlaceholderText('--flag'), {
@@ -159,10 +176,6 @@ describe('TerminalInvocationSettings', () => {
       }>
     }
 
-    expect(stored.customShellProfiles?.[0]).toMatchObject({
-      label: 'Git Bash',
-      command: '/usr/bin/bash',
-    })
     expect(stored.customSpawnCommands?.[0]).toMatchObject({
       label: 'Claude Safe',
       command: 'claude',

--- a/packages/web/src/components/terminal/terminal-panel.test.tsx
+++ b/packages/web/src/components/terminal/terminal-panel.test.tsx
@@ -119,8 +119,24 @@ describe('TerminalPanel', () => {
           id: 'builtin:claude',
           label: 'Claude',
           command: 'claude',
-          args: [],
-          fields: [],
+          args: [
+            {
+              kind: 'booleanFlag',
+              fieldId: 'dangerouslySkipPermissions',
+              flag: '--dangerously-skip-permissions',
+            },
+          ],
+          fields: [
+            {
+              id: 'dangerouslySkipPermissions',
+              label: 'Skip permissions',
+              type: 'boolean',
+              options: [],
+              defaultValue: false,
+              required: false,
+              advanced: true,
+            },
+          ],
           source: 'builtin',
         },
       ],

--- a/packages/web/src/components/terminal/terminal-spawn-command-dialog.test.tsx
+++ b/packages/web/src/components/terminal/terminal-spawn-command-dialog.test.tsx
@@ -124,13 +124,22 @@ describe('TerminalSpawnCommandDialog', () => {
     )
 
     expect(getByDisplayValue('draft prompt')).toBeTruthy()
-    expect(screen.getByRole('checkbox', { name: 'Show advanced options' })).toBeTruthy()
+    const advancedButton = screen.getByRole('button', { name: /Advanced options/ })
+    const advancedSectionId = advancedButton.getAttribute('aria-controls')
+    expect(advancedSectionId).toBeTruthy()
+    const advancedSection = document.getElementById(advancedSectionId!)
+    expect(advancedSection?.getAttribute('aria-hidden')).toBe('true')
+    expect(advancedSection?.hasAttribute('inert')).toBe(true)
+    expect(advancedButton.getAttribute('aria-expanded')).toBe('false')
     expect(screen.queryByRole('checkbox', { name: /Skip permissions/ })).toBeNull()
     expect(document.body.textContent).toContain("claude 'draft prompt'")
     expect(document.body.textContent).not.toContain('--dangerously-skip-permissions')
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Show advanced options' }))
+    fireEvent.click(advancedButton)
 
+    expect(advancedButton.getAttribute('aria-expanded')).toBe('true')
+    expect(advancedSection?.getAttribute('aria-hidden')).toBe('false')
+    expect(advancedSection?.hasAttribute('inert')).toBe(false)
     expect(screen.getByRole('checkbox', { name: /Skip permissions/ })).toBeTruthy()
   })
 
@@ -145,7 +154,7 @@ describe('TerminalSpawnCommandDialog', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Show advanced options' }))
+    fireEvent.click(screen.getByRole('button', { name: /Advanced options/ }))
     fireEvent.click(screen.getByRole('checkbox', { name: /Skip permissions/ }))
     fireEvent.click(getByText('Create'))
 
@@ -158,5 +167,14 @@ describe('TerminalSpawnCommandDialog', () => {
       })
     )
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not close on outside dismiss requests', () => {
+    const onClose = vi.fn()
+    render(<TerminalSpawnCommandDialog open command={command} onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole('dialog', { hidden: true }), { clientX: 1, clientY: 1 })
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/packages/web/src/components/terminal/terminal-spawn-command-dialog.tsx
+++ b/packages/web/src/components/terminal/terminal-spawn-command-dialog.tsx
@@ -1,6 +1,5 @@
 import { Dialog } from '@/components/dialog'
 import { Select, type SelectOption } from '@/components/select'
-import { Switch } from '@/components/switch'
 import { useTerminalContext } from '@/lib/terminal-context'
 import { useTerminalInvocationConfig } from '@/lib/use-terminal-invocation-config'
 import {
@@ -14,8 +13,8 @@ import {
   type TerminalShellProfile,
   type TerminalSpawnCommand,
 } from '@openspecui/core/terminal-invocation'
-import { Rocket } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { ChevronDown, Rocket } from 'lucide-react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import { TerminalCommandForm } from './terminal-command-form'
 
 interface TerminalSpawnCommandDialogProps {
@@ -44,14 +43,12 @@ function isAdvancedField(uiSchemaEntry: unknown): boolean {
 
 function filterTerminalCommandParameters(
   parameters: TerminalCommandParameters,
-  includeAdvanced: boolean
+  predicate: (fieldId: string) => boolean
 ): TerminalCommandParameters {
-  if (includeAdvanced) return parameters
-
   const properties: Record<string, TerminalCommandJsonSchemaProperty> = {}
   const uiSchema: Record<string, Record<string, unknown>> = {}
   for (const [fieldId, property] of Object.entries(parameters.schema.properties)) {
-    if (isAdvancedField(parameters.uiSchema[fieldId])) continue
+    if (!predicate(fieldId)) continue
     properties[fieldId] = property
     const fieldUiSchema = parameters.uiSchema[fieldId]
     if (isRecord(fieldUiSchema)) {
@@ -80,6 +77,7 @@ export function TerminalSpawnCommandDialog({
   onClose,
   onCreated,
 }: TerminalSpawnCommandDialogProps) {
+  const advancedSectionId = useId()
   const { createShellSession } = useTerminalContext()
   const { shellProfiles, defaultShellProfile } = useTerminalInvocationConfig()
   const [values, setValues] = useState<TerminalCommandFieldValues>({})
@@ -116,9 +114,24 @@ export function TerminalSpawnCommandDialog({
     () => (parameters ? hasAdvancedFields(parameters) : false),
     [parameters]
   )
-  const visibleParameters = useMemo(
-    () => (parameters ? filterTerminalCommandParameters(parameters, showAdvanced) : null),
-    [parameters, showAdvanced]
+  const basicParameters = useMemo(
+    () =>
+      parameters
+        ? filterTerminalCommandParameters(
+            parameters,
+            (fieldId) => !isAdvancedField(parameters.uiSchema[fieldId])
+          )
+        : null,
+    [parameters]
+  )
+  const advancedParameters = useMemo(
+    () =>
+      parameters
+        ? filterTerminalCommandParameters(parameters, (fieldId) =>
+            isAdvancedField(parameters.uiSchema[fieldId])
+          )
+        : null,
+    [parameters]
   )
 
   const shellOptions = useMemo<SelectOption<string>[]>(
@@ -161,6 +174,7 @@ export function TerminalSpawnCommandDialog({
         </>
       }
       onClose={onClose}
+      onDismissRequest={null}
       className="max-w-xl"
       footer={
         <>
@@ -193,17 +207,10 @@ export function TerminalSpawnCommandDialog({
           />
         </label>
 
-        {hasAdvancedParameters && (
-          <label className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
-            <span className="font-medium">Show advanced options</span>
-            <Switch checked={showAdvanced} onCheckedChange={setShowAdvanced} />
-          </label>
-        )}
-
-        {visibleParameters && (
+        {basicParameters && (
           <TerminalCommandForm
-            schema={visibleParameters.schema}
-            uiSchema={visibleParameters.uiSchema}
+            schema={basicParameters.schema}
+            uiSchema={basicParameters.uiSchema}
             values={values}
             onChange={(nextValues) =>
               setValues((currentValues) => ({
@@ -212,6 +219,47 @@ export function TerminalSpawnCommandDialog({
               }))
             }
           />
+        )}
+
+        {hasAdvancedParameters && advancedParameters && (
+          <section className="space-y-2">
+            <button
+              type="button"
+              aria-expanded={showAdvanced}
+              aria-controls={advancedSectionId}
+              onClick={() => setShowAdvanced((current) => !current)}
+              className="border-border hover:bg-muted/40 flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left text-xs transition-colors"
+            >
+              <span className="font-medium">Advanced options</span>
+              <ChevronDown
+                className={`h-4 w-4 shrink-0 transition-transform ${showAdvanced ? 'rotate-180' : ''}`}
+              />
+            </button>
+            <div
+              id={advancedSectionId}
+              aria-hidden={!showAdvanced}
+              inert={!showAdvanced}
+              className={`grid transition-[grid-template-rows,opacity] duration-200 ease-out ${
+                showAdvanced ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+              }`}
+            >
+              <div className="min-h-0 overflow-hidden">
+                <div className="border-primary/35 rounded-md border bg-[color-mix(in_srgb,var(--primary)_7%,transparent)] p-3">
+                  <TerminalCommandForm
+                    schema={advancedParameters.schema}
+                    uiSchema={advancedParameters.uiSchema}
+                    values={values}
+                    onChange={(nextValues) =>
+                      setValues((currentValues) => ({
+                        ...currentValues,
+                        ...nextValues,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
         )}
 
         <div className="bg-muted/30 border-border rounded-md border px-3 py-2 text-xs">

--- a/packages/web/src/routes/opsx-compose.test.tsx
+++ b/packages/web/src/routes/opsx-compose.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OpsxComposeRoute } from './opsx-compose'
+
+const { setConfigMock, useLocationMock } = vi.hoisted(() => ({
+  setConfigMock: vi.fn(),
+  useLocationMock: vi.fn(),
+}))
+
+vi.mock('@/components/layout/pop-area', () => ({
+  usePopAreaConfigContext: () => ({
+    setConfig: setConfigMock,
+  }),
+  usePopAreaLifecycleContext: () => ({
+    requestClose: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/code-editor', () => ({
+  CodeEditor: () => <textarea aria-label="Prompt" />,
+}))
+
+vi.mock('@/lib/terminal-context', () => ({
+  useTerminalContext: () => ({
+    sessions: [],
+    activeSessionId: null,
+  }),
+}))
+
+vi.mock('@/lib/terminal-controller', () => ({
+  terminalController: {
+    writeToSession: vi.fn(),
+    addInputHistory: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock('@/lib/use-subscription', () => ({
+  useConfigSubscription: () => ({
+    data: { opsx: { agentInvocationMode: 'compose' } },
+  }),
+}))
+
+vi.mock('@/lib/opsx-workflow-invocation', () => ({
+  prepareWorkflowInvocation: vi.fn().mockResolvedValue({
+    kind: 'agent-prompt',
+    text: 'prepared prompt',
+    format: 'markdown',
+    mode: { requestedMode: 'compose', actualMode: 'compose', fallbackReason: null },
+  }),
+  stringifyWorkflowInvocation: vi.fn(() => 'prepared prompt'),
+  workflowDiagnosticsToText: vi.fn(() => null),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => useLocationMock(),
+}))
+
+describe('OpsxComposeRoute', () => {
+  beforeEach(() => {
+    setConfigMock.mockReset()
+    useLocationMock.mockReturnValue({
+      pathname: '/opsx-compose',
+      search: '?action=archive&change=add-terminal-spawn-command',
+      hash: '',
+      state: null,
+    })
+  })
+
+  it('blocks outside dismiss for change detail compose workflow dialogs', () => {
+    render(<OpsxComposeRoute />)
+
+    expect(setConfigMock).toHaveBeenCalledWith(expect.objectContaining({ onDismissRequest: null }))
+  })
+})

--- a/packages/web/src/routes/opsx-compose.tsx
+++ b/packages/web/src/routes/opsx-compose.tsx
@@ -191,6 +191,7 @@ export function OpsxComposeRoute() {
       panelClassName: 'w-full',
       bodyClassName: 'p-0',
       maxHeight: 'min(86dvh,920px)',
+      onDismissRequest: null,
     })
   }, [setConfig])
 

--- a/packages/web/src/routes/opsx-new.tsx
+++ b/packages/web/src/routes/opsx-new.tsx
@@ -32,6 +32,7 @@ export function OpsxNewRoute() {
       panelClassName: 'w-full',
       bodyClassName: 'p-0',
       maxHeight: 'min(86dvh,900px)',
+      onDismissRequest: null,
     })
   }, [setConfig])
 

--- a/packages/web/src/routes/opsx-propose.test.tsx
+++ b/packages/web/src/routes/opsx-propose.test.tsx
@@ -152,6 +152,16 @@ describe('OpsxProposeRoute terminal target', () => {
     queryClient.clear()
   })
 
+  it('blocks outside dismiss for the propose form dialog', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <OpsxProposeRoute />
+      </QueryClientProvider>
+    )
+
+    expect(setConfigMock).toHaveBeenCalledWith(expect.objectContaining({ onDismissRequest: null }))
+  })
+
   it('opens the shared spawn dialog with prepared payload when target is create', async () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/packages/web/src/routes/opsx-propose.tsx
+++ b/packages/web/src/routes/opsx-propose.tsx
@@ -118,6 +118,7 @@ export function OpsxProposeRoute() {
       panelClassName: 'w-full',
       bodyClassName: 'p-0',
       maxHeight: 'min(86dvh,900px)',
+      onDismissRequest: null,
     })
   }, [setConfig])
 

--- a/packages/web/src/routes/opsx-verify.test.tsx
+++ b/packages/web/src/routes/opsx-verify.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OpsxVerifyRoute } from './opsx-verify'
+
+const { setConfigMock, useLocationMock } = vi.hoisted(() => ({
+  setConfigMock: vi.fn(),
+  useLocationMock: vi.fn(),
+}))
+
+vi.mock('@/components/layout/pop-area', () => ({
+  usePopAreaConfigContext: () => ({
+    setConfig: setConfigMock,
+  }),
+  usePopAreaLifecycleContext: () => ({
+    requestClose: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/use-cli-runner', () => ({
+  useCliRunner: () => ({
+    lines: [],
+    status: 'idle',
+    hasStarted: false,
+    commands: {
+      replaceAll: vi.fn(),
+      runAll: vi.fn(),
+    },
+    reset: vi.fn(),
+    cancel: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/opsx-workflow-invocation', () => ({
+  prepareWorkflowInvocation: vi.fn().mockResolvedValue({
+    kind: 'cli-command',
+    command: 'openspec',
+    args: ['validate', 'add-terminal-spawn-command'],
+    mode: { requestedMode: 'direct', actualMode: 'direct', fallbackReason: null },
+  }),
+  workflowDiagnosticsToText: vi.fn(() => null),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => useLocationMock(),
+}))
+
+describe('OpsxVerifyRoute', () => {
+  beforeEach(() => {
+    setConfigMock.mockReset()
+    useLocationMock.mockReturnValue({
+      pathname: '/opsx-verify',
+      search: '?change=add-terminal-spawn-command',
+      hash: '',
+      state: null,
+    })
+  })
+
+  it('blocks outside dismiss for change detail verify workflow dialogs', () => {
+    render(<OpsxVerifyRoute />)
+
+    expect(setConfigMock).toHaveBeenCalledWith(expect.objectContaining({ onDismissRequest: null }))
+  })
+})

--- a/packages/web/src/routes/opsx-verify.tsx
+++ b/packages/web/src/routes/opsx-verify.tsx
@@ -34,6 +34,7 @@ export function OpsxVerifyRoute() {
       panelClassName: 'w-full',
       bodyClassName: 'p-0',
       maxHeight: 'min(82dvh,760px)',
+      onDismissRequest: null,
     })
   }, [setConfig])
 

--- a/packages/web/src/routes/search.tsx
+++ b/packages/web/src/routes/search.tsx
@@ -89,6 +89,7 @@ export function SearchRoute() {
       panelClassName: 'w-full',
       bodyClassName: 'p-0',
       maxHeight: 'min(88dvh,920px)',
+      onDismissRequest: undefined,
     })
   }, [setConfig])
 


### PR DESCRIPTION
## Summary
- Add a shared `onDismissRequest` dialog rule so form-heavy dialogs can block accidental backdrop/ESC dismiss while explicit close actions still work.
- Apply that rule to terminal spawn command dialogs, archive/workflow dialogs, and PopArea routes that contain important forms.
- Improve terminal command creation UX with collapsed advanced options, accessible empty select labels, and safer form label hit targets.

## Validation
- `git diff --check`
- `pnpm format:check`
- `pnpm exec oxlint packages/web --ignore-path .gitignore`
- `pnpm --filter @openspecui/web typecheck`
- `pnpm --filter @openspecui/web exec vitest run --project unit src/components/dialog.test.tsx src/components/global-archive-modal.test.tsx src/components/select.test.tsx src/components/terminal/terminal-command-form.test.tsx src/components/terminal/terminal-spawn-command-dialog.test.tsx src/components/terminal/terminal-panel.test.tsx src/routes/opsx-propose.test.tsx src/routes/opsx-compose.test.tsx src/routes/opsx-verify.test.tsx --testTimeout=15000`
- Scoped CI fast gate via `CI_SCOPE_JSON=... node scripts/ci-fast-gate.mjs`
- `pnpm --filter @openspecui/web test:browser:ci`
- `pnpm changeset:check` (skipped because `CHANGESET_CHECK_BASE_SHA` is not set locally)

## Changeset
- Patch release for `@openspecui/web`.
