### PR TITLE
fix(cli): resolve translation sqlite at runtime

### DIFF
--- a/.changeset/tall-masks-shake.md
+++ b/.changeset/tall-masks-shake.md
@@ -1,0 +1,5 @@
+---
+'openspecui': patch
+---
+
+Fix document translation cache in the packaged CLI by resolving the native SQLite binding from runtime dependencies.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@lydell/node-pty": "^1.1.0",
     "@parcel/watcher": "^2.5.1",
+    "better-sqlite3": "^12.5.0",
     "semver": "^7.7.3",
     "tsx": "^4.19.2",
     "yaml": "^2.8.0"

--- a/packages/cli/src/native-runtime-dependencies.test.ts
+++ b/packages/cli/src/native-runtime-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { CLI_NATIVE_RUNTIME_DEPENDENCIES } from './native-runtime-dependencies.js'
+
+interface PackageJson {
+  dependencies?: Record<string, string>
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, '../package.json'), 'utf-8')
+) as PackageJson
+
+describe('CLI native runtime dependencies', () => {
+  it('keeps native bindings available as installed runtime dependencies', () => {
+    for (const dependency of CLI_NATIVE_RUNTIME_DEPENDENCIES) {
+      expect(packageJson.dependencies).toHaveProperty(dependency)
+    }
+  })
+})

--- a/packages/cli/src/native-runtime-dependencies.ts
+++ b/packages/cli/src/native-runtime-dependencies.ts
@@ -1,0 +1,5 @@
+export const CLI_NATIVE_RUNTIME_DEPENDENCIES = [
+  '@parcel/watcher',
+  '@lydell/node-pty',
+  'better-sqlite3',
+] as const

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'tsdown'
+import { CLI_NATIVE_RUNTIME_DEPENDENCIES } from './src/native-runtime-dependencies.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -20,7 +21,7 @@ export default defineConfig([
     noExternal: [/.*/],
     // Keep Node.js built-in modules and native dependencies external.
     // Native bindings must be resolved from installed runtime dependencies.
-    external: [/^node:/, '@parcel/watcher', '@lydell/node-pty', /^tsx/],
+    external: [/^node:/, ...CLI_NATIVE_RUNTIME_DEPENDENCIES, /^tsx/],
     // No minification for better debugging
     minify: false,
     // Clean output directory before build

--- a/packages/server/src/router.test.ts
+++ b/packages/server/src/router.test.ts
@@ -417,6 +417,30 @@ describe('appRouter', () => {
       const writeConfig = context.configManager.writeConfig as unknown as ReturnType<typeof vi.fn>
       expect(writeConfig).toHaveBeenCalledWith({ opsx: { agentInvocationMode: 'command' } })
     })
+
+    it('accepts document translation config updates', async () => {
+      const context = createMockContext()
+      const caller = appRouter.createCaller(context)
+
+      await caller.config.update({ translation: { enabled: true, cacheEnabled: true } })
+
+      const writeConfig = context.configManager.writeConfig as unknown as ReturnType<typeof vi.fn>
+      expect(writeConfig).toHaveBeenCalledWith({
+        translation: { enabled: true, cacheEnabled: true },
+      })
+    })
+
+    it('accepts user-level translation cache settings updates', async () => {
+      const context = createMockContext()
+      const caller = appRouter.createCaller(context)
+
+      await caller.globalSettings.update({ translationCache: { entryLimit: 12300 } })
+
+      const writeSettings = context.globalSettingsManager.writeSettings as unknown as ReturnType<
+        typeof vi.fn
+      >
+      expect(writeSettings).toHaveBeenCalledWith({ translationCache: { entryLimit: 12300 } })
+    })
   })
 
   describe('sounds', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.1
         version: 2.5.1
+      better-sqlite3:
+        specifier: ^12.5.0
+        version: 12.10.0
       semver:
         specifier: ^7.7.3
         version: 7.7.3


### PR DESCRIPTION
## Summary

- externalize `better-sqlite3` from the packaged CLI bundle through a shared native runtime dependency list
- add `better-sqlite3` as an `openspecui` runtime dependency so packaged CLI installs can resolve the native binding
- cover the native dependency rule and translation cache config/control-plane updates with tests

## Root Cause

The document translation cache worked in source-level tests, but the packaged CLI bundled `better-sqlite3` into ESM output. `better-sqlite3` has CommonJS/native binding internals that expect runtime module globals such as `__filename`, so `translationCache.stats` returned a plain 500 from the built CLI.

The platform rule is now explicit: native bindings used by the packaged CLI stay external and must also be installed runtime dependencies.

## Validation

- `corepack pnpm --filter openspecui exec tsdown`
- `corepack pnpm --filter openspecui run build`
- `corepack pnpm --filter openspecui test -- src/native-runtime-dependencies.test.ts`
- `corepack pnpm --filter @openspecui/server test -- src/router.test.ts src/translation-cache-adapter.test.ts src/translation-cache-service.test.ts src/translation-cache-router.test.ts`
- `corepack pnpm --filter @openspecui/core test -- src/global-settings.test.ts src/config.test.ts`
- `corepack pnpm --filter @openspecui/web exec vitest run --project unit src/lib/browser-translation.test.ts src/components/document-translation-action.test.tsx src/routes/settings.test.tsx --testNamePattern 'translation|cache|HAST|placeholder|settings'`
- `corepack pnpm typecheck`
- `corepack pnpm format:check`
- `corepack pnpm lint:ci`
- built CLI smoke on `http://localhost:13156`: `config.update({ translation: { enabled: true, cacheEnabled: true } })`, `translationCache.write`, `translationCache.read`, and `translationCache.stats` all returned JSON successfully

Note: the CLI build still emits the existing `scroll-button` CSS pseudo-element warning from the web build; it is unrelated to this runtime fix.
