### PR TITLE
fix(web): polish mobile terminal and select interactions

### DIFF
--- a/.changeset/four-fixes-mobile-audio-select.md
+++ b/.changeset/four-fixes-mobile-audio-select.md
@@ -1,0 +1,5 @@
+---
+"@openspecui/web": patch
+---
+
+Fix mobile terminal input remounting, audio context gesture gating, terminal tab scroll control spacing, mobile notification action styling, and mobile select popover closing behavior.

--- a/packages/web/src/components/layout/mobile-header.test.tsx
+++ b/packages/web/src/components/layout/mobile-header.test.tsx
@@ -60,10 +60,23 @@ describe('MobileHeader', () => {
   afterEach(() => cleanup())
 
   it('places notifications next to search and renders live status as icon-only', () => {
-    render(<MobileHeader />)
+    const { container } = render(<MobileHeader />)
 
-    expect(screen.getByRole('button', { name: 'Open search' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Open notifications, 2 unread' })).toBeTruthy()
+    const searchButton = screen.getByRole('button', { name: 'Open search' })
+    const notificationButton = screen.getByRole('button', {
+      name: 'Open notifications, 2 unread',
+    })
+    const headerActions = container.querySelector('.mobile-header > div:last-child')
+
+    expect(searchButton).toBeTruthy()
+    expect(notificationButton).toBeTruthy()
+    expect(headerActions?.children[0]).toBe(searchButton)
+    expect(headerActions?.children[1]).toBe(notificationButton)
+    expect(searchButton.className).toContain('border-primary')
+    expect(notificationButton.className).toContain('border-primary')
+    expect(searchButton.className).toContain('h-7.5')
+    expect(notificationButton.className).toContain('h-7.5')
+    expect(notificationButton.className).toContain('w-7.5')
     expect(screen.queryByText('Live')).toBeNull()
   })
 })

--- a/packages/web/src/components/layout/mobile-header.tsx
+++ b/packages/web/src/components/layout/mobile-header.tsx
@@ -39,12 +39,14 @@ export function MobileHeader() {
           <button
             type="button"
             onClick={() => vtNavController.activatePop('/search')}
-            className="hover:bg-muted border-primary rounded-md border p-1.5"
+            className="hover:bg-muted border-primary h-7.5 w-7.5 inline-flex items-center justify-center rounded-md border"
             aria-label="Open search"
           >
             <Search className="h-4 w-4" />
           </button>
-          {!isStatic && <NotificationEntryButton className="h-8 w-8" />}
+          {!isStatic && (
+            <NotificationEntryButton className="border-primary hover:bg-muted h-7.5 w-7.5" />
+          )}
           <StatusIndicator compact />
         </div>
       </header>

--- a/packages/web/src/components/select.test.tsx
+++ b/packages/web/src/components/select.test.tsx
@@ -62,6 +62,17 @@ describe('Select', () => {
     expect(trigger.className).toContain('h-9')
   })
 
+  it('hides the positioner when its anchor is hidden during close transitions', async () => {
+    const { container } = render(<SelectHarness />)
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Auto refresh' }))
+    await screen.findByRole('option', { name: '5min' })
+
+    const positioner = container.ownerDocument.body.querySelector('[role="presentation"]')
+
+    expect(positioner?.className).toContain('data-[anchor-hidden]:opacity-0')
+  })
+
   it('renders grouped options with accessible group labels', async () => {
     render(<Select value="shell:zsh" groups={GROUPS} onValueChange={() => {}} ariaLabel="Target" />)
 

--- a/packages/web/src/components/select.tsx
+++ b/packages/web/src/components/select.tsx
@@ -139,7 +139,10 @@ export function Select<T extends string>({
       <BaseSelect.Portal container={portalContainer ?? undefined}>
         <BaseSelect.Positioner
           sideOffset={sideOffset}
-          className={cn('z-50 select-none outline-none', positionerClassName)}
+          className={cn(
+            'z-50 select-none outline-none data-[anchor-hidden]:opacity-0',
+            positionerClassName
+          )}
         >
           <BaseSelect.Popup
             className={cn(

--- a/packages/web/src/components/tabs.tsx
+++ b/packages/web/src/components/tabs.tsx
@@ -120,7 +120,7 @@ const tabsStyleText = (id: string) => {
       border: 0;
       font-size: 1.2rem;
       background: none;
-      z-index: 2;
+      z-index: 100;
       color: currentColor;
     }
 

--- a/packages/web/src/components/terminal/terminal-tabs.test.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.test.tsx
@@ -43,7 +43,7 @@ describe('TerminalTabs', () => {
       headerForeground: 'z-auto flex-1',
       headerFrame: 'items-end',
       strip: 'min-w-0 flex-1 items-end border-b border-terminal-foreground/20 px-4 rounded-none',
-      list: 'flex-1 items-end overflow-y-hidden pt-2',
+      list: 'flex-1 items-end overflow-y-hidden pt-2 [&::scroll-button(*)]:mt-3',
       buttonBase:
         'z-20 w-[clamp(8.5rem,18vw,13rem)] rounded-t-[8px] border border-b-0 border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
       buttonInner:
@@ -54,7 +54,8 @@ describe('TerminalTabs', () => {
         'bg-transparent text-terminal-foreground/72 hover:border-[color-mix(in_oklab,var(--background)_10%,transparent)] hover:text-terminal-foreground',
       inactiveButtonInner:
         'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
-      selectionIndicatorViewport: 'inset-x-0 top-0 bottom-[-1px] overflow-visible',
+      selectionIndicatorViewport:
+        'inset-x-0 top-0 bottom-[-1px] overflow-visible overflow-x-hidden',
       selectionIndicator:
         'border-terminal-foreground/20 border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ease-[cubic-bezier(0.22,0.61,0.36,1)]',
     })

--- a/packages/web/src/components/terminal/terminal-tabs.tsx
+++ b/packages/web/src/components/terminal/terminal-tabs.tsx
@@ -44,7 +44,7 @@ export function TerminalTabs({
         headerForeground: 'z-auto flex-1',
         headerFrame: 'items-end',
         strip: `min-w-0 flex-1 items-end border-b ${TERMINAL_CHROME_BORDER} px-4 rounded-none`,
-        list: 'flex-1 items-end overflow-y-hidden pt-2',
+        list: 'flex-1 items-end overflow-y-hidden pt-2 [&::scroll-button(*)]:mt-3',
         buttonBase: `z-20 w-[clamp(8.5rem,18vw,13rem)] rounded-t-[8px] border border-b-0 border-transparent px-0 py-0 transition-[color,background-color,border-color] duration-180 ${IOS_TAB_EASE}`,
         buttonInner: `grid h-full min-w-0 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-t-[8px] px-3 py-1.5 transition-[color,background-color,transform,filter] duration-180 ${IOS_TAB_EASE} will-change-transform`,
         activeButton: 'bg-transparent text-terminal-foreground',
@@ -54,7 +54,8 @@ export function TerminalTabs({
         inactiveButtonInner:
           'bg-terminal [filter:brightness(0.9)] [transform:translateY(0.25em)] hover:text-terminal-foreground hover:[filter:brightness(0.96)] hover:[transform:translateY(0.125em)]',
         actions: `${TERMINAL_CHROME_BORDER} bg-terminal text-terminal-foreground border-b rounded-none px-1`,
-        selectionIndicatorViewport: 'inset-x-0 top-0 bottom-[-1px] overflow-visible',
+        selectionIndicatorViewport:
+          'inset-x-0 top-0 bottom-[-1px] overflow-visible overflow-x-hidden',
         closeButtonActive: 'text-terminal-foreground/70 hover:text-terminal-foreground',
         closeButtonInactive: 'text-terminal-foreground/50 hover:text-terminal-foreground',
         selectionIndicator: `${TERMINAL_CHROME_BORDER} border-x border-t border-b-0 bg-terminal rounded-t-[8px] shadow-[0_1px_0_var(--terminal)] duration-180 ${IOS_TAB_EASE}`,

--- a/packages/web/src/lib/audio-cue-engine.ts
+++ b/packages/web/src/lib/audio-cue-engine.ts
@@ -7,22 +7,19 @@ import {
   type SoundId,
 } from '@openspecui/core/sounds'
 import { getApiBaseUrl } from './api-config'
+import {
+  createAudioContextAfterUserGesture,
+  prepareAudioContextAfterUserGesture,
+} from './user-gesture-audio-context'
 
-type AudioContextConstructor = typeof AudioContext
 export type AudioCueFallback = 'bell' | 'notification'
 export type AudioCueSound = SoundId
 export type AudioCueVolume = number
-
-function getAudioContextConstructor(): AudioContextConstructor | null {
-  if (typeof window === 'undefined') return null
-  return window.AudioContext ?? window.webkitAudioContext ?? null
-}
 
 export class AudioCueEngine {
   private readonly fallbackSound: SoundId
   private unlocked = false
   private unlockPromise: Promise<void> | null = null
-  private audioContext: AudioContext | null = null
   private silentAudio: HTMLAudioElement | null = null
   private readonly activeAudios = new Set<HTMLAudioElement>()
 
@@ -31,14 +28,7 @@ export class AudioCueEngine {
   }
 
   init(): void {
-    if (typeof window === 'undefined') return
-    const unlock = () => {
-      void this.unlock()
-      window.removeEventListener('pointerdown', unlock)
-      window.removeEventListener('keydown', unlock)
-    }
-    window.addEventListener('pointerdown', unlock, { once: true, passive: true })
-    window.addEventListener('keydown', unlock, { once: true })
+    prepareAudioContextAfterUserGesture()
   }
 
   async unlock(): Promise<void> {
@@ -59,14 +49,11 @@ export class AudioCueEngine {
   }
 
   private async unlockAudioContext(): Promise<void> {
-    const AudioContextCtor = getAudioContextConstructor()
-    if (!AudioContextCtor) {
+    const context = await createAudioContextAfterUserGesture()
+    if (!context) {
       this.unlocked = true
       return
     }
-
-    const context = this.audioContext ?? new AudioContextCtor()
-    this.audioContext = context
 
     this.silentAudio ??= new Audio(
       'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA='
@@ -74,9 +61,6 @@ export class AudioCueEngine {
     this.silentAudio.volume = 0
     await this.silentAudio.play().catch(() => {})
 
-    if (context.state === 'suspended') {
-      await context.resume()
-    }
     this.unlocked = true
   }
 

--- a/packages/web/src/lib/terminal-controller.test.ts
+++ b/packages/web/src/lib/terminal-controller.test.ts
@@ -179,6 +179,7 @@ class MockInputPanelAddon {
   static active: MockInputPanelAddon | null = null
   static options: Array<{ showFab?: boolean }> = []
 
+  attachListenerCalls = 0
   private onInput: (data: string) => void
   private isOpen = false
 
@@ -189,7 +190,7 @@ class MockInputPanelAddon {
   }
 
   attachListeners(): void {
-    // noop
+    this.attachListenerCalls += 1
   }
 
   setPlatform(_platform: 'windows' | 'macos' | 'common'): void {
@@ -1122,6 +1123,33 @@ describe('terminal-controller PTY behavior', () => {
     expect(MockInputPanelAddon.options).toEqual(
       expect.arrayContaining([expect.objectContaining({ showFab: false })])
     )
+
+    terminalController.closeAll()
+    unsubscribe()
+  })
+
+  it('reattaches input panel listeners when an existing terminal is remounted', async () => {
+    const terminalController = await loadTerminalController()
+    const unsubscribe = terminalController.subscribe(() => {})
+    const ws = getPtySocket(0)
+    ws.emitOpen()
+
+    const localId = terminalController.createSession()
+    ws.emitJson({
+      type: 'created',
+      requestId: localId,
+      sessionId: 'pty-remount',
+      platform: 'common',
+    })
+
+    terminalController.mount(localId, document.createElement('div'))
+    const addon = MockInputPanelAddon.instances[0]
+    expect(addon?.attachListenerCalls).toBe(1)
+
+    terminalController.unmount(localId)
+    terminalController.mount(localId, document.createElement('div'))
+
+    expect(addon?.attachListenerCalls).toBe(2)
 
     terminalController.closeAll()
     unsubscribe()

--- a/packages/web/src/lib/terminal-controller.ts
+++ b/packages/web/src/lib/terminal-controller.ts
@@ -890,6 +890,7 @@ class TerminalController {
       }
       this.flushPendingOutput(instance)
       this.applyGhosttyBackground(instance, container)
+      instance.inputPanelAddon.attachListeners()
     }
 
     instance.mountedContainer = container

--- a/packages/web/src/lib/user-gesture-audio-context.test.ts
+++ b/packages/web/src/lib/user-gesture-audio-context.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+class MockAudioContext {
+  static constructorCalls = 0
+  state: AudioContextState = 'suspended'
+  resume = vi.fn(async () => {
+    this.state = 'running'
+  })
+
+  constructor() {
+    MockAudioContext.constructorCalls += 1
+  }
+}
+
+function stubAudioContext(): void {
+  vi.stubGlobal('AudioContext', MockAudioContext as unknown as typeof AudioContext)
+}
+
+function stubUserActivation(userActivation: UserActivation): void {
+  Object.defineProperty(navigator, 'userActivation', {
+    configurable: true,
+    value: userActivation,
+  })
+}
+
+async function loadAudioContextModule() {
+  vi.resetModules()
+  return import('./user-gesture-audio-context')
+}
+
+describe('createAudioContextAfterUserGesture', () => {
+  afterEach(() => {
+    MockAudioContext.constructorCalls = 0
+    vi.unstubAllGlobals()
+    Object.defineProperty(navigator, 'userActivation', {
+      configurable: true,
+      value: undefined,
+    })
+  })
+
+  it('waits for a user gesture before constructing AudioContext', async () => {
+    stubAudioContext()
+    const { createAudioContextAfterUserGesture } = await loadAudioContextModule()
+
+    const contextPromise = createAudioContextAfterUserGesture()
+    await Promise.resolve()
+
+    expect(MockAudioContext.constructorCalls).toBe(0)
+
+    window.dispatchEvent(new PointerEvent('pointerdown'))
+
+    await expect(contextPromise).resolves.toBeInstanceOf(MockAudioContext)
+    expect(MockAudioContext.constructorCalls).toBe(1)
+  })
+
+  it('constructs immediately after the page already has user activation', async () => {
+    stubAudioContext()
+    stubUserActivation({ hasBeenActive: true, isActive: false })
+    const { createAudioContextAfterUserGesture } = await loadAudioContextModule()
+
+    await expect(createAudioContextAfterUserGesture()).resolves.toBeInstanceOf(MockAudioContext)
+
+    expect(MockAudioContext.constructorCalls).toBe(1)
+  })
+
+  it('reuses the same AudioContext across callers', async () => {
+    stubAudioContext()
+    stubUserActivation({ hasBeenActive: true, isActive: false })
+    const { createAudioContextAfterUserGesture } = await loadAudioContextModule()
+
+    const first = await createAudioContextAfterUserGesture()
+    const second = await createAudioContextAfterUserGesture()
+
+    expect(first).toBe(second)
+    expect(MockAudioContext.constructorCalls).toBe(1)
+  })
+
+  it('returns null immediately when AudioContext is unsupported', async () => {
+    const { createAudioContextAfterUserGesture } = await loadAudioContextModule()
+
+    await expect(createAudioContextAfterUserGesture()).resolves.toBeNull()
+  })
+
+  it('remembers gestures registered by prepare without constructing AudioContext', async () => {
+    stubAudioContext()
+    const { createAudioContextAfterUserGesture, prepareAudioContextAfterUserGesture } =
+      await loadAudioContextModule()
+
+    prepareAudioContextAfterUserGesture()
+    window.dispatchEvent(new PointerEvent('pointerdown'))
+
+    expect(MockAudioContext.constructorCalls).toBe(0)
+
+    await expect(createAudioContextAfterUserGesture()).resolves.toBeInstanceOf(MockAudioContext)
+    expect(MockAudioContext.constructorCalls).toBe(1)
+  })
+})

--- a/packages/web/src/lib/user-gesture-audio-context.ts
+++ b/packages/web/src/lib/user-gesture-audio-context.ts
@@ -1,0 +1,93 @@
+type AudioContextConstructor = typeof AudioContext
+
+let audioContext: AudioContext | null = null
+let audioContextPromise: Promise<AudioContext | null> | null = null
+let userGesturePromise: Promise<void> | null = null
+let resolveUserGesturePromise: (() => void) | null = null
+let userGestureResolved = false
+let userGestureListenersActive = false
+
+function getAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === 'undefined') return null
+  return window.AudioContext ?? window.webkitAudioContext ?? null
+}
+
+function hasUserActivation(): boolean {
+  if (userGestureResolved) return true
+  if (typeof navigator === 'undefined') return false
+  return (
+    navigator.userActivation?.hasBeenActive === true || navigator.userActivation?.isActive === true
+  )
+}
+
+function removeUserGestureListeners(): void {
+  if (typeof window === 'undefined' || !userGestureListenersActive) return
+  window.removeEventListener('pointerdown', resolveUserGesture, true)
+  window.removeEventListener('keydown', resolveUserGesture, true)
+  userGestureListenersActive = false
+}
+
+function resolveUserGesture(): void {
+  userGestureResolved = true
+  removeUserGestureListeners()
+  resolveUserGesturePromise?.()
+  resolveUserGesturePromise = null
+  userGesturePromise = null
+}
+
+function addUserGestureListeners(): void {
+  if (typeof window === 'undefined' || userGestureListenersActive || hasUserActivation()) return
+  window.addEventListener('pointerdown', resolveUserGesture, {
+    capture: true,
+    once: true,
+    passive: true,
+  })
+  window.addEventListener('keydown', resolveUserGesture, { capture: true, once: true })
+  userGestureListenersActive = true
+}
+
+export function prepareAudioContextAfterUserGesture(): void {
+  addUserGestureListeners()
+}
+
+function waitForUserGesture(): Promise<void> {
+  if (typeof window === 'undefined' || hasUserActivation()) {
+    return Promise.resolve()
+  }
+
+  if (userGesturePromise) return userGesturePromise
+
+  userGesturePromise = new Promise<void>((resolve) => {
+    resolveUserGesturePromise = resolve
+    addUserGestureListeners()
+  })
+
+  return userGesturePromise
+}
+
+export async function createAudioContextAfterUserGesture(): Promise<AudioContext | null> {
+  if (audioContext) return audioContext
+  if (audioContextPromise) return audioContextPromise
+
+  if (!getAudioContextConstructor()) return null
+
+  audioContextPromise = waitForUserGesture()
+    .then(async () => {
+      const AudioContextCtor = getAudioContextConstructor()
+      if (!AudioContextCtor) return null
+
+      const context = audioContext ?? new AudioContextCtor()
+      audioContext = context
+
+      if (context.state === 'suspended') {
+        await context.resume()
+      }
+
+      return context
+    })
+    .finally(() => {
+      audioContextPromise = null
+    })
+
+  return audioContextPromise
+}


### PR DESCRIPTION
## Summary

- Align terminal tab scroll controls and prevent the terminal selection indicator from leaking horizontally.
- Defer AudioContext construction/resume until a user gesture has happened.
- Reattach mobile terminal input panel listeners when a terminal is remounted so the virtual keyboard can open again.
- Match the mobile Notifications entry styling and placement with the mobile Search entry.
- Hide Select positioners when the anchor is hidden during close transitions to prevent the mobile popover from flashing at the page origin.

## Validation

- pnpm --filter @openspecui/web exec vitest run --project unit src/components/terminal/terminal-tabs.test.tsx src/lib/user-gesture-audio-context.test.ts src/lib/terminal-controller.test.ts src/components/layout/mobile-header.test.tsx src/components/select.test.tsx
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
