### PR TITLE
fix: polish mobile floating input panel

### DIFF
--- a/.changeset/floating-input-panel-fixes.md
+++ b/.changeset/floating-input-panel-fixes.md
@@ -1,0 +1,7 @@
+---
+"openspecui": patch
+"@openspecui/web": patch
+"xterm-input-panel": patch
+---
+
+Fix mobile floating input panel chrome and settings switch semantics.

--- a/packages/web/src/routes/settings.test.tsx
+++ b/packages/web/src/routes/settings.test.tsx
@@ -1,0 +1,241 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Settings } from './settings'
+
+const { useConfigSubscriptionMock, staticModeMock, useServerStatusMock } = vi.hoisted(() => ({
+  useConfigSubscriptionMock: vi.fn(),
+  staticModeMock: vi.fn(() => false),
+  useServerStatusMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+  }),
+  useQuery: ({ queryKey }: { queryKey?: readonly string[] }) => {
+    const key = queryKey?.join('.') ?? ''
+    if (key === 'cli.getAllTools') {
+      return { data: [{ value: 'claude', name: 'Claude', available: true }], isLoading: false }
+    }
+    if (key === 'cli.getDetectedProjectTools') {
+      return { data: [{ value: 'claude', name: 'Claude' }], isLoading: false, refetch: vi.fn() }
+    }
+    if (key === 'cli.getProfileState') {
+      return {
+        data: {
+          available: true,
+          delivery: 'both',
+          workflows: [],
+          profile: 'core',
+          driftStatus: 'in-sync',
+          warningText: null,
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      }
+    }
+    if (key === 'cli.getToolInitStates') {
+      return {
+        data: [
+          {
+            toolId: 'claude',
+            toolName: 'Claude',
+            status: 'uninitialized',
+            hasAnyArtifacts: false,
+            expectedSkillCount: 0,
+            presentExpectedSkillCount: 0,
+            detectedSkillCount: 0,
+            expectedCommandCount: 0,
+            presentExpectedCommandCount: 0,
+            detectedCommandCount: 0,
+            missingSkillWorkflows: [],
+            missingCommandWorkflows: [],
+            unexpectedSkillWorkflows: [],
+            unexpectedCommandWorkflows: [],
+            legacyCommandWorkflows: [],
+          },
+        ],
+        refetch: vi.fn(),
+      }
+    }
+    if (key === 'cli.sniffGlobalCli') {
+      return { data: { hasGlobal: true, version: '1.3.0', hasUpdate: false }, isLoading: false }
+    }
+    if (key === 'cli.checkAvailability') {
+      return { data: { available: true, version: '1.3.0' }, isLoading: false, refetch: vi.fn() }
+    }
+    if (key === 'config.getEffectiveCliCommand') {
+      return { data: 'openspec', refetch: vi.fn() }
+    }
+    return { data: undefined, isLoading: false, refetch: vi.fn() }
+  },
+}))
+
+vi.mock('@/components/terminal/terminal-invocation-settings', () => ({
+  TerminalInvocationSettings: () => <div data-testid="terminal-invocation-settings" />,
+}))
+
+vi.mock('@/components/notifications/notification-settings', () => ({
+  NotificationSettings: () => <div data-testid="notification-settings" />,
+}))
+
+vi.mock('@/components/sound-setting-control', () => ({
+  SoundSettingControl: () => <div data-testid="sound-setting-control" />,
+}))
+
+vi.mock('@/components/cli-terminal', () => ({
+  CliTerminal: () => <div data-testid="cli-terminal" />,
+}))
+
+vi.mock('@/components/toc', () => ({
+  generateTimelineScope: () => '',
+  Toc: () => null,
+  TocSection: ({ children }: { children?: ReactNode }) => <section>{children}</section>,
+}))
+
+vi.mock('@/lib/static-mode', () => ({
+  getBasePath: () => '/',
+  isStaticMode: () => staticModeMock(),
+}))
+
+vi.mock('@/lib/use-server-status', () => ({
+  useServerStatus: () => useServerStatusMock(),
+}))
+
+vi.mock('@/lib/use-subscription', () => ({
+  useConfigSubscription: () => useConfigSubscriptionMock(),
+}))
+
+vi.mock('@/lib/use-cli-runner', () => ({
+  useCliRunner: () => ({
+    lines: [],
+    status: 'idle',
+    commands: {
+      replaceAll: vi.fn(),
+      runAll: vi.fn(),
+    },
+    cancel: vi.fn(),
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/terminal-bell-sound-engine', () => ({
+  TerminalBellSoundEngine: class {
+    init(): void {}
+    async play(): Promise<void> {}
+  },
+}))
+
+vi.mock('@/lib/terminal-controller', () => {
+  return {
+    GOOGLE_FONT_PRESETS: [],
+    TERMINAL_RENDERER_ENGINES: ['xterm'],
+    isTerminalRendererEngine: (value: string): value is 'xterm' => value === 'xterm',
+    terminalController: {
+      getConfig: () => ({
+        fontSize: 13,
+        fontFamily: '',
+        cursorBlink: true,
+        cursorStyle: 'block',
+        scrollback: 1000,
+        useTheme: 'app',
+        lightTheme: 'default-light',
+        darkTheme: 'default-dark',
+        rendererEngine: 'xterm',
+        bellSound: 'builtin:Blow',
+        bellVolume: 1,
+      }),
+      applyConfig: vi.fn(),
+      setRendererEngine: vi.fn(),
+    },
+  }
+})
+
+vi.mock('@/lib/api-config', () => ({
+  getApiBaseUrl: () => '',
+}))
+
+vi.mock('@/lib/theme', () => ({
+  applyTheme: vi.fn(),
+  getStoredTheme: () => 'system',
+  persistTheme: vi.fn(),
+}))
+
+vi.mock('@/lib/trpc', () => ({
+  queryClient: {
+    invalidateQueries: vi.fn(),
+  },
+  trpc: {
+    cli: {
+      sniffGlobalCli: {
+        queryOptions: () => ({ queryKey: ['cli.getAllTools'] }),
+        queryFilter: () => ({ queryKey: ['cli.sniffGlobalCli'] }),
+      },
+      checkAvailability: {
+        queryOptions: () => ({ queryKey: ['cli.checkAvailability'] }),
+        queryFilter: () => ({ queryKey: ['cli.checkAvailability'] }),
+      },
+      getAllTools: {
+        queryOptions: () => ({ queryKey: ['cli.getAllTools'] }),
+      },
+      getDetectedProjectTools: {
+        queryOptions: () => ({ queryKey: ['cli.getDetectedProjectTools'] }),
+      },
+      getProfileState: {
+        queryOptions: () => ({ queryKey: ['cli.getProfileState'] }),
+      },
+      getToolInitStates: {
+        queryOptions: () => ({ queryKey: ['cli.getToolInitStates'] }),
+      },
+    },
+    config: {
+      getEffectiveCliCommand: {
+        queryOptions: () => ({ queryKey: ['config.getEffectiveCliCommand'] }),
+        queryFilter: () => ({ queryKey: ['config.getEffectiveCliCommand'] }),
+      },
+    },
+  },
+  trpcClient: {
+    cli: {
+      execute: {
+        mutate: vi.fn(),
+      },
+    },
+    config: {
+      update: {
+        mutate: vi.fn(),
+      },
+    },
+  },
+}))
+
+describe('Settings', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders force init as the shared Switch control', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    )
+    useConfigSubscriptionMock.mockReturnValue({ data: {} })
+    useServerStatusMock.mockReturnValue({ projectDir: '/tmp/project' })
+
+    render(<Settings />)
+
+    const forceSwitch = await screen.findByRole('switch', { name: 'Force non-interactive init' })
+    await waitFor(() => expect(screen.queryByText('Loading settings...')).toBeNull())
+
+    expect(forceSwitch).toHaveAttribute('aria-checked', 'true')
+    expect(forceSwitch.className).toContain('w-11')
+  })
+})

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -1952,21 +1952,11 @@ export function Settings() {
                         <span className="break-word text-xs font-medium leading-4">
                           Force non-interactive init
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => setInitForce((prev) => !prev)}
-                          className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
-                            initForce ? 'bg-primary' : 'bg-muted-foreground/30'
-                          }`}
-                          aria-pressed={initForce}
-                          aria-label="Toggle force init"
-                        >
-                          <span
-                            className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
-                              initForce ? 'translate-x-4' : 'translate-x-0'
-                            }`}
-                          />
-                        </button>
+                        <Switch
+                          checked={initForce}
+                          onCheckedChange={setInitForce}
+                          ariaLabel="Force non-interactive init"
+                        />
                       </span>
                       <span className="text-muted-foreground text-[11px] leading-4">
                         Enabled by default so{' '}

--- a/packages/xterm-input-panel/src/input-panel.stories.ts
+++ b/packages/xterm-input-panel/src/input-panel.stories.ts
@@ -13,6 +13,24 @@ async function getLitElement(container: HTMLElement, selector: string) {
   return el
 }
 
+function pointer(target: Element, type: string, x: number, y: number, id = 1) {
+  target.dispatchEvent(
+    new PointerEvent(type, {
+      clientX: x,
+      clientY: y,
+      pointerId: id,
+      pointerType: 'mouse',
+      bubbles: true,
+      cancelable: true,
+    })
+  )
+}
+
+function expectFloatingDialogVisible(dialog: HTMLDialogElement) {
+  expect(dialog.open || dialog.matches(':popover-open')).toBe(true)
+  expect(dialog.matches(':modal')).toBe(false)
+}
+
 const meta: Meta = {
   title: 'InputPanel',
   tags: ['autodocs'],
@@ -58,8 +76,20 @@ export const FloatingLayout: StoryObj = {
   `,
   play: async ({ canvasElement }) => {
     const panel = await getLitElement(canvasElement, 'input-panel')
-    const dialog = panel.shadowRoot?.querySelector('.panel-dialog') as HTMLElement
+    const dialog = panel.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).toBeTruthy()
+    expectFloatingDialogVisible(dialog)
+    const moveBar = panel.shadowRoot?.querySelector('.move-bar') as HTMLElement
+    expect(moveBar).toBeTruthy()
+
+    const dialogStyles = getComputedStyle(dialog)
+    expect(dialogStyles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)')
+    expect(dialogStyles.borderTopWidth).toBe('1px')
+    expect(dialogStyles.borderRadius).toBe('8px')
+
+    const moveBarRect = moveBar.getBoundingClientRect()
+    const dialogRect = dialog.getBoundingClientRect()
+    expect(moveBarRect.top).toBeLessThan(dialogRect.top)
 
     const styles = getComputedStyle(dialog) as CSSStyleDeclaration & {
       webkitBackdropFilter?: string
@@ -214,6 +244,7 @@ export const FloatingResize: StoryObj = {
     const shadow = panel.shadowRoot!
     const dialog = shadow.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).toBeTruthy()
+    expectFloatingDialogVisible(dialog)
 
     const handles = shadow.querySelectorAll('.resize-handle')
     expect(handles.length).toBe(4)
@@ -223,6 +254,61 @@ export const FloatingResize: StoryObj = {
     expect(shadow.querySelector('.resize-tr')).toBeTruthy()
     expect(shadow.querySelector('.resize-bl')).toBeTruthy()
     expect(shadow.querySelector('.resize-br')).toBeTruthy()
+  },
+}
+
+/**
+ * Floating panel moves through the protruding move bar and toolbar blank space.
+ */
+export const FloatingDragHandles: StoryObj = {
+  render: () => html`
+    <input-panel layout="floating" style="height: 100%;">
+      <input-method-tab slot="input"></input-method-tab>
+      <virtual-keyboard-tab slot="keys" floating></virtual-keyboard-tab>
+      <shortcut-tab slot="shortcuts"></shortcut-tab>
+      <virtual-trackpad-tab slot="trackpad" floating></virtual-trackpad-tab>
+    </input-panel>
+  `,
+  play: async ({ canvasElement }) => {
+    const panel = await getLitElement(canvasElement, 'input-panel')
+    const shadow = panel.shadowRoot!
+    const dialog = shadow.querySelector('.panel-dialog') as HTMLDialogElement
+    const moveBar = shadow.querySelector('.move-bar') as HTMLElement
+    const toolbar = shadow.querySelector('.toolbar') as HTMLElement
+    const layoutBtn = shadow.querySelector('.action-group .icon-btn') as HTMLButtonElement
+    expectFloatingDialogVisible(dialog)
+    expect(moveBar).toBeTruthy()
+    expect(toolbar).toBeTruthy()
+
+    const before = dialog.getBoundingClientRect()
+    const handleRect = moveBar.getBoundingClientRect()
+    const startX = handleRect.left + handleRect.width / 2
+    const startY = handleRect.top + handleRect.height / 2
+
+    pointer(moveBar, 'pointerdown', startX, startY)
+    pointer(moveBar, 'pointermove', startX + 40, startY + 22)
+    pointer(moveBar, 'pointerup', startX + 40, startY + 22)
+
+    const after = dialog.getBoundingClientRect()
+    expect(after.left).toBeGreaterThan(before.left + 20)
+    expect(after.top).toBeGreaterThan(before.top + 10)
+
+    const toolbarRect = toolbar.getBoundingClientRect()
+    const toolbarStartX = toolbarRect.left + toolbarRect.width / 2
+    const toolbarStartY = toolbarRect.top + toolbarRect.height / 2
+
+    pointer(toolbar, 'pointerdown', toolbarStartX, toolbarStartY, 2)
+    pointer(toolbar, 'pointermove', toolbarStartX - 35, toolbarStartY + 16, 2)
+    pointer(toolbar, 'pointerup', toolbarStartX - 35, toolbarStartY + 16, 2)
+
+    const toolbarAfter = dialog.getBoundingClientRect()
+    expect(toolbarAfter.left).toBeLessThan(after.left - 15)
+    expect(toolbarAfter.top).toBeGreaterThan(after.top + 8)
+
+    layoutBtn.click()
+    await panel.updateComplete
+
+    expect(panel.getAttribute('layout')).toBe('fixed')
   },
 }
 

--- a/packages/xterm-input-panel/src/input-panel.ts
+++ b/packages/xterm-input-panel/src/input-panel.ts
@@ -24,6 +24,7 @@ const MIN_WIDTH_PX = 300
 const MIN_HEIGHT_PX = 150
 const MAX_WIDTH_PCT = 95
 const MAX_HEIGHT_PCT = 85
+const MOVE_BAR_PROTRUSION_PX = 10
 
 const SETTINGS_KEY = 'xtermInputPanelSettings'
 
@@ -92,6 +93,8 @@ export class InputPanel extends LitElement {
       --muted-foreground: var(--_ip-muted-fg);
       --terminal: var(--_ip-bg);
       --terminal-foreground: var(--_ip-fg);
+      --move-bar-height: 10px;
+      --move-bar-protrusion: 10px;
       font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
       font-size: 13px;
       color: var(--foreground, #fff);
@@ -214,7 +217,7 @@ export class InputPanel extends LitElement {
       border-radius: 8px;
       background: var(--background, #1a1a1a);
       color: var(--foreground, #fff);
-      overflow: hidden;
+      overflow: visible;
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
       display: flex;
       flex-direction: column;
@@ -224,6 +227,54 @@ export class InputPanel extends LitElement {
 
     .panel-dialog {
       z-index: 9999;
+    }
+
+    .panel-body {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      border-radius: inherit;
+    }
+
+    .move-bar {
+      position: absolute;
+      top: calc(-1 * var(--move-bar-protrusion));
+      left: 50%;
+      width: 68px;
+      height: var(--move-bar-height);
+      transform: translateX(-50%);
+      border: 1px solid var(--primary, #e04a2f);
+      border-bottom: 0;
+      border-radius: 10px 10px 0 0;
+      background: var(--background, #1a1a1a);
+      color: var(--muted-foreground, #888);
+      touch-action: none;
+      cursor: grab;
+      z-index: 12;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 -6px 12px rgba(0, 0, 0, 0.12);
+    }
+
+    .move-bar::before {
+      content: '';
+      width: 34px;
+      height: 4px;
+      border-radius: 999px;
+      background: currentColor;
+      opacity: 0.72;
+    }
+
+    .move-bar:hover,
+    :host([data-interacting]) .move-bar {
+      color: var(--primary, #e04a2f);
+    }
+
+    :host([data-interacting]) .move-bar {
+      cursor: grabbing;
     }
 
     /* --- Resize handles --- */
@@ -345,6 +396,7 @@ export class InputPanel extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback()
+    this._closeFloatingDialog()
     this.dispatchEvent(
       new CustomEvent('input-panel:disconnected', { bubbles: true, composed: true })
     )
@@ -416,8 +468,8 @@ export class InputPanel extends LitElement {
       maxOverY = hPx / 3
     return {
       left: Math.max(-maxOverX, Math.min(vw - wPx + maxOverX, leftPx)),
-      // Top edge: never go above 0 — toolbar must stay accessible for dragging
-      top: Math.max(0, Math.min(vh - hPx + maxOverY, topPx)),
+      // Keep the protruding move handle reachable even when the panel is near the top edge.
+      top: Math.max(MOVE_BAR_PROTRUSION_PX, Math.min(vh - hPx + maxOverY, topPx)),
     }
   }
 
@@ -453,6 +505,55 @@ export class InputPanel extends LitElement {
     if (dialog) this._applyGeometry(dialog)
   }
 
+  private _isPopoverOpen(dialog: HTMLDialogElement) {
+    try {
+      return dialog.matches(':popover-open')
+    } catch {
+      return false
+    }
+  }
+
+  private _isFloatingDialogOpen(dialog: HTMLDialogElement) {
+    return dialog.open || this._isPopoverOpen(dialog)
+  }
+
+  private _showFloatingDialog(dialog: HTMLDialogElement) {
+    if (this._isFloatingDialogOpen(dialog)) return
+    if (!dialog.isConnected) {
+      requestAnimationFrame(() => {
+        if (
+          this.layout === 'floating' &&
+          dialog.isConnected &&
+          !this._isFloatingDialogOpen(dialog)
+        ) {
+          this._showFloatingDialog(dialog)
+          this._applyGeometry(dialog)
+        }
+      })
+      return
+    }
+    const popoverDialog = dialog as HTMLDialogElement & {
+      showPopover?: () => void
+    }
+    if (typeof popoverDialog.showPopover === 'function') {
+      popoverDialog.showPopover()
+      return
+    }
+    dialog.show()
+  }
+
+  private _closeFloatingDialog() {
+    const dialog = this.shadowRoot?.querySelector('.panel-dialog') as
+      | (HTMLDialogElement & { hidePopover?: () => void })
+      | null
+    if (!dialog) return
+    if (this._isPopoverOpen(dialog) && typeof dialog.hidePopover === 'function') {
+      dialog.hidePopover()
+      return
+    }
+    if (dialog.open) dialog.close()
+  }
+
   // --- Tab / layout ---
 
   private _switchTab(tab: InputPanelTab) {
@@ -469,6 +570,9 @@ export class InputPanel extends LitElement {
 
   private _toggleLayout() {
     this.layout = this.layout === 'fixed' ? 'floating' : 'fixed'
+    if (this.layout === 'fixed') {
+      this._closeFloatingDialog()
+    }
     this.dispatchEvent(
       new CustomEvent('input-panel:layout-change', {
         detail: { layout: this.layout },
@@ -480,8 +584,7 @@ export class InputPanel extends LitElement {
   }
 
   private _close() {
-    const dialog = this.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement | null
-    if (dialog?.open) dialog.close()
+    this._closeFloatingDialog()
     this.dispatchEvent(
       new CustomEvent('input-panel:close', {
         bubbles: true,
@@ -494,8 +597,8 @@ export class InputPanel extends LitElement {
     super.firstUpdated(changed)
     if (this.layout === 'floating') {
       const dialog = this.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement | null
-      if (dialog && !dialog.open) {
-        dialog.show()
+      if (dialog && !this._isFloatingDialogOpen(dialog)) {
+        this._showFloatingDialog(dialog)
         this._applyGeometry(dialog)
       }
     }
@@ -510,10 +613,10 @@ export class InputPanel extends LitElement {
       const dialog = this.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement | null
       if (dialog) {
         // Only re-open dialog when layout just switched to floating
-        if (changed.has('layout') && !dialog.open) {
-          dialog.show()
+        if (changed.has('layout') && !this._isFloatingDialogOpen(dialog)) {
+          this._showFloatingDialog(dialog)
         }
-        if (dialog.open) {
+        if (this._isFloatingDialogOpen(dialog)) {
           this._applyGeometry(dialog)
         }
       }
@@ -523,9 +626,12 @@ export class InputPanel extends LitElement {
   // --- Dialog drag ---
 
   private _onToolbarPointerDown(e: PointerEvent) {
-    if (this.layout !== 'floating') return
-    // Don't intercept clicks on buttons (close, tabs, layout toggle)
     if ((e.target as HTMLElement).closest('button')) return
+    this._onDragPointerDown(e)
+  }
+
+  private _onDragPointerDown(e: PointerEvent) {
+    if (this.layout !== 'floating') return
     const dialog = this.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement | null
     if (!dialog) return
 
@@ -540,10 +646,15 @@ export class InputPanel extends LitElement {
       origTop: rect.top,
     }
     this.setAttribute('data-interacting', '')
-    ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+    const handle = e.currentTarget as HTMLElement
+    try {
+      handle.setPointerCapture(e.pointerId)
+    } catch {
+      // Synthetic PointerEvents used by browser tests do not always create an active pointer.
+    }
   }
 
-  private _onToolbarPointerMove(e: PointerEvent) {
+  private _onDragPointerMove(e: PointerEvent) {
     if (!this._dragState) return
     e.stopPropagation()
     e.preventDefault()
@@ -567,8 +678,10 @@ export class InputPanel extends LitElement {
     dialog.style.bottom = 'auto'
   }
 
-  private _onToolbarPointerUp() {
+  private _onDragPointerUp(e: PointerEvent) {
     if (!this._dragState) return
+    e.stopPropagation()
+    e.preventDefault()
     this._dragState = null
     this.removeAttribute('data-interacting')
 
@@ -737,8 +850,9 @@ export class InputPanel extends LitElement {
         class="toolbar"
         part="toolbar"
         @pointerdown=${(e: PointerEvent) => this._onToolbarPointerDown(e)}
-        @pointermove=${(e: PointerEvent) => this._onToolbarPointerMove(e)}
-        @pointerup=${() => this._onToolbarPointerUp()}
+        @pointermove=${(e: PointerEvent) => this._onDragPointerMove(e)}
+        @pointerup=${(e: PointerEvent) => this._onDragPointerUp(e)}
+        @pointercancel=${(e: PointerEvent) => this._onDragPointerUp(e)}
       >
         <div class="tab-group">
           ${tabs.map(
@@ -778,7 +892,16 @@ export class InputPanel extends LitElement {
     `
 
     if (this.layout === 'floating') {
-      return html` <dialog class="panel-dialog">
+      return html` <dialog class="panel-dialog" popover="manual">
+        <div
+          class="move-bar"
+          part="move-bar"
+          aria-label="Move input panel"
+          @pointerdown=${(e: PointerEvent) => this._onDragPointerDown(e)}
+          @pointermove=${(e: PointerEvent) => this._onDragPointerMove(e)}
+          @pointerup=${(e: PointerEvent) => this._onDragPointerUp(e)}
+          @pointercancel=${(e: PointerEvent) => this._onDragPointerUp(e)}
+        ></div>
         <div
           class="resize-handle resize-tl"
           @pointerdown=${(e: PointerEvent) => this._onResizeStart(e, 'tl')}
@@ -795,7 +918,7 @@ export class InputPanel extends LitElement {
           class="resize-handle resize-br"
           @pointerdown=${(e: PointerEvent) => this._onResizeStart(e, 'br')}
         ></div>
-        ${inner}
+        <div class="panel-body">${inner}</div>
       </dialog>`
     }
 

--- a/packages/xterm-input-panel/src/xterm-addon.stories.ts
+++ b/packages/xterm-input-panel/src/xterm-addon.stories.ts
@@ -52,6 +52,11 @@ function setupTerminal(container: HTMLElement, opts?: { stateKey?: string }) {
   return { terminal, addon, inputHandler }
 }
 
+function expectFloatingDialogVisible(dialog: HTMLDialogElement) {
+  expect(dialog.open || dialog.matches(':popover-open')).toBe(true)
+  expect(dialog.matches(':modal')).toBe(false)
+}
+
 const meta: Meta = {
   title: 'InputPanelAddon',
   tags: ['autodocs'],
@@ -94,13 +99,13 @@ export const OpenCreatesPanel: StoryObj = {
     expect(panel!.getAttribute('layout')).toBe('floating')
     expect(panel!.parentElement).toBe(container)
 
-    // Wait for Lit to render + firstUpdated to call dialog.show()
+    // Wait for Lit to render + firstUpdated to open the floating dialog without modal inert behavior.
     await (panel as any).updateComplete
 
-    // The dialog inside shadow DOM should be open
+    // The dialog inside shadow DOM should be visible.
     const dialog = (panel as any).shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).not.toBeNull()
-    expect(dialog.open).toBe(true)
+    expectFloatingDialogVisible(dialog)
 
     // Cleanup
     addon.close()
@@ -178,11 +183,11 @@ export const ToggleCycle: StoryObj = {
     const panel = container.querySelector('input-panel')
     expect(panel).not.toBeNull()
 
-    // Wait for Lit render and verify dialog is open
+    // Wait for Lit render and verify dialog is visible.
     await (panel as any).updateComplete
     const dialog = (panel as any).shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).not.toBeNull()
-    expect(dialog.open).toBe(true)
+    expectFloatingDialogVisible(dialog)
 
     addon.close()
   },
@@ -303,10 +308,10 @@ export const CustomElementRegistered: StoryObj = {
     const dialog = shadow.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).not.toBeNull()
 
-    // firstUpdated should have called dialog.show()
-    expect(dialog.open).toBe(true)
+    // firstUpdated should have opened the floating dialog without modal inert behavior.
+    expectFloatingDialogVisible(dialog)
 
-    // Floating mode intentionally has no backdrop.
+    // Floating mode intentionally renders no custom backdrop element.
     const backdrop = shadow.querySelector('.backdrop')
     expect(backdrop).toBeNull()
 
@@ -341,7 +346,7 @@ export const FabClickSimulation: StoryObj = {
 
     const dialog = panel.shadowRoot?.querySelector('.panel-dialog') as HTMLDialogElement
     expect(dialog).not.toBeNull()
-    expect(dialog.open).toBe(true)
+    expectFloatingDialogVisible(dialog)
 
     // Verify dialog has reasonable dimensions (not 0x0)
     const rect = dialog.getBoundingClientRect()


### PR DESCRIPTION
## Summary

- Use the shared Switch control for the Force non-interactive init setting.
- Restore the floating input panel as a non-modal top-layer surface with preserved translucent chrome.
- Add the protruding move bar while keeping toolbar blank-space drag and button clicks separate.

## Validation

- pnpm --filter xterm-input-panel typecheck
- pnpm --filter xterm-input-panel exec vitest run --retry 0 --config vitest.storybook.config.ts src/input-panel.stories.ts src/xterm-addon.stories.ts
- pnpm --filter xterm-input-panel test:browser
- pnpm --filter @openspecui/web typecheck
- pnpm --filter @openspecui/web test -- src/routes/settings.test.tsx
- pnpm format:check
- pnpm lint:ci
- pnpm changeset:check
- git diff --check
