### PR TITLE
Polish shared detail translation availability UX

### DIFF
--- a/.changeset/some-beers-brake.md
+++ b/.changeset/some-beers-brake.md
@@ -1,0 +1,8 @@
+---
+'openspecui': patch
+'@openspecui/web': patch
+---
+
+Unify the shared change and archive document detail UI, keep detail heading anchors aligned,
+normalize pnpm CLI argv separators, and tighten translation UX with unavailable-state buttons
+plus dark-mode-safe target language popovers.

--- a/packages/cli/src/argv.test.ts
+++ b/packages/cli/src/argv.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { getCliArgs } from './argv.js'
+
+describe('getCliArgs', () => {
+  it('drops pnpm separator markers before yargs parsing', () => {
+    expect(getCliArgs(['node', 'cli', '--', '--port', '3101', '--no-open'])).toEqual([
+      '--port',
+      '3101',
+      '--no-open',
+    ])
+  })
+
+  it('keeps ordinary arguments intact', () => {
+    expect(getCliArgs(['node', 'cli', 'start', '.', '--port=3200'])).toEqual([
+      'start',
+      '.',
+      '--port=3200',
+    ])
+  })
+})

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -1,0 +1,5 @@
+import { hideBin } from 'yargs/helpers'
+
+export function getCliArgs(argv: string[]): string[] {
+  return hideBin(argv).filter((arg) => arg !== '--')
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,8 +5,8 @@ import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
 import type { ExportFormat } from './export.js'
+import { getCliArgs } from './argv.js'
 import { exportStaticSite } from './export.js'
 import { buildHostedAppLaunchUrl, resolveEffectiveHostedAppBaseUrl } from './hosted-app.js'
 import { startServer } from './index.js'
@@ -39,8 +39,9 @@ function buildHostedCorsOrigins(baseUrl: string): string[] {
 
 async function main(): Promise<void> {
   const originalCwd = process.env.INIT_CWD || process.cwd()
+  const args = getCliArgs(process.argv)
 
-  await yargs(hideBin(process.argv))
+  await yargs(args)
     .scriptName('openspecui')
     .command(
       ['$0 [project-dir]', 'start [project-dir]'],

--- a/packages/web/src/components/document-translation-action.test.tsx
+++ b/packages/web/src/components/document-translation-action.test.tsx
@@ -1,3 +1,4 @@
+import type { BrowserTranslationStatus } from '@/lib/browser-translation'
 import { DOCUMENT_TRANSLATION_SESSION_STORAGE_KEY } from '@/lib/document-translation-session-state'
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -5,12 +6,15 @@ import { MarkdownViewer } from './markdown-viewer'
 
 const translateMarkdownDocumentProgressivelyMock = vi.hoisted(() => vi.fn())
 const navigateMock = vi.hoisted(() => vi.fn())
+const probeBrowserTranslationMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<BrowserTranslationStatus> => ({ availability: 'available' }))
+)
 
 vi.mock('@/lib/browser-translation', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/lib/browser-translation')>()
   return {
     ...original,
-    probeBrowserTranslation: vi.fn(async () => ({ availability: 'available' })),
+    probeBrowserTranslation: probeBrowserTranslationMock,
     translateMarkdownDocumentProgressively: translateMarkdownDocumentProgressivelyMock,
   }
 })
@@ -40,12 +44,46 @@ describe('MarkdownViewer translation plugin', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Configure translation' }))
+    const button = screen.getByRole('button', { name: 'Configure translation' })
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+    expect(button).not.toBeDisabled()
+
+    fireEvent.click(button)
 
     expect(navigateMock).toHaveBeenCalledWith({
       to: '/settings',
       hash: 'settings-translation',
     })
+  })
+
+  it('renders a disabled translation action when browser translation is unavailable', async () => {
+    probeBrowserTranslationMock.mockResolvedValueOnce({
+      availability: 'missing',
+      message: 'Chrome Translator API is not exposed.',
+    })
+
+    render(
+      <MarkdownViewer
+        markdown={'# Hello'}
+        translationConfig={{
+          enabled: true,
+          targetLanguage: 'zh',
+          displayMode: 'direct',
+          cacheEnabled: false,
+        }}
+      />
+    )
+
+    const button = await screen.findByRole('button', { name: 'Translation unavailable' })
+    await waitFor(() => expect(button).toBeDisabled())
+
+    expect(button.getAttribute('title')).toContain('Chrome Translator API is not exposed.')
+    expect(translateMarkdownDocumentProgressivelyMock).not.toHaveBeenCalled()
+
+    fireEvent.click(button)
+
+    expect(translateMarkdownDocumentProgressivelyMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it('projects direct translation as the final render stage and uses translated ToC labels', async () => {

--- a/packages/web/src/components/document-translation-action.tsx
+++ b/packages/web/src/components/document-translation-action.tsx
@@ -4,7 +4,7 @@ import { useDocumentTranslation } from '@/lib/use-document-translation'
 import type { DocumentTranslationConfig } from '@openspecui/core/document-translation'
 import { useNavigate } from '@tanstack/react-router'
 import type { Element, Properties, RootContent } from 'hast'
-import { Languages, Loader2 } from 'lucide-react'
+import { AlertTriangle, Languages, Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
 import { visit } from 'unist-util-visit'
 import {
@@ -62,6 +62,8 @@ export function useDocumentTranslationRenderPlugin({
           translationConfig?.enabled ? 'enabled' : 'disabled',
           translationConfig?.targetLanguage,
           translationConfig?.displayMode,
+          session.capability?.availability ?? 'unknown',
+          session.capability?.message ?? 'no-message',
           session.status,
           hashString(markdown),
         ].join(':')
@@ -79,9 +81,14 @@ function DocumentTranslationAction({
 }) {
   const navigate = useNavigate()
   const { setActivation } = useDocumentTranslationActivation()
+  const capabilityUnavailable =
+    session.capability?.availability === 'missing' ||
+    session.capability?.availability === 'unavailable' ||
+    session.capability?.availability === 'error'
 
   return (
     <DocumentTranslationButton
+      capability={session.capability}
       enabled={enabled}
       status={session.status}
       onActivate={() => {
@@ -90,6 +97,9 @@ function DocumentTranslationAction({
             to: '/settings',
             hash: 'settings-translation',
           })
+          return
+        }
+        if (capabilityUnavailable || session.status === 'unavailable') {
           return
         }
         if (session.status === 'translating' || session.status === 'initializing') {
@@ -329,41 +339,79 @@ function sanitizeTranslatedProperties(properties: Properties): Properties {
 }
 
 function DocumentTranslationButton({
+  capability,
   enabled,
   status,
   onActivate,
 }: {
+  capability: ReturnType<typeof useDocumentTranslation>['capability']
   enabled: boolean
   status: ReturnType<typeof useDocumentTranslation>['status']
   onActivate: () => void
 }) {
+  const isCapabilityUnavailable =
+    capability?.availability === 'missing' ||
+    capability?.availability === 'unavailable' ||
+    capability?.availability === 'error' ||
+    status === 'unavailable'
+  const isSettingsDisabled = !enabled
   const isTranslated = status === 'translated'
   const isBusy = status === 'initializing' || status === 'translating'
-  const title = !enabled
-    ? 'Configure translation'
-    : isBusy
-      ? 'Cancel translation'
-      : isTranslated
-        ? 'Show source'
-        : 'Translate'
+  const ariaLabel = isCapabilityUnavailable
+    ? 'Translation unavailable'
+    : isSettingsDisabled
+      ? 'Configure translation'
+      : isBusy
+        ? 'Cancel translation'
+        : isTranslated
+          ? 'Show source'
+          : 'Translate'
+  const title = isCapabilityUnavailable
+    ? (capability?.message ?? 'Translation is unavailable in this browser.')
+    : isSettingsDisabled
+      ? 'Translation is disabled in settings.'
+      : ariaLabel
 
   return (
     <Button
       size="icon-sm"
       variant="secondary"
+      disabled={isCapabilityUnavailable}
+      aria-disabled={isSettingsDisabled ? true : undefined}
       onClick={(event) => {
         event.stopPropagation()
         onActivate()
       }}
       title={title}
-      aria-label={title}
+      aria-label={ariaLabel}
+      data-translation-action-state={
+        isCapabilityUnavailable
+          ? 'unavailable'
+          : isSettingsDisabled
+            ? 'settings-disabled'
+            : isBusy
+              ? 'busy'
+              : isTranslated
+                ? 'translated'
+                : 'ready'
+      }
       className={
-        isTranslated
-          ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
-          : 'border-primary text-primary hover:bg-primary/10'
+        isCapabilityUnavailable
+          ? 'border-border bg-muted text-muted-foreground disabled:border-border disabled:bg-muted disabled:text-muted-foreground'
+          : isSettingsDisabled
+            ? 'border-border bg-muted/40 text-muted-foreground opacity-70'
+            : isTranslated
+              ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'border-primary text-primary hover:bg-primary/10'
       }
     >
-      {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Languages className="h-4 w-4" />}
+      {isBusy ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : isCapabilityUnavailable ? (
+        <AlertTriangle className="h-4 w-4" />
+      ) : (
+        <Languages className="h-4 w-4" />
+      )}
     </Button>
   )
 }

--- a/packages/web/src/components/markdown-viewer.test.tsx
+++ b/packages/web/src/components/markdown-viewer.test.tsx
@@ -147,9 +147,9 @@ describe('MarkdownViewer ToC behavior', () => {
       .join('\n')
     expect(styles).toContain('.toc-page-layout > .toc-page-content')
     expect(styles).toContain('padding-top: var(--toc-narrow-gap, 1rem)')
-    expect(styles).toContain('top: var(--toc-sticky-top, 1rem)')
+    expect(styles).toContain('top: var(--toc-sticky-top, 0)')
     expect(styles).toContain(
-      '--toc-anchor-scroll-margin-top: calc(var(--toc-sticky-top, 1rem) + 3rem)'
+      '--toc-anchor-scroll-margin-top: calc(var(--toc-sticky-top, 0) + 3rem)'
     )
     expect(styles).toContain('scroll-margin-top: var(--toc-anchor-scroll-margin-top)')
     expect(styles).toContain('.toc-narrow')

--- a/packages/web/src/components/opsx/artifact-document-shell.tsx
+++ b/packages/web/src/components/opsx/artifact-document-shell.tsx
@@ -1,0 +1,71 @@
+import type { ArtifactStatus } from '@openspecui/core'
+import { AlertTriangle, CheckCircle2, Circle } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+const statusConfig: Record<
+  ArtifactStatus['status'],
+  { label: string; className: string; icon: typeof Circle }
+> = {
+  done: { label: 'Done', className: 'text-emerald-500', icon: CheckCircle2 },
+  ready: { label: 'Ready', className: 'text-sky-500', icon: Circle },
+  blocked: { label: 'Blocked', className: 'text-amber-500', icon: AlertTriangle },
+}
+
+export function OpsxArtifactStatusBadge({ status }: { status: ArtifactStatus['status'] }) {
+  const config = statusConfig[status]
+  const StatusIcon = config.icon
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1.5 text-xs font-medium ${config.className}`}
+    >
+      <StatusIcon className="h-4 w-4" />
+      {config.label}
+    </span>
+  )
+}
+
+export function OpsxArtifactTabStatusIcon({ status }: { status: ArtifactStatus['status'] }) {
+  const StatusIcon = statusConfig[status].icon
+  return <StatusIcon className={`h-3.5 w-3.5 ${statusConfig[status].className}`} />
+}
+
+export function OpsxArtifactDocumentShell({
+  id,
+  path,
+  status,
+  missingDeps,
+  meta,
+  children,
+}: {
+  id: string
+  path?: string
+  status?: ArtifactStatus['status']
+  missingDeps?: readonly string[]
+  meta?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <>
+      <section className="border-border bg-muted/25 mb-5 rounded-md border px-4 py-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="font-medium">{id}</div>
+            {path ? <div className="text-muted-foreground break-all text-xs">{path}</div> : null}
+          </div>
+          {status ? <OpsxArtifactStatusBadge status={status} /> : meta}
+        </div>
+        {status === 'blocked' && missingDeps?.length ? (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs text-amber-700">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <div>
+              <div className="font-medium">Blocked by missing dependencies</div>
+              <div className="mt-1">{missingDeps.join(', ')}</div>
+            </div>
+          </div>
+        ) : null}
+      </section>
+      {children}
+    </>
+  )
+}

--- a/packages/web/src/components/opsx/artifact-output-viewer.test.tsx
+++ b/packages/web/src/components/opsx/artifact-output-viewer.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ArtifactOutputViewer } from './artifact-output-viewer'
+import { ArtifactOutputViewer, ContentFallbackViewer } from './artifact-output-viewer'
 
 const artifactOutputMock = vi.hoisted(() => vi.fn())
 const globArtifactFilesMock = vi.hoisted(() => vi.fn())
@@ -11,7 +11,16 @@ vi.mock('@/lib/use-opsx', () => ({
 }))
 
 vi.mock('@/lib/use-subscription', () => ({
-  useConfigSubscription: () => ({ data: { translation: { enabled: false } } }),
+  useConfigSubscription: () => ({
+    data: {
+      translation: {
+        enabled: false,
+        targetLanguage: 'zh',
+        displayMode: 'direct',
+        cacheEnabled: false,
+      },
+    },
+  }),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -48,6 +57,71 @@ describe('ArtifactOutputViewer', () => {
     expect(within(content as HTMLElement).getByText('tasks')).toBeTruthy()
     expect(within(content as HTMLElement).getByText('tasks.md')).toBeTruthy()
     expect(artifactOutputMock).toHaveBeenCalledWith('add-auth', 'tasks.md')
+  })
+
+  it('renders archived artifact files without subscribing to live artifact output', () => {
+    render(
+      <ArtifactOutputViewer
+        changeId="2026-05-17-add-auth"
+        artifact={{
+          id: 'summary',
+          outputPath: 'reports/summary.md',
+          files: [
+            {
+              path: 'reports/summary.md',
+              type: 'file',
+              content: '# Archived Summary\n\nThe archived artifact is already materialized.',
+            },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Archived Summary' })).toBeTruthy()
+    expect(screen.getByText(/already materialized/)).toBeTruthy()
+    expect(screen.getByText('summary')).toBeTruthy()
+    expect(screen.getByText('reports/summary.md')).toBeTruthy()
+    expect(screen.getByText('1 file')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Configure translation' })).toBeTruthy()
+    const content = document.querySelector('.toc-page-content')
+    expect(content).toBeTruthy()
+    expect(
+      within(content as HTMLElement).getByRole('heading', { name: 'Archived Summary' })
+    ).toBeTruthy()
+    expect(artifactOutputMock).not.toHaveBeenCalled()
+    expect(globArtifactFilesMock).not.toHaveBeenCalled()
+  })
+
+  it('renders content fallback through the same root document viewer contract', () => {
+    render(
+      <ContentFallbackViewer
+        fallback={{
+          id: 'content',
+          label: 'Content',
+          outputPath: 'openspec/changes/archive/**/*.md',
+          relativePath: 'archive/2026-05-17-add-auth',
+          files: [
+            {
+              path: 'notes/decision.md',
+              type: 'file',
+              content: '# Decision\n\nKeep the shared shell.',
+            },
+          ],
+          emptyMessage: 'No Markdown files found.',
+        }}
+      />
+    )
+
+    const content = document.querySelector('.toc-page-content')
+    expect(content).toBeTruthy()
+    expect(within(content as HTMLElement).getByText('content')).toBeTruthy()
+    expect(
+      within(content as HTMLElement).getByText('archive/2026-05-17-add-auth')
+    ).toBeTruthy()
+    expect(within(content as HTMLElement).getByRole('heading', { name: 'Decision' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Configure translation' })).toBeTruthy()
+    expect(document.querySelectorAll('aside.toc-root')).toHaveLength(1)
+    expect(document.querySelectorAll('.viewer-scroll')).toHaveLength(1)
   })
 
   it('renders change delta spec glob artifacts with the spec document renderer', () => {

--- a/packages/web/src/components/opsx/artifact-output-viewer.tsx
+++ b/packages/web/src/components/opsx/artifact-output-viewer.tsx
@@ -4,74 +4,124 @@ import {
   useOpsxGlobArtifactFilesSubscription,
 } from '@/lib/use-opsx'
 import { useConfigSubscription } from '@/lib/use-subscription'
-import type { ArtifactStatus } from '@openspecui/core'
+import type { ArtifactStatus, OpsxEntityArtifactFile, OpsxEntityFile } from '@openspecui/core'
 import type { DocumentTranslationConfig } from '@openspecui/core/document-translation'
-import { AlertTriangle, CheckCircle2, Circle, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { OpsxArtifactDocumentShell } from './artifact-document-shell'
+import { MarkdownFilesContent, fileCountLabel } from './opsx-markdown-files-viewer'
 
 function isGlobPattern(pattern: string): boolean {
   return pattern.includes('*') || pattern.includes('?') || pattern.includes('[')
 }
 
+export interface ArtifactOutputDescriptor {
+  id: string
+  outputPath: string
+  status?: ArtifactStatus['status']
+  missingDeps?: readonly string[]
+  relativePath?: string
+  files?: readonly OpsxEntityArtifactFile[]
+}
+
+export interface DocumentContentFallbackDescriptor {
+  id?: string
+  label?: string
+  outputPath?: string
+  relativePath?: string
+  files: readonly OpsxEntityFile[]
+  emptyMessage: string
+}
+
 interface Props {
   changeId: string
-  artifact: ArtifactStatus
+  artifact: ArtifactOutputDescriptor
 }
 
-const statusConfig: Record<
-  ArtifactStatus['status'],
-  { label: string; className: string; icon: typeof Circle }
-> = {
-  done: { label: 'Done', className: 'text-emerald-500', icon: CheckCircle2 },
-  ready: { label: 'Ready', className: 'text-sky-500', icon: Circle },
-  blocked: { label: 'Blocked', className: 'text-amber-500', icon: AlertTriangle },
-}
-
-function ArtifactDocumentHeader({ artifact }: { artifact: ArtifactStatus }) {
-  const status = statusConfig[artifact.status]
-  const StatusIcon = status.icon
-
-  return (
-    <section className="border-border bg-muted/25 mb-5 rounded-md border px-4 py-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 space-y-1">
-          <div className="font-medium">{artifact.id}</div>
-          <div className="text-muted-foreground break-all text-xs">
-            {artifact.relativePath ?? artifact.outputPath}
-          </div>
-        </div>
-        <span
-          className={`inline-flex shrink-0 items-center gap-1.5 text-xs font-medium ${status.className}`}
-        >
-          <StatusIcon className="h-4 w-4" />
-          {status.label}
-        </span>
-      </div>
-      {artifact.status === 'blocked' && artifact.missingDeps?.length ? (
-        <div className="mt-3 flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-xs text-amber-700">
-          <AlertTriangle className="h-4 w-4 shrink-0" />
-          <div>
-            <div className="font-medium">Blocked by missing dependencies</div>
-            <div className="mt-1">{artifact.missingDeps.join(', ')}</div>
-          </div>
-        </div>
-      ) : null}
-    </section>
-  )
-}
-
-function ArtifactDocumentShell({
+function ArtifactOutputDocumentShell({
   artifact,
   children,
 }: {
-  artifact: ArtifactStatus
+  artifact: ArtifactOutputDescriptor
   children: ReactNode
 }) {
   return (
-    <>
-      <ArtifactDocumentHeader artifact={artifact} />
+    <OpsxArtifactDocumentShell
+      id={artifact.id}
+      path={artifact.relativePath ?? artifact.outputPath}
+      status={artifact.status}
+      missingDeps={artifact.missingDeps}
+    >
       {children}
-    </>
+    </OpsxArtifactDocumentShell>
+  )
+}
+
+function ArtifactFilesDocumentShell({
+  artifact,
+  files,
+  translationConfig,
+}: {
+  artifact: Props['artifact']
+  files: readonly OpsxEntityArtifactFile[]
+  translationConfig?: DocumentTranslationConfig
+}) {
+  return (
+    <MarkdownViewer
+      markdown={(components) => (
+        <OpsxArtifactDocumentShell
+          id={artifact.id}
+          path={artifact.relativePath ?? artifact.outputPath}
+          meta={
+            <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1.5 text-xs font-medium">
+              {fileCountLabel(files)}
+            </span>
+          }
+        >
+          <MarkdownFilesContent
+            components={components}
+            files={files}
+            emptyMessage="No Markdown files matched this artifact."
+            translationConfig={translationConfig}
+          />
+        </OpsxArtifactDocumentShell>
+      )}
+      path={artifact.relativePath ?? artifact.outputPath}
+      translationConfig={translationConfig}
+    />
+  )
+}
+
+function FallbackDocumentShell({
+  fallback,
+  translationConfig,
+}: {
+  fallback: DocumentContentFallbackDescriptor
+  translationConfig?: DocumentTranslationConfig
+}) {
+  return (
+    <MarkdownViewer
+      markdown={(components) => (
+        <OpsxArtifactDocumentShell
+          id={fallback.id ?? fallback.label ?? 'Content'}
+          path={fallback.relativePath ?? fallback.outputPath}
+          meta={
+            <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1.5 text-xs font-medium">
+              {fileCountLabel(fallback.files)}
+            </span>
+          }
+        >
+          <MarkdownFilesContent
+            components={components}
+            files={fallback.files}
+            emptyMessage={fallback.emptyMessage}
+            translationConfig={translationConfig}
+          />
+        </OpsxArtifactDocumentShell>
+      )}
+      path={fallback.relativePath ?? fallback.outputPath}
+      translationConfig={translationConfig}
+    />
   )
 }
 
@@ -97,13 +147,13 @@ function SingleFileContent({
     return (
       <MarkdownViewer
         markdown={() => (
-          <ArtifactDocumentShell artifact={artifact}>
+          <ArtifactOutputDocumentShell artifact={artifact}>
             <MarkdownViewer
               markdown={content}
               path={artifact.outputPath}
               translationConfig={translationConfig}
             />
-          </ArtifactDocumentShell>
+          </ArtifactOutputDocumentShell>
         )}
         path={artifact.outputPath}
         translationConfig={translationConfig}
@@ -149,7 +199,7 @@ function GlobContent({
   return (
     <MarkdownViewer
       markdown={({ H1, Section }) => (
-        <ArtifactDocumentShell artifact={artifact}>
+        <ArtifactOutputDocumentShell artifact={artifact}>
           <div className="space-y-6">
             {files.map((file) => (
               <Section key={file.path}>
@@ -164,30 +214,75 @@ function GlobContent({
               </Section>
             ))}
           </div>
-        </ArtifactDocumentShell>
+        </ArtifactOutputDocumentShell>
       )}
     />
   )
 }
 
 export function ArtifactOutputViewer({ changeId, artifact }: Props) {
-  const isGlob = isGlobPattern(artifact.outputPath)
+  const { data: config } = useConfigSubscription()
+
+  if (artifact.files) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1">
+          <ArtifactFilesDocumentShell
+            artifact={artifact}
+            files={artifact.files}
+            translationConfig={config?.translation}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <LiveArtifactOutputViewer
+      changeId={changeId}
+      artifact={artifact}
+      translationConfig={config?.translation}
+    />
+  )
+}
+
+export function ContentFallbackViewer({
+  fallback,
+}: {
+  fallback: DocumentContentFallbackDescriptor
+}) {
   const { data: config } = useConfigSubscription()
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col py-4">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1">
+        <FallbackDocumentShell fallback={fallback} translationConfig={config?.translation} />
+      </div>
+    </div>
+  )
+}
+
+function LiveArtifactOutputViewer({
+  changeId,
+  artifact,
+  translationConfig,
+}: Props & { translationConfig?: DocumentTranslationConfig }) {
+  const isGlob = isGlobPattern(artifact.outputPath)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="min-h-0 flex-1">
         {isGlob ? (
           <GlobContent
             changeId={changeId}
             artifact={artifact}
-            translationConfig={config?.translation}
+            translationConfig={translationConfig}
           />
         ) : (
           <SingleFileContent
             changeId={changeId}
             artifact={artifact}
-            translationConfig={config?.translation}
+            translationConfig={translationConfig}
           />
         )}
       </div>

--- a/packages/web/src/components/opsx/opsx-detail-layout.tsx
+++ b/packages/web/src/components/opsx/opsx-detail-layout.tsx
@@ -1,0 +1,182 @@
+import { Tabs, type Tab } from '@/components/tabs'
+import { cn } from '@/lib/utils'
+import { VTLink, type VTLinkProps } from '@/lib/view-transitions/navigation'
+import {
+  getSharedElementBinding,
+  type SharedElementDescriptor,
+  type SharedElementHandoff,
+} from '@/lib/view-transitions/shared-elements'
+import type { OpsxEntityDiagnostic } from '@openspecui/core'
+import type { LucideIcon } from 'lucide-react'
+import { AlertTriangle, ArrowLeft } from 'lucide-react'
+import type { ReactNode, RefObject } from 'react'
+import type { TabsHandle } from '../tabs'
+
+interface OpsxDetailHeaderProps {
+  backTo: VTLinkProps['to']
+  backTitle: string
+  headerRef: RefObject<HTMLDivElement | null>
+  sharedDescriptor: SharedElementDescriptor
+  icon: LucideIcon
+  title: ReactNode
+  subtitle: ReactNode
+  toolbar?: ReactNode
+}
+
+interface OpsxDetailPageProps extends OpsxDetailHeaderProps {
+  diagnostics?: readonly OpsxEntityDiagnostic[]
+  children: ReactNode
+}
+
+interface OpsxDetailLoadingPageProps
+  extends Omit<OpsxDetailHeaderProps, 'title' | 'subtitle' | 'toolbar'> {
+  handoff: SharedElementHandoff | null
+  fallbackTitle: string
+  fallbackSubtitle: string
+  loadingMessage: string
+}
+
+interface OpsxDetailStatePanelProps {
+  message: ReactNode
+  tone?: 'default' | 'destructive'
+}
+
+interface OpsxDetailTabsProps {
+  tabsRef: RefObject<TabsHandle | null>
+  tabs: Tab[]
+  selectedTab?: string
+  onTabChange: (id: string) => void
+  className?: string
+}
+
+function OpsxDetailHeader({
+  backTo,
+  backTitle,
+  headerRef,
+  sharedDescriptor,
+  icon: Icon,
+  title,
+  subtitle,
+  toolbar,
+}: OpsxDetailHeaderProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex min-w-0 items-center gap-4">
+        <VTLink
+          to={backTo}
+          vt={{ source: headerRef, sharedElements: sharedDescriptor }}
+          className="hover:bg-muted rounded-md p-2 transition-colors"
+          title={backTitle}
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </VTLink>
+        <div
+          ref={headerRef}
+          {...getSharedElementBinding(sharedDescriptor, 'container')}
+          className="flex min-w-0 flex-col gap-1"
+        >
+          <h1 className="font-nav flex min-w-0 items-center gap-2 text-2xl font-bold">
+            <Icon
+              {...getSharedElementBinding(sharedDescriptor, 'icon')}
+              className="h-6 w-6 shrink-0"
+            />
+            <span {...getSharedElementBinding(sharedDescriptor, 'title')} className="truncate">
+              {title}
+            </span>
+          </h1>
+          <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
+        </div>
+      </div>
+      {toolbar}
+    </div>
+  )
+}
+
+export function OpsxDetailPage({ diagnostics, children, ...headerProps }: OpsxDetailPageProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+      <OpsxDetailHeader {...headerProps} />
+      <OpsxDetailDiagnostics diagnostics={diagnostics ?? []} />
+      {children}
+    </div>
+  )
+}
+
+export function OpsxDetailLoadingPage({
+  handoff,
+  fallbackTitle,
+  fallbackSubtitle,
+  loadingMessage,
+  ...headerProps
+}: OpsxDetailLoadingPageProps) {
+  return (
+    <OpsxDetailPage
+      {...headerProps}
+      title={handoff?.title ?? fallbackTitle}
+      subtitle={handoff?.subtitle ?? fallbackSubtitle}
+    >
+      <OpsxDetailStatePanel message={loadingMessage} />
+    </OpsxDetailPage>
+  )
+}
+
+export function OpsxDetailTabs({
+  tabsRef,
+  tabs,
+  selectedTab,
+  onTabChange,
+  className,
+}: OpsxDetailTabsProps) {
+  return (
+    <div className="vt-detail-content flex min-h-0 flex-1 flex-col">
+      <Tabs
+        ref={tabsRef}
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onTabChange={onTabChange}
+        className={cn('min-h-0 flex-1', className)}
+      />
+    </div>
+  )
+}
+
+export function OpsxDetailDiagnostics({
+  diagnostics,
+}: {
+  diagnostics: readonly OpsxEntityDiagnostic[]
+}) {
+  if (diagnostics.length === 0) return null
+
+  return (
+    <div className="border-border bg-muted/20 flex flex-col gap-2 rounded-md border p-3 text-sm">
+      {diagnostics.map((diagnostic, index) => (
+        <div key={`${diagnostic.message}-${index}`} className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <div>
+            <div className="font-medium capitalize">{diagnostic.level}</div>
+            <div className="text-muted-foreground">
+              {diagnostic.path ? `${diagnostic.path}: ` : ''}
+              {diagnostic.message}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function OpsxDetailStatePanel({
+  message,
+  tone = 'default',
+}: OpsxDetailStatePanelProps) {
+  return (
+    <div
+      className={cn(
+        'vt-detail-content flex min-h-[240px] flex-1 items-center justify-center rounded-lg border border-dashed p-6 text-sm',
+        tone === 'destructive' ? 'text-destructive border-destructive/40' : 'text-muted-foreground'
+      )}
+    >
+      {message}
+    </div>
+  )
+}

--- a/packages/web/src/components/opsx/opsx-entity-detail-tabs.tsx
+++ b/packages/web/src/components/opsx/opsx-entity-detail-tabs.tsx
@@ -1,0 +1,90 @@
+import { FolderEditorViewer } from '@/components/folder-editor-viewer'
+import type { Tab } from '@/components/tabs'
+import type { OpsxEntityFile } from '@openspecui/core'
+import { FileText, FolderTree } from 'lucide-react'
+import { OpsxArtifactTabStatusIcon } from './artifact-document-shell'
+import {
+  ArtifactOutputViewer,
+  ContentFallbackViewer,
+  type ArtifactOutputDescriptor,
+} from './artifact-output-viewer'
+
+export interface OpsxEntityDetailFolder {
+  changeId: string
+  archived?: boolean
+  files?: OpsxEntityFile[]
+}
+
+export interface OpsxEntityDetailContentFallback {
+  id?: string
+  label?: string
+  outputPath?: string
+  relativePath?: string
+  files: readonly OpsxEntityFile[]
+  emptyMessage: string
+}
+
+function createArtifactTab(
+  folder: OpsxEntityDetailFolder,
+  artifact: ArtifactOutputDescriptor
+): Tab {
+  return {
+    id: artifact.files ? `artifact:${artifact.id}` : artifact.id,
+    label: artifact.id,
+    icon: artifact.status ? (
+      <OpsxArtifactTabStatusIcon status={artifact.status} />
+    ) : (
+      <FileText className="h-4 w-4" />
+    ),
+    content: <ArtifactOutputViewer changeId={folder.changeId} artifact={artifact} />,
+  }
+}
+
+function createContentFallbackTab(contentFallback: OpsxEntityDetailContentFallback): Tab {
+  return {
+    id: 'content',
+    label: contentFallback.label ?? 'Content',
+    icon: <FileText className="h-4 w-4" />,
+    content: <ContentFallbackViewer fallback={contentFallback} />,
+  }
+}
+
+function createFolderTab(folder: OpsxEntityDetailFolder): Tab {
+  return {
+    id: 'folder',
+    label: 'Folder',
+    icon: <FolderTree className="h-4 w-4" />,
+    content: (
+      <FolderEditorViewer
+        changeId={folder.changeId}
+        archived={folder.archived}
+        files={folder.files}
+      />
+    ),
+  }
+}
+
+export function buildOpsxEntityDetailTabs({
+  artifacts,
+  hideEmptyArtifacts,
+  contentFallback,
+  folder,
+}: {
+  artifacts: readonly ArtifactOutputDescriptor[]
+  hideEmptyArtifacts: boolean
+  contentFallback?: OpsxEntityDetailContentFallback
+  folder: OpsxEntityDetailFolder
+}): Tab[] {
+  const visibleArtifacts = hideEmptyArtifacts
+    ? artifacts.filter((artifact) => (artifact.files?.length ?? 0) > 0)
+    : artifacts
+
+  const primaryTabs =
+    visibleArtifacts.length > 0
+      ? visibleArtifacts.map((artifact) => createArtifactTab(folder, artifact))
+      : contentFallback
+        ? [createContentFallbackTab(contentFallback)]
+        : []
+
+  return [...primaryTabs, createFolderTab(folder)]
+}

--- a/packages/web/src/components/opsx/opsx-entity-detail-view.tsx
+++ b/packages/web/src/components/opsx/opsx-entity-detail-view.tsx
@@ -1,0 +1,231 @@
+import type { VTLinkProps } from '@/lib/view-transitions/navigation'
+import type { SharedElementHandoff } from '@/lib/view-transitions/shared-elements'
+import { useRoutedCarouselTabs } from '@/lib/view-transitions/tabs'
+import type { OpsxEntityDiagnostic } from '@openspecui/core'
+import type { LucideIcon } from 'lucide-react'
+import { AlertCircle } from 'lucide-react'
+import { useMemo, useRef, type ReactNode, type RefObject } from 'react'
+import type { ArtifactOutputDescriptor } from './artifact-output-viewer'
+import {
+  OpsxDetailLoadingPage,
+  OpsxDetailPage,
+  OpsxDetailStatePanel,
+  OpsxDetailTabs,
+} from './opsx-detail-layout'
+import {
+  buildOpsxEntityDetailTabs,
+  type OpsxEntityDetailContentFallback,
+  type OpsxEntityDetailFolder,
+} from './opsx-entity-detail-tabs'
+
+interface OpsxEntityDetailViewProps {
+  entityId: string
+  sharedFamily: string
+  backTo: VTLinkProps['to']
+  backTitle: string
+  icon: LucideIcon
+  title?: ReactNode
+  subtitle?: ReactNode
+  toolbar?: ReactNode
+  diagnostics?: readonly OpsxEntityDiagnostic[]
+  handoff: SharedElementHandoff | null
+  isLoading: boolean
+  loadingMessage: string
+  errorMessage?: string
+  notFoundMessage?: string
+  notFoundBackLabel?: string
+  artifacts?: readonly ArtifactOutputDescriptor[]
+  hideEmptyArtifacts?: boolean
+  contentFallback?: OpsxEntityDetailContentFallback
+  folder: OpsxEntityDetailFolder
+  tabsQueryKey: string
+  initialTab?: string
+}
+
+type OpsxEntityDetailReadyProps = Pick<
+  OpsxEntityDetailViewProps,
+  | 'artifacts'
+  | 'hideEmptyArtifacts'
+  | 'contentFallback'
+  | 'folder'
+  | 'tabsQueryKey'
+  | 'initialTab'
+  | 'backTo'
+  | 'backTitle'
+  | 'icon'
+  | 'title'
+  | 'subtitle'
+  | 'toolbar'
+  | 'diagnostics'
+  | 'entityId'
+> & {
+  headerRef: RefObject<HTMLDivElement | null>
+  sharedDescriptor: { family: string; entityId: string }
+}
+
+function OpsxEntityDetailReadyView({
+  artifacts = [],
+  hideEmptyArtifacts = false,
+  contentFallback,
+  folder,
+  tabsQueryKey,
+  initialTab,
+  backTo,
+  backTitle,
+  icon,
+  title,
+  subtitle,
+  toolbar,
+  diagnostics,
+  entityId,
+  headerRef,
+  sharedDescriptor,
+}: OpsxEntityDetailReadyProps) {
+  const tabs = useMemo(
+    () =>
+      buildOpsxEntityDetailTabs({
+        artifacts,
+        hideEmptyArtifacts,
+        contentFallback,
+        folder,
+      }),
+    [artifacts, contentFallback, folder, hideEmptyArtifacts]
+  )
+
+  const { tabsRef, selectedTab, onTabChange } = useRoutedCarouselTabs({
+    queryKey: tabsQueryKey,
+    tabs,
+    initialTab: initialTab ?? tabs[0]?.id,
+  })
+
+  return (
+    <OpsxDetailPage
+      backTo={backTo}
+      backTitle={backTitle}
+      headerRef={headerRef}
+      sharedDescriptor={sharedDescriptor}
+      icon={icon}
+      title={title ?? entityId}
+      subtitle={subtitle ?? entityId}
+      toolbar={toolbar}
+      diagnostics={diagnostics}
+    >
+      <OpsxDetailTabs
+        tabsRef={tabsRef}
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onTabChange={onTabChange}
+      />
+    </OpsxDetailPage>
+  )
+}
+
+export function OpsxEntityDetailView({
+  entityId,
+  sharedFamily,
+  backTo,
+  backTitle,
+  icon,
+  title,
+  subtitle,
+  toolbar,
+  diagnostics,
+  handoff,
+  isLoading,
+  loadingMessage,
+  errorMessage,
+  notFoundMessage,
+  artifacts,
+  hideEmptyArtifacts,
+  contentFallback,
+  folder,
+  tabsQueryKey,
+  initialTab,
+}: OpsxEntityDetailViewProps) {
+  const headerRef = useRef<HTMLDivElement | null>(null)
+  const sharedDescriptor = useMemo(
+    () => ({ family: sharedFamily, entityId }) as const,
+    [entityId, sharedFamily]
+  )
+
+  if (isLoading) {
+    return (
+      <OpsxDetailLoadingPage
+        backTo={backTo}
+        backTitle={backTitle}
+        headerRef={headerRef}
+        sharedDescriptor={sharedDescriptor}
+        icon={icon}
+        handoff={handoff}
+        fallbackTitle={entityId}
+        fallbackSubtitle={entityId}
+        loadingMessage={loadingMessage}
+      />
+    )
+  }
+
+  if (notFoundMessage) {
+    return (
+      <OpsxDetailPage
+        backTo={backTo}
+        backTitle={backTitle}
+        headerRef={headerRef}
+        sharedDescriptor={sharedDescriptor}
+        icon={icon}
+        title={title ?? entityId}
+        subtitle={subtitle ?? entityId}
+        toolbar={toolbar}
+        diagnostics={diagnostics}
+      >
+        <OpsxDetailStatePanel message={notFoundMessage} />
+      </OpsxDetailPage>
+    )
+  }
+
+  if (errorMessage) {
+    return (
+      <OpsxDetailPage
+        backTo={backTo}
+        backTitle={backTitle}
+        headerRef={headerRef}
+        sharedDescriptor={sharedDescriptor}
+        icon={icon}
+        title={title ?? entityId}
+        subtitle={subtitle ?? entityId}
+        toolbar={toolbar}
+        diagnostics={diagnostics}
+      >
+        <OpsxDetailStatePanel
+          tone="destructive"
+          message={
+            <span className="flex items-center gap-2">
+              <AlertCircle className="h-5 w-5" />
+              {errorMessage}
+            </span>
+          }
+        />
+      </OpsxDetailPage>
+    )
+  }
+
+  return (
+    <OpsxEntityDetailReadyView
+      entityId={entityId}
+      backTo={backTo}
+      backTitle={backTitle}
+      icon={icon}
+      title={title}
+      subtitle={subtitle}
+      toolbar={toolbar}
+      diagnostics={diagnostics}
+      headerRef={headerRef}
+      sharedDescriptor={sharedDescriptor}
+      artifacts={artifacts}
+      hideEmptyArtifacts={hideEmptyArtifacts}
+      contentFallback={contentFallback}
+      folder={folder}
+      tabsQueryKey={tabsQueryKey}
+      initialTab={initialTab}
+    />
+  )
+}

--- a/packages/web/src/components/opsx/opsx-markdown-files-viewer.tsx
+++ b/packages/web/src/components/opsx/opsx-markdown-files-viewer.tsx
@@ -1,0 +1,95 @@
+import { MarkdownViewer } from '@/components/markdown-viewer'
+import type { OpsxEntityFile } from '@openspecui/core'
+import type { DocumentTranslationConfig } from '@openspecui/core/document-translation'
+import type { ReactNode } from 'react'
+
+interface MarkdownBuilderComponents {
+  H1: (props: { children?: ReactNode }) => ReactNode
+  Section: (props: { children?: ReactNode }) => ReactNode
+}
+
+function getMarkdownFiles(files: readonly OpsxEntityFile[]) {
+  return files.filter(
+    (file) => file.type === 'file' && file.content !== undefined && file.path.endsWith('.md')
+  )
+}
+
+export function fileCountLabel(files: readonly OpsxEntityFile[]): string {
+  const count = files.filter((file) => file.type === 'file').length
+  return `${count} ${count === 1 ? 'file' : 'files'}`
+}
+
+export function MarkdownFilesContent({
+  components,
+  files,
+  emptyMessage,
+  translationConfig,
+}: {
+  components: MarkdownBuilderComponents
+  files: readonly OpsxEntityFile[]
+  emptyMessage: string
+  translationConfig?: DocumentTranslationConfig
+}) {
+  const markdownFiles = getMarkdownFiles(files)
+
+  if (markdownFiles.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center rounded-md border border-dashed p-6 text-sm">
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  if (markdownFiles.length === 1) {
+    const file = markdownFiles[0]!
+    return (
+      <MarkdownViewer
+        markdown={file.content ?? ''}
+        path={file.path}
+        translationConfig={translationConfig}
+      />
+    )
+  }
+
+  const { H1, Section } = components
+
+  return (
+    <div className="space-y-6">
+      {markdownFiles.map((file) => (
+        <Section key={file.path}>
+          <H1>{file.path}</H1>
+          <div className="border-border bg-muted/30 mt-2 rounded-lg border p-4 [zoom:0.86]">
+            <MarkdownViewer
+              markdown={file.content ?? ''}
+              path={file.path}
+              translationConfig={translationConfig}
+            />
+          </div>
+        </Section>
+      ))}
+    </div>
+  )
+}
+
+export function MarkdownFilesViewer({
+  files,
+  emptyMessage,
+  translationConfig,
+}: {
+  files: readonly OpsxEntityFile[]
+  emptyMessage: string
+  translationConfig?: DocumentTranslationConfig
+}) {
+  return (
+    <MarkdownViewer
+      markdown={(components) => (
+        <MarkdownFilesContent
+          components={components}
+          files={files}
+          emptyMessage={emptyMessage}
+          translationConfig={translationConfig}
+        />
+      )}
+    />
+  )
+}

--- a/packages/web/src/components/toc.tsx
+++ b/packages/web/src/components/toc.tsx
@@ -287,7 +287,7 @@ const css = String.raw
 /** CSS for container queries and scroll-driven ToC highlighting */
 const tocStyles = css`
   .toc-root {
-    top: var(--toc-sticky-top, 1rem);
+    top: var(--toc-sticky-top, 0);
   }
   /*
    * Best practice: route headers live before toc-page-layout; narrow ToC is
@@ -296,7 +296,7 @@ const tocStyles = css`
    * shared visual gap that sticky margins cannot guarantee in scroll containers.
    */
   .toc-page-layout {
-    --toc-anchor-scroll-margin-top: calc(var(--toc-sticky-top, 1rem) + 3rem);
+    --toc-anchor-scroll-margin-top: calc(var(--toc-sticky-top, 0) + 3rem);
   }
   .toc-page-layout > .toc-page-content {
     padding-top: var(--toc-narrow-gap, 1rem);
@@ -324,7 +324,7 @@ const tocStyles = css`
   /* Wide container: show sidebar mode */
   @container (min-width: 768px) {
     .toc-page-layout {
-      --toc-anchor-scroll-margin-top: var(--toc-sticky-top, 1rem);
+      --toc-anchor-scroll-margin-top: var(--toc-sticky-top, 0);
     }
     .toc-narrow {
       display: none;

--- a/packages/web/src/lib/use-document-translation.ts
+++ b/packages/web/src/lib/use-document-translation.ts
@@ -29,6 +29,14 @@ export interface DocumentTranslationSession {
   reset: () => void
 }
 
+function isUnavailableCapability(capability: BrowserTranslationStatus | null): boolean {
+  return (
+    capability?.availability === 'missing' ||
+    capability?.availability === 'unavailable' ||
+    capability?.availability === 'error'
+  )
+}
+
 export function useDocumentTranslation(
   markdown: string,
   config: DocumentTranslationConfig | undefined
@@ -60,10 +68,42 @@ export function useDocumentTranslation(
   useEffect(() => reset, [reset])
 
   useEffect(() => {
+    setCapability(null)
     setResult(null)
     setStatus('source')
     setError(null)
-  }, [markdown, config?.targetLanguage, config?.displayMode])
+  }, [markdown, config?.displayMode, config?.enabled, config?.targetLanguage])
+
+  useEffect(() => {
+    let disposed = false
+
+    if (!config?.enabled || markdown.length === 0) {
+      setCapability(null)
+      return () => {
+        disposed = true
+      }
+    }
+
+    void probeBrowserTranslation(config.targetLanguage)
+      .then((nextCapability) => {
+        if (disposed) return
+        setCapability(nextCapability)
+      })
+      .catch((probeError) => {
+        if (disposed) return
+        setCapability({
+          availability: 'error',
+          message:
+            probeError instanceof Error
+              ? probeError.message
+              : 'Unable to check translation support.',
+        })
+      })
+
+    return () => {
+      disposed = true
+    }
+  }, [config?.enabled, config?.targetLanguage, markdown.length])
 
   const start = useCallback(async () => {
     if (!config?.enabled) return
@@ -75,13 +115,12 @@ export function useDocumentTranslation(
     setStatus('initializing')
 
     try {
-      const nextCapability = await probeBrowserTranslation(config.targetLanguage)
-      setCapability(nextCapability)
-      if (
-        nextCapability.availability === 'missing' ||
-        nextCapability.availability === 'unavailable' ||
-        nextCapability.availability === 'error'
-      ) {
+      const nextCapability = capability ?? (await probeBrowserTranslation(config.targetLanguage))
+      if (!capability) {
+        setCapability(nextCapability)
+      }
+      if (isUnavailableCapability(nextCapability)) {
+        setError(nextCapability.message ?? 'Translation is unavailable.')
         setStatus('unavailable')
         return
       }
@@ -128,7 +167,7 @@ export function useDocumentTranslation(
         abortRef.current = null
       }
     }
-  }, [config?.displayMode, config?.enabled, config?.targetLanguage, markdown])
+  }, [capability, config?.displayMode, config?.enabled, config?.targetLanguage, markdown])
 
   useEffect(() => {
     latestStartRef.current = start
@@ -137,8 +176,10 @@ export function useDocumentTranslation(
   useEffect(() => {
     if (activation !== 'translated' || !config?.enabled || markdown.length === 0) return
     if (status !== 'source') return
+    if (capability === null) return
+    if (isUnavailableCapability(capability)) return
     void latestStartRef.current?.()
-  }, [activation, config?.enabled, markdown.length, status])
+  }, [activation, capability, config?.enabled, markdown.length, status])
 
   return {
     status,

--- a/packages/web/src/routes/archive-view.test.tsx
+++ b/packages/web/src/routes/archive-view.test.tsx
@@ -1,10 +1,12 @@
 import type { OpsxEntityDetail } from '@openspecui/core'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ArchiveView } from './archive-view'
 
 const archiveSubscriptionMock = vi.hoisted(() => vi.fn())
+const artifactOutputSubscriptionMock = vi.hoisted(() => vi.fn())
+const globArtifactFilesSubscriptionMock = vi.hoisted(() => vi.fn())
 
 interface MockMarkdownBuilderComponents {
   H1: (props: { children?: ReactNode }) => ReactNode
@@ -18,8 +20,18 @@ vi.mock('@/lib/use-subscription', async (importOriginal) => {
   return {
     ...actual,
     useArchiveSubscription: archiveSubscriptionMock,
+    useConfigSubscription: () => ({
+      data: { translation: { enabled: false } },
+      isLoading: false,
+      error: null,
+    }),
   }
 })
+
+vi.mock('@/lib/use-opsx', () => ({
+  useOpsxArtifactOutputSubscription: artifactOutputSubscriptionMock,
+  useOpsxGlobArtifactFilesSubscription: globArtifactFilesSubscriptionMock,
+}))
 
 vi.mock('@tanstack/react-router', () => ({
   getRouteApi: () => ({
@@ -137,6 +149,8 @@ describe('ArchiveView', () => {
 
   beforeEach(() => {
     archiveSubscriptionMock.mockReset()
+    artifactOutputSubscriptionMock.mockReset()
+    globArtifactFilesSubscriptionMock.mockReset()
     archiveSubscriptionMock.mockReturnValue({
       data: archivedChange,
       isLoading: false,
@@ -156,6 +170,11 @@ describe('ArchiveView', () => {
     expect(screen.getAllByText('summary').length).toBeGreaterThan(0)
     expect(screen.getByText('# Processed summary')).toBeTruthy()
     expect(screen.getByText(/Schema: custom-audit/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'summary' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Folder' })).toBeTruthy()
+    expect(screen.getByText('1 file')).toBeTruthy()
+    expect(artifactOutputSubscriptionMock).not.toHaveBeenCalled()
+    expect(globArtifactFilesSubscriptionMock).not.toHaveBeenCalled()
   })
 
   it('keeps the loading state while the archive subscription has not resolved', () => {
@@ -195,8 +214,46 @@ describe('ArchiveView', () => {
 
     expect(screen.getByText('Content')).toBeTruthy()
     expect(screen.getByText('Folder')).toBeTruthy()
-    expect(screen.getByText('notes/decision.md')).toBeTruthy()
-    expect(screen.getByText(/Keep visible/)).toBeTruthy()
+    const content = document.querySelector('.vt-detail-content')
+    expect(content).toBeTruthy()
+    expect(
+      within(content as HTMLElement).getAllByText(
+        'archive/2026-05-17-fix-change-document-hook-rendering'
+      ).length
+    ).toBeGreaterThan(0)
+    expect(within(content as HTMLElement).getByText('notes/decision.md')).toBeTruthy()
+    expect(within(content as HTMLElement).getByText(/Keep visible/)).toBeTruthy()
     expect(screen.queryByText(/^folder:/)).not.toBeInTheDocument()
+  })
+
+  it('shows a friendly fallback for missing archived changes', () => {
+    archiveSubscriptionMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error(
+        "Archived change '2026-05-17-fix-change-document-hook-rendering' not found. Available archives: 2026-05-16-sample"
+      ),
+    })
+
+    render(<ArchiveView />)
+
+    expect(screen.getByText('Archived change not found in the current project.')).toBeTruthy()
+    expect(screen.queryByText(/Error loading archive:/)).toBeNull()
+    expect(screen.getByRole('link', { name: 'Back to Archive' }).getAttribute('href')).toBe(
+      '/archive'
+    )
+  })
+
+  it('surfaces non-not-found archive subscription errors through the shared detail view', () => {
+    archiveSubscriptionMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('archive daemon unavailable'),
+    })
+
+    render(<ArchiveView />)
+
+    expect(screen.getByText('Error loading archive: archive daemon unavailable')).toBeTruthy()
+    expect(screen.queryByText('Archived change not found in the current project.')).toBeNull()
   })
 })

--- a/packages/web/src/routes/archive-view.tsx
+++ b/packages/web/src/routes/archive-view.tsx
@@ -1,17 +1,10 @@
-import { FolderEditorViewer } from '@/components/folder-editor-viewer'
-import { MarkdownViewer } from '@/components/markdown-viewer'
-import { Tabs, type Tab } from '@/components/tabs'
+import { OpsxEntityDetailView } from '@/components/opsx/opsx-entity-detail-view'
+import { fileCountLabel } from '@/components/opsx/opsx-markdown-files-viewer'
 import { useArchiveSubscription } from '@/lib/use-subscription'
-import { VTLink } from '@/lib/view-transitions/navigation'
-import {
-  getSharedElementBinding,
-  readSharedElementHandoffState,
-} from '@/lib/view-transitions/shared-elements'
-import { useRoutedCarouselTabs } from '@/lib/view-transitions/tabs'
-import type { OpsxEntityArtifact, OpsxEntityDetail, OpsxEntityFile } from '@openspecui/core'
+import { readSharedElementHandoffState } from '@/lib/view-transitions/shared-elements'
+import type { OpsxEntityDetail } from '@openspecui/core'
 import { getRouteApi, useLocation } from '@tanstack/react-router'
-import { AlertTriangle, Archive, ArrowLeft, FileText, FolderTree } from 'lucide-react'
-import { useMemo, useRef } from 'react'
+import { Archive } from 'lucide-react'
 
 const route = getRouteApi('/archive/$changeId')
 
@@ -19,251 +12,67 @@ function getArchiveTitle(entity: OpsxEntityDetail | null | undefined, fallbackId
   return entity?.id ?? fallbackId
 }
 
-function fileCountLabel(files: readonly OpsxEntityFile[]): string {
-  const count = files.filter((file) => file.type === 'file').length
-  return `${count} ${count === 1 ? 'file' : 'files'}`
-}
-
-function MarkdownFilesViewer({
-  files,
-  emptyMessage,
-}: {
-  files: readonly OpsxEntityFile[]
-  emptyMessage: string
-}) {
-  const markdownFiles = files.filter(
-    (file) => file.type === 'file' && file.content !== undefined && file.path.endsWith('.md')
-  )
-
-  if (markdownFiles.length === 0) {
-    return (
-      <div className="text-muted-foreground flex h-full items-center justify-center rounded-md border border-dashed p-6 text-sm">
-        {emptyMessage}
-      </div>
-    )
-  }
-
-  if (markdownFiles.length === 1) {
-    const file = markdownFiles[0]!
-    return <MarkdownViewer markdown={file.content ?? ''} path={file.path} />
-  }
-
-  return (
-    <MarkdownViewer
-      markdown={({ H1, Section }) => (
-        <div className="space-y-6">
-          {markdownFiles.map((file) => (
-            <Section key={file.path}>
-              <H1>{file.path}</H1>
-              <div className="border-border bg-muted/30 mt-2 rounded-md border p-4 [zoom:0.86]">
-                <MarkdownViewer markdown={file.content ?? ''} path={file.path} />
-              </div>
-            </Section>
-          ))}
-        </div>
-      )}
-    />
-  )
-}
-
-function ArtifactMarkdown({ artifact }: { artifact: OpsxEntityArtifact }) {
-  return (
-    <MarkdownFilesViewer
-      files={artifact.files}
-      emptyMessage="No Markdown files matched this artifact."
-    />
-  )
-}
-
-function EntityMarkdown({ files }: { files: readonly OpsxEntityFile[] }) {
-  return (
-    <MarkdownFilesViewer
-      files={files}
-      emptyMessage="No Markdown files found. Open the folder view to inspect archived files."
-    />
-  )
-}
-
-function DiagnosticsPanel({ entity }: { entity: OpsxEntityDetail }) {
-  if (entity.diagnostics.length === 0) return null
-
-  return (
-    <div className="border-border bg-muted/20 flex flex-col gap-2 rounded-md border p-3 text-sm">
-      {entity.diagnostics.map((diagnostic, index) => (
-        <div key={`${diagnostic.message}-${index}`} className="flex items-start gap-2">
-          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-          <div>
-            <div className="font-medium capitalize">{diagnostic.level}</div>
-            <div className="text-muted-foreground">
-              {diagnostic.path ? `${diagnostic.path}: ` : ''}
-              {diagnostic.message}
-            </div>
-          </div>
-        </div>
-      ))}
-    </div>
-  )
-}
-
 export function ArchiveView() {
   const { changeId } = route.useParams()
   const location = useLocation()
 
-  const { data: entity, isLoading } = useArchiveSubscription(changeId)
-  const headerRef = useRef<HTMLDivElement | null>(null)
-  const sharedDescriptor = useMemo(
-    () => ({ family: 'archive', entityId: changeId }) as const,
-    [changeId]
-  )
+  const { data: entity, isLoading, error } = useArchiveSubscription(changeId)
   const handoff = readSharedElementHandoffState(location.state)
-  const tabs = useMemo<Tab[]>(() => {
-    if (!entity) return []
-
-    const artifactTabs = entity.artifacts
-      .filter((artifact) => artifact.files.length > 0)
-      .map<Tab>((artifact) => ({
-        id: `artifact:${artifact.id}`,
-        label: artifact.id,
-        icon: <FileText className="h-4 w-4" />,
-        content: (
-          <div className="flex min-h-0 flex-1 flex-col gap-3 py-4">
-            <div className="border-border bg-card flex flex-wrap items-center justify-between gap-3 rounded-md border px-4 py-3">
-              <div className="flex min-w-0 items-center gap-2">
-                <FileText className="text-muted-foreground h-4 w-4 shrink-0" />
-                <span className="font-medium">{artifact.id}</span>
-                <span className="text-muted-foreground truncate text-xs">
-                  {artifact.outputPath}
-                </span>
-              </div>
-              <span className="text-muted-foreground text-xs">
-                {fileCountLabel(artifact.files)}
-              </span>
-            </div>
-            <div className="min-h-0 flex-1">
-              <ArtifactMarkdown artifact={artifact} />
-            </div>
-          </div>
-        ),
-      }))
-
-    const result: Tab[] =
-      artifactTabs.length > 0
-        ? artifactTabs
-        : [
-            {
-              id: 'content',
-              label: 'Content',
-              icon: <FileText className="h-4 w-4" />,
-              content: (
-                <div className="min-h-0 flex-1 py-4">
-                  <EntityMarkdown files={entity.files} />
-                </div>
-              ),
-            },
-          ]
-
-    result.push({
-      id: 'folder',
-      label: 'Folder',
-      icon: <FolderTree className="h-4 w-4" />,
-      content: <FolderEditorViewer changeId={changeId} archived files={entity.files} />,
-    })
-
-    return result
-  }, [entity, changeId])
-
-  const { tabsRef, selectedTab, onTabChange } = useRoutedCarouselTabs({
-    queryKey: 'archiveTab',
-    tabs,
-    initialTab: tabs[0]?.id,
-  })
-
-  if (isLoading || entity === undefined) {
-    if (handoff) {
-      return (
-        <div className="flex min-h-0 flex-1 flex-col gap-6 p-4">
-          <div className="flex items-center gap-4">
-            <VTLink
-              to="/archive"
-              vt={{ source: headerRef, sharedElements: sharedDescriptor }}
-              className="hover:bg-muted rounded-md p-2 transition-colors"
-              title="Back to Archive"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </VTLink>
-            <div ref={headerRef} {...getSharedElementBinding(sharedDescriptor, 'container')}>
-              <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
-                <Archive
-                  {...getSharedElementBinding(sharedDescriptor, 'icon')}
-                  className="h-6 w-6 shrink-0"
-                />
-                <span {...getSharedElementBinding(sharedDescriptor, 'title')}>
-                  {handoff.title ?? changeId}
-                </span>
-              </h1>
-              <p className="text-muted-foreground text-sm">{handoff.subtitle ?? changeId}</p>
-            </div>
-          </div>
-          <div className="vt-detail-content route-loading animate-pulse rounded-lg border p-4">
-            Loading archived entity...
-          </div>
-        </div>
-      )
-    }
-
-    return <div className="route-loading animate-pulse">Loading archived entity...</div>
-  }
-
-  if (!entity) {
-    return (
-      <div className="py-12 text-center">
-        <p className="text-muted-foreground">Archived change not found: {changeId}</p>
-        <VTLink to="/archive" className="text-primary mt-4 inline-block hover:underline">
-          Back to Archive
-        </VTLink>
-      </div>
-    )
-  }
+  const isMissingArchiveError =
+    error?.message.includes(`Archived change '${changeId}' not found`) ||
+    error?.message.includes(`Archived change "${changeId}" not found`)
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-6 p-4">
-      <div className="flex items-center gap-4">
-        <VTLink
-          to="/archive"
-          vt={{ source: headerRef, sharedElements: sharedDescriptor }}
-          className="hover:bg-muted rounded-md p-2 transition-colors"
-          title="Back to Archive"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </VTLink>
-        <div ref={headerRef} {...getSharedElementBinding(sharedDescriptor, 'container')}>
-          <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
-            <Archive
-              {...getSharedElementBinding(sharedDescriptor, 'icon')}
-              className="h-6 w-6 shrink-0"
-            />
-            <span {...getSharedElementBinding(sharedDescriptor, 'title')}>
-              {getArchiveTitle(entity, changeId)}
-            </span>
-          </h1>
-          <p className="text-muted-foreground text-sm">
-            {entity.schemaName ? `Schema: ${entity.schemaName}` : 'Schema: unknown'} ·{' '}
-            {fileCountLabel(entity.files)}
-          </p>
-        </div>
-      </div>
-
-      <DiagnosticsPanel entity={entity} />
-
-      <div className="vt-detail-content flex min-h-0 flex-1 flex-col">
-        <Tabs
-          ref={tabsRef}
-          tabs={tabs}
-          selectedTab={selectedTab}
-          onTabChange={onTabChange}
-          className="min-h-0 flex-1 gap-6"
-        />
-      </div>
-    </div>
+    <OpsxEntityDetailView
+      entityId={changeId}
+      sharedFamily="archive"
+      backTo="/archive"
+      backTitle="Back to Archive"
+      icon={Archive}
+      title={getArchiveTitle(entity, changeId)}
+      subtitle={
+        entity
+          ? `${entity.schemaName ? `Schema: ${entity.schemaName}` : 'Schema: unknown'} · ${fileCountLabel(entity.files)}`
+          : undefined
+      }
+      diagnostics={entity?.diagnostics}
+      handoff={handoff}
+      isLoading={isLoading && !entity}
+      loadingMessage="Loading archived entity..."
+      errorMessage={
+        error && !isMissingArchiveError && !entity
+          ? `Error loading archive: ${error.message}`
+          : undefined
+      }
+      notFoundMessage={
+        isMissingArchiveError && !entity
+          ? 'Archived change not found in the current project.'
+          : !entity && !isLoading && !error
+            ? `Archived change not found: ${changeId}`
+            : undefined
+      }
+      notFoundBackLabel="Back to Archive"
+      artifacts={entity?.artifacts}
+      hideEmptyArtifacts
+      contentFallback={
+        entity
+          ? {
+              id: 'content',
+              label: 'Content',
+              outputPath: 'openspec/changes/archive/**/*.md',
+              relativePath: `archive/${changeId}`,
+              files: entity.files,
+              emptyMessage:
+                'No Markdown files found. Open the folder view to inspect archived files.',
+            }
+          : undefined
+      }
+      folder={{
+        changeId,
+        archived: true,
+        files: entity?.files,
+      }}
+      tabsQueryKey="archiveTab"
+    />
   )
 }

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -1,16 +1,17 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { createContext, type ComponentProps, type ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeView } from './change-view'
 
 const statusMock = vi.hoisted(() => vi.fn())
+const changeFilesMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/use-opsx', () => ({
   useOpsxStatusSubscription: statusMock,
 }))
 
-vi.mock('@/lib/use-tabs-status-by-query', () => ({
-  useTabsStatusByQuery: () => ({ selectedTab: undefined, setSelectedTab: vi.fn() }),
+vi.mock('@/lib/use-subscription', () => ({
+  useChangeFilesSubscription: changeFilesMock,
 }))
 
 vi.mock('@/components/folder-editor-viewer', () => ({
@@ -18,7 +19,12 @@ vi.mock('@/components/folder-editor-viewer', () => ({
 }))
 
 vi.mock('@/components/opsx/artifact-output-viewer', () => ({
-  ArtifactOutputViewer: () => <div>artifact</div>,
+  ArtifactOutputViewer: ({ artifact }: { artifact: { id: string } }) => (
+    <div>artifact:{artifact.id}</div>
+  ),
+  ContentFallbackViewer: ({ fallback }: { fallback: { label?: string } }) => (
+    <div>fallback:{fallback.label ?? 'Content'}</div>
+  ),
 }))
 
 vi.mock('@/components/opsx/change-command-bar', () => ({
@@ -26,11 +32,50 @@ vi.mock('@/components/opsx/change-command-bar', () => ({
 }))
 
 vi.mock('@/components/tabs', () => ({
-  Tabs: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Tabs: ({
+    tabs,
+    selectedTab,
+  }: {
+    tabs: Array<{ id: string; label?: ReactNode; content: ReactNode }>
+    selectedTab?: string
+  }) => (
+    <div>
+      <nav>
+        {tabs.map((tab) => (
+          <button key={tab.id} type="button">
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+      <div>{tabs.find((tab) => tab.id === selectedTab)?.content ?? tabs[0]?.content}</div>
+    </div>
+  ),
 }))
 
-vi.mock('@/lib/nav-controller', () => ({
-  navController: { activatePop: vi.fn() },
+vi.mock('@/lib/view-transitions/navigation', () => ({
+  VTLink: ({
+    to,
+    children,
+    ...props
+  }: { to: string; children?: ReactNode } & Omit<ComponentProps<'a'>, 'href'>) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  vtNavController: { activatePop: vi.fn() },
+}))
+
+vi.mock('@/lib/view-transitions/shared-elements', () => ({
+  getSharedElementBinding: () => ({}),
+  readSharedElementHandoffState: () => null,
+}))
+
+vi.mock('@/lib/view-transitions/tabs', () => ({
+  useRoutedCarouselTabs: ({ initialTab }: { initialTab?: string }) => ({
+    tabsRef: { current: null },
+    selectedTab: initialTab,
+    onTabChange: vi.fn(),
+  }),
 }))
 
 vi.mock('@tanstack/react-router', () => ({
@@ -55,8 +100,18 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 describe('ChangeView', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   beforeEach(() => {
     statusMock.mockReset()
+    changeFilesMock.mockReset()
+    changeFilesMock.mockReturnValue({
+      data: [{ path: 'notes/decision.md', type: 'file', content: '# Decision' }],
+      isLoading: false,
+      error: null,
+    })
   })
 
   it('shows a friendly fallback for missing changes', () => {
@@ -75,5 +130,52 @@ describe('ChangeView', () => {
     expect(screen.getByRole('link', { name: 'Back to Changes' }).getAttribute('href')).toBe(
       '/changes'
     )
+  })
+
+  it('renders change artifacts, folder, and toolbar through the shared detail view', () => {
+    statusMock.mockReturnValue({
+      data: {
+        changeName: 'Extract Terminal View Webcomponent',
+        schemaName: 'opsx-collab-pr-loop',
+        isComplete: false,
+        applyRequires: [],
+        artifacts: [
+          { id: 'intake', outputPath: 'intake.md', status: 'done' },
+          { id: 'implementation', outputPath: 'implementation.md', status: 'ready' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    expect(screen.getByText('Extract Terminal View Webcomponent')).toBeTruthy()
+    expect(screen.getByText('Schema: opsx-collab-pr-loop · 1/2 artifacts')).toBeTruthy()
+    expect(screen.getByText('commands')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'intake' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'implementation' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Folder' })).toBeTruthy()
+    expect(screen.getByText('artifact:implementation')).toBeTruthy()
+  })
+
+  it('falls back to the shared content document tab when no artifact tab is available', () => {
+    statusMock.mockReturnValue({
+      data: {
+        changeName: 'Extract Terminal View Webcomponent',
+        schemaName: 'opsx-collab-pr-loop',
+        isComplete: false,
+        applyRequires: [],
+        artifacts: [],
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    expect(screen.getByRole('button', { name: 'Content' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Folder' })).toBeTruthy()
+    expect(screen.getByText('fallback:Content')).toBeTruthy()
   })
 })

--- a/packages/web/src/routes/change-view.tsx
+++ b/packages/web/src/routes/change-view.tsx
@@ -1,44 +1,21 @@
-import { FolderEditorViewer } from '@/components/folder-editor-viewer'
-import { ArtifactOutputViewer } from '@/components/opsx/artifact-output-viewer'
 import { ChangeCommandBar } from '@/components/opsx/change-command-bar'
-import { Tabs, type Tab } from '@/components/tabs'
+import { OpsxEntityDetailView } from '@/components/opsx/opsx-entity-detail-view'
 import { buildOpsxComposeHref, type OpsxComposeActionId } from '@/lib/opsx-compose'
 import { useOpsxStatusSubscription } from '@/lib/use-opsx'
-import { VTLink, vtNavController } from '@/lib/view-transitions/navigation'
-import {
-  getSharedElementBinding,
-  readSharedElementHandoffState,
-} from '@/lib/view-transitions/shared-elements'
-import { useRoutedCarouselTabs } from '@/lib/view-transitions/tabs'
+import { useChangeFilesSubscription } from '@/lib/use-subscription'
+import { vtNavController } from '@/lib/view-transitions/navigation'
+import { readSharedElementHandoffState } from '@/lib/view-transitions/shared-elements'
 import { useLocation, useParams } from '@tanstack/react-router'
-import {
-  AlertCircle,
-  AlertTriangle,
-  ArrowLeft,
-  CheckCircle2,
-  Circle,
-  FolderTree,
-  GitBranch,
-} from 'lucide-react'
-import { useCallback, useMemo, useRef } from 'react'
-
-function StatusBadge({ status }: { status: 'done' | 'ready' | 'blocked' }) {
-  if (status === 'done') return <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
-  if (status === 'ready') return <Circle className="h-3.5 w-3.5 text-sky-500" />
-  return <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-}
+import { GitBranch } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
 
 export function ChangeView() {
   const { changeId } = useParams({ from: '/changes/$changeId' })
   const location = useLocation()
-  const headerRef = useRef<HTMLDivElement | null>(null)
-  const sharedDescriptor = useMemo(
-    () => ({ family: 'changes', entityId: changeId }) as const,
-    [changeId]
-  )
   const handoff = readSharedElementHandoffState(location.state)
 
   const { data: status, isLoading, error } = useOpsxStatusSubscription({ change: changeId })
+  const { data: files } = useChangeFilesSubscription(changeId)
 
   const handleComposeAction = useCallback(
     (actionId: OpsxComposeActionId, artifactId?: string) => {
@@ -56,34 +33,10 @@ export function ChangeView() {
     vtNavController.activatePop(`/opsx-verify?change=${encodeURIComponent(changeId)}`)
   }, [changeId])
 
-  const tabs: Tab[] = useMemo(() => {
-    if (!status) return []
-    return [
-      ...status.artifacts.map((artifact) => ({
-        id: artifact.id,
-        label: artifact.id,
-        icon: <StatusBadge status={artifact.status} />,
-        content: <ArtifactOutputViewer changeId={changeId} artifact={artifact} />,
-      })),
-      {
-        id: 'folder',
-        label: 'Folder',
-        icon: <FolderTree className="h-4 w-4" />,
-        content: <FolderEditorViewer changeId={changeId} />,
-      },
-    ]
-  }, [status, changeId])
-
   const selectedArtifactId = useMemo(() => {
     if (!status) return undefined
     return status.artifacts.find((a) => a.status === 'ready')?.id ?? status.artifacts[0]?.id
   }, [status])
-
-  const { tabsRef, selectedTab, onTabChange } = useRoutedCarouselTabs({
-    queryKey: 'artifact',
-    tabs,
-    initialTab: selectedArtifactId ?? tabs[0]?.id,
-  })
 
   const doneCount = status?.artifacts.filter((a) => a.status === 'done').length ?? 0
   const totalCount = status?.artifacts.length ?? 0
@@ -91,129 +44,59 @@ export function ChangeView() {
     error?.message.includes(`Change '${changeId}' not found`) ||
     error?.message.includes(`Change "${changeId}" not found`)
 
-  if (isLoading && !status) {
-    if (handoff) {
-      return (
-        <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-          <div className="flex items-center gap-4">
-            <VTLink
-              to="/changes"
-              vt={{ source: headerRef, sharedElements: sharedDescriptor }}
-              className="hover:bg-muted rounded-md p-2"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </VTLink>
-            <div
-              ref={headerRef}
-              {...getSharedElementBinding(sharedDescriptor, 'container')}
-              className="flex min-w-0 flex-col gap-1"
-            >
-              <h1 className="font-nav flex min-w-0 items-center gap-2 text-2xl font-bold">
-                <GitBranch
-                  {...getSharedElementBinding(sharedDescriptor, 'icon')}
-                  className="h-6 w-6 shrink-0"
-                />
-                <span {...getSharedElementBinding(sharedDescriptor, 'title')} className="truncate">
-                  {handoff.title ?? changeId}
-                </span>
-              </h1>
-              <p className="text-muted-foreground text-sm">
-                {handoff.subtitle ?? changeId} · Loading change status…
-              </p>
-            </div>
-          </div>
-          <div className="vt-detail-content route-loading animate-pulse rounded-lg border p-4">
-            Loading change status...
-          </div>
-        </div>
-      )
-    }
-
-    return <div className="route-loading animate-pulse">Loading change status...</div>
-  }
-
-  if (isMissingChangeError && !status) {
-    return (
-      <div className="flex flex-col gap-3 p-4">
-        <div className="text-muted-foreground flex items-center gap-2 text-sm">
-          <AlertCircle className="h-4 w-4" />
-          Change not found in the current project.
-        </div>
-        <div>
-          <VTLink to="/changes" className="text-primary hover:underline">
-            Back to Changes
-          </VTLink>
-        </div>
-      </div>
-    )
-  }
-
-  if (error && !status) {
-    return (
-      <div className="text-destructive flex items-center gap-2">
-        <AlertCircle className="h-5 w-5" />
-        Error loading change: {error.message}
-      </div>
-    )
-  }
-
-  if (!status) {
-    return (
-      <div className="text-muted-foreground flex items-center gap-2 text-sm">
-        <AlertCircle className="h-4 w-4" />
-        Change not found.
-      </div>
-    )
-  }
-
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-4">
-          <VTLink
-            to="/changes"
-            vt={{ source: headerRef, sharedElements: sharedDescriptor }}
-            className="hover:bg-muted rounded-md p-2"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </VTLink>
-          <div
-            ref={headerRef}
-            {...getSharedElementBinding(sharedDescriptor, 'container')}
-            className="flex min-w-0 flex-col gap-1"
-          >
-            <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
-              <GitBranch
-                {...getSharedElementBinding(sharedDescriptor, 'icon')}
-                className="h-6 w-6 shrink-0"
-              />
-              <span {...getSharedElementBinding(sharedDescriptor, 'title')}>
-                {status.changeName}
-              </span>
-            </h1>
-            <p className="text-muted-foreground text-sm">
-              Schema: {status.schemaName} · {doneCount}/{totalCount} artifacts
-            </p>
-          </div>
-        </div>
-        <ChangeCommandBar
-          status={status}
-          selectedArtifactId={selectedArtifactId}
-          onComposeAction={handleComposeAction}
-          onVerify={handleVerify}
-        />
-      </div>
-
-      <div className="vt-detail-content flex min-h-0 flex-1 flex-col">
-        <Tabs
-          ref={tabsRef}
-          tabs={tabs}
-          selectedTab={selectedTab}
-          onTabChange={onTabChange}
-          className="min-h-0 flex-1"
-        />
-      </div>
-    </div>
+    <OpsxEntityDetailView
+      entityId={changeId}
+      sharedFamily="changes"
+      backTo="/changes"
+      backTitle="Back to Changes"
+      icon={GitBranch}
+      title={status?.changeName}
+      subtitle={
+        status ? `Schema: ${status.schemaName} · ${doneCount}/${totalCount} artifacts` : undefined
+      }
+      handoff={handoff}
+      isLoading={isLoading && !status}
+      loadingMessage="Loading change status..."
+      errorMessage={
+        error && !isMissingChangeError && !status
+          ? `Error loading change: ${error.message}`
+          : undefined
+      }
+      notFoundMessage={
+        isMissingChangeError && !status
+          ? 'Change not found in the current project.'
+          : !status && !isLoading && !error
+            ? 'Change not found.'
+            : undefined
+      }
+      notFoundBackLabel="Back to Changes"
+      artifacts={status?.artifacts}
+      contentFallback={
+        files
+          ? {
+              id: 'content',
+              label: 'Content',
+              outputPath: 'openspec/changes/**/*.md',
+              relativePath: `changes/${changeId}`,
+              files,
+              emptyMessage: 'No Markdown files found. Open the folder view to inspect change files.',
+            }
+          : undefined
+      }
+      folder={{ changeId }}
+      tabsQueryKey="artifact"
+      initialTab={selectedArtifactId}
+      toolbar={
+        status ? (
+          <ChangeCommandBar
+            status={status}
+            selectedArtifactId={selectedArtifactId}
+            onComposeAction={handleComposeAction}
+            onVerify={handleVerify}
+          />
+        ) : null
+      }
+    />
   )
 }

--- a/packages/web/src/routes/settings.test.tsx
+++ b/packages/web/src/routes/settings.test.tsx
@@ -416,6 +416,41 @@ describe('Settings', () => {
     expect(screen.getByRole('button', { name: 'Clear search' })).toBeTruthy()
   })
 
+  it('uses popover theme tokens for the translation language dialog in dark mode-safe surfaces', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    )
+    useConfigSubscriptionMock.mockReturnValue({
+      data: {
+        translation: {
+          enabled: false,
+          targetLanguage: 'zh',
+          displayMode: 'direct',
+          cacheEnabled: false,
+        },
+      },
+    })
+    useServerStatusMock.mockReturnValue({ projectDir: '/tmp/project' })
+
+    render(<Settings />)
+
+    await waitFor(() => expect(screen.queryByText('Loading settings...')).toBeNull())
+    fireEvent.click(screen.getByRole('button', { name: 'Translation target language' }))
+    const popover = screen.getByRole('dialog', { name: 'Select translation target language' })
+    dispatchPopoverToggle(popover, 'open')
+
+    expect(popover.className).toContain('bg-popover')
+    expect(popover.className).toContain('text-popover-foreground')
+    expect(screen.getByRole('option', { name: /Chinese 中文/ }).className).toContain(
+      'bg-primary/10'
+    )
+  })
+
   it('keeps the popover open when the inner search input is clicked', async () => {
     vi.stubGlobal(
       'matchMedia',

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -2560,7 +2560,7 @@ function TranslationLanguageCombobox({
         aria-label="Select translation target language"
         popover="auto"
         onToggle={handleToggle}
-        className="bg-card border-border m-0 rounded-md border p-2 shadow-lg backdrop:bg-transparent"
+        className="bg-popover text-popover-foreground border-border m-0 rounded-md border p-2 shadow-lg backdrop:bg-black/20"
         style={
           popoverPosition
             ? {
@@ -2573,7 +2573,7 @@ function TranslationLanguageCombobox({
             : undefined
         }
       >
-        <div className="border-border bg-background sticky top-0 z-10 mb-2 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2 py-1.5">
+        <div className="border-border bg-popover sticky top-0 z-10 mb-2 grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2 py-1.5">
           <Search className="text-muted-foreground h-4 w-4" aria-hidden="true" />
           <input
             ref={searchInputRef}
@@ -2618,7 +2618,11 @@ function TranslationLanguageCombobox({
                 type="button"
                 role="option"
                 aria-selected={language.code === value}
-                className="hover:bg-muted grid w-full grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm"
+                className={`grid w-full grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm ${
+                  language.code === value
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-popover-foreground hover:bg-muted/70'
+                }`}
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => commitLanguage(language.code)}
               >


### PR DESCRIPTION
## Summary\n- unify the shared detail translation session so unsupported browser translation renders a disabled action instead of a misleading active control\n- keep settings-disabled translation actions visually unavailable while preserving the settings shortcut\n- switch the translation target language popover to popover theme tokens and add a patch changeset for this branch\n\n## Verification\n- pnpm format:check\n- pnpm lint:ci\n- pnpm typecheck\n- pnpm test:ci\n- pnpm test:browser:ci\n- pnpm --filter @openspecui/web exec vitest run src/components/document-translation-action.test.tsx src/routes/settings.test.tsx --project unit\n\n## Notes\n- http://localhost:3101/archive/2026-05-17-fix-cli-shell-native-selection-shortcuts?_b=%2F currently renders "Archived change not found" in this workspace because there is no openspec/archive payload for that id here. Live DOM verification used the existing spec detail route instead.