### PR TITLE
fix(translation): stream local model download progress

### DIFF
--- a/.changeset/stream-local-model-progress.md
+++ b/.changeset/stream-local-model-progress.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/server': minor
+---
+
+Stream Local-Transformers model downloads from the Hugging Face fetch body so Settings can receive real progress updates and automatic resume events instead of a single completion jump.

--- a/packages/server/src/local-model-asset-service.test.ts
+++ b/packages/server/src/local-model-asset-service.test.ts
@@ -238,7 +238,11 @@ describe('LocalModelAssetService', () => {
     await waitForState(indexPath, (states) =>
       states.some((entry) =>
         entry.files?.some(
-          (file) => file.path === 'onnx/encoder_model_q4.onnx' && file.downloadedBytes === 4
+          (file) =>
+            file.path === 'onnx/encoder_model_q4.onnx' &&
+            typeof file.downloadedBytes === 'number' &&
+            file.downloadedBytes > 0 &&
+            file.downloadedBytes < 10
         )
       )
     )
@@ -301,7 +305,11 @@ describe('LocalModelAssetService', () => {
     await waitForState(indexPath, (states) =>
       states.some((entry) =>
         entry.files?.some(
-          (file) => file.path === 'onnx/encoder_model_q4.onnx' && file.downloadedBytes === 4
+          (file) =>
+            file.path === 'onnx/encoder_model_q4.onnx' &&
+            typeof file.downloadedBytes === 'number' &&
+            file.downloadedBytes > 0 &&
+            file.downloadedBytes < 10
         )
       )
     )

--- a/packages/server/src/local-model-asset-service.test.ts
+++ b/packages/server/src/local-model-asset-service.test.ts
@@ -13,19 +13,8 @@ import {
 
 const hubMock = vi.hoisted(() => ({
   downloadFile: vi.fn(),
-  fileDownloadInfo: vi.fn(async (input: { path: string }) => ({
-    size: input.path.includes('_q4') || input.path === 'config.json' ? 10 : 100,
-    etag: `${input.path.replace(/[^a-zA-Z0-9]+/g, '-')}-etag`,
-    url: `https://huggingface.co/test/resolve/main/${input.path}`,
-  })),
-  listFiles: vi.fn(async function* (input?: { fetch?: typeof fetch; hubUrl?: string }) {
-    await input?.fetch?.(
-      `${input.hubUrl ?? 'https://huggingface.co'}/api/models/onnx-community/opus-mt-en-zh/tree/main?recursive=true&expand=true`
-    )
-    yield { path: 'config.json', type: 'file', size: 10 }
-    yield { path: 'onnx/encoder_model_q4.onnx', type: 'file', size: 10 }
-    yield { path: 'onnx/decoder_model_merged_q4.onnx', type: 'file', size: 10 }
-  }),
+  fileDownloadInfo: vi.fn(),
+  listFiles: vi.fn(),
 }))
 
 vi.mock('@huggingface/hub', () => hubMock)
@@ -74,8 +63,24 @@ describe('LocalModelAssetService', () => {
       })
     )
     hubMock.downloadFile.mockReset()
-    hubMock.fileDownloadInfo.mockClear()
-    hubMock.listFiles.mockClear()
+    hubMock.fileDownloadInfo.mockReset()
+    hubMock.listFiles.mockReset()
+    hubMock.fileDownloadInfo.mockImplementation(async (input: { path: string }) => ({
+      size: input.path.includes('_q4') || input.path === 'config.json' ? 10 : 100,
+      etag: `${input.path.replace(/[^a-zA-Z0-9]+/g, '-')}-etag`,
+      url: `https://huggingface.co/test/resolve/main/${input.path}`,
+    }))
+    hubMock.listFiles.mockImplementation(async function* (input?: {
+      fetch?: typeof fetch
+      hubUrl?: string
+    }) {
+      await input?.fetch?.(
+        `${input.hubUrl ?? 'https://huggingface.co'}/api/models/onnx-community/opus-mt-en-zh/tree/main?recursive=true&expand=true`
+      )
+      yield { path: 'config.json', type: 'file', size: 10 }
+      yield { path: 'onnx/encoder_model_q4.onnx', type: 'file', size: 10 }
+      yield { path: 'onnx/decoder_model_merged_q4.onnx', type: 'file', size: 10 }
+    })
   })
 
   afterEach(async () => {
@@ -108,6 +113,11 @@ describe('LocalModelAssetService', () => {
       indexPath,
       cacheDir,
       fetchCachePath,
+      networkRetryPolicy: {
+        limit: 2,
+        delayMs: 10,
+        maxDelayMs: 20,
+      },
     }) as TestableLocalModelAssetService
     vi.spyOn(service, 'getTransformersModule').mockResolvedValue({
       env: {
@@ -138,6 +148,7 @@ describe('LocalModelAssetService', () => {
     })
 
     await service.startDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(hubMock.downloadFile).toHaveBeenCalledTimes(3)
@@ -183,12 +194,46 @@ describe('LocalModelAssetService', () => {
   })
 
   it('persists byte-level progress while streaming a selected NMT file', async () => {
-    hubMock.downloadFile.mockImplementation(async (input: { path: string }) =>
-      createMockDownloadBlob(
-        input.path === 'onnx/encoder_model_q4.onnx'
-          ? [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8, 9, 10])]
-          : [new Uint8Array(10)]
-      )
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+        if (url.includes('/api/models/') && url.includes('/tree/')) {
+          return Response.json([
+            { path: 'config.json', type: 'file', size: 10 },
+            { path: 'onnx/encoder_model_q4.onnx', type: 'file', size: 10 },
+            { path: 'onnx/decoder_model_merged_q4.onnx', type: 'file', size: 10 },
+          ])
+        }
+        if (url.includes('/resolve/main/onnx/encoder_model_q4.onnx')) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3, 4]))
+                await new Promise((resolve) => setTimeout(resolve, 20))
+                controller.enqueue(new Uint8Array([5, 6, 7, 8, 9, 10]))
+                controller.close()
+              },
+            }),
+            {
+              status: 200,
+              headers: {
+                'Content-Length': '10',
+              },
+            }
+          )
+        }
+        if (url.includes('/resolve/main/')) {
+          return new Response(new Uint8Array(10), {
+            status: 200,
+            headers: {
+              'Content-Length': '10',
+            },
+          })
+        }
+        return new Response(null, { status: 200 })
+      })
     )
 
     const service = new LocalModelAssetService({
@@ -209,6 +254,11 @@ describe('LocalModelAssetService', () => {
       indexPath,
       cacheDir,
       fetchCachePath,
+      networkRetryPolicy: {
+        limit: 2,
+        delayMs: 10,
+        maxDelayMs: 20,
+      },
     }) as TestableLocalModelAssetService
     vi.spyOn(service, 'getTransformersModule').mockResolvedValue({
       env: {
@@ -246,6 +296,7 @@ describe('LocalModelAssetService', () => {
         )
       )
     )
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
   })
 
@@ -276,6 +327,11 @@ describe('LocalModelAssetService', () => {
       indexPath,
       cacheDir,
       fetchCachePath,
+      networkRetryPolicy: {
+        limit: 2,
+        delayMs: 10,
+        maxDelayMs: 20,
+      },
     }) as TestableLocalModelAssetService
     vi.spyOn(service, 'getTransformersModule').mockResolvedValue({
       env: {
@@ -313,6 +369,7 @@ describe('LocalModelAssetService', () => {
         )
       )
     )
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
   })
 
@@ -346,6 +403,11 @@ describe('LocalModelAssetService', () => {
       indexPath,
       cacheDir,
       fetchCachePath,
+      networkRetryPolicy: {
+        limit: 2,
+        delayMs: 10,
+        maxDelayMs: 20,
+      },
     }) as TestableLocalModelAssetService
     vi.spyOn(service, 'getTransformersModule').mockResolvedValue({
       env: {
@@ -371,6 +433,7 @@ describe('LocalModelAssetService', () => {
     })
 
     await service.startDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(encoderAttempts).toBe(2)
@@ -430,6 +493,7 @@ describe('LocalModelAssetService', () => {
     })
 
     await service.startDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForState(indexPath, (states) => states.some((entry) => entry.status === 'error'))
 
     const state = (await new LocalModelAssetStore({ indexPath }).readAll())[0]
@@ -500,6 +564,7 @@ describe('LocalModelAssetService', () => {
     })
 
     await service.startDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(metadataAttempts).toBe(2)
@@ -577,6 +642,7 @@ describe('LocalModelAssetService', () => {
     })
 
     await service.startDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(metadataAttempts).toBe(2)
@@ -656,6 +722,7 @@ describe('LocalModelAssetService', () => {
         )
       )
     )
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(encoderAttempts).toBe(2)
@@ -751,6 +818,7 @@ describe('LocalModelAssetService', () => {
     ])
 
     await service.resumeDownload('onnx-community/opus-mt-en-zh', 'q4')
+    await service.waitForModelTask('onnx-community/opus-mt-en-zh')
     await waitForDownloadedState(indexPath)
 
     expect(hubMock.downloadFile).toHaveBeenCalledTimes(2)

--- a/packages/server/src/local-model-asset-service.ts
+++ b/packages/server/src/local-model-asset-service.ts
@@ -132,6 +132,7 @@ export class LocalModelAssetService {
   private readonly networkRetryPolicy: Required<LocalModelNetworkRetryPolicy>
   private readonly listeners = new Set<LogListener>()
   private readonly sessions = new Map<string, DownloadSession>()
+  private readonly sessionTasks = new Map<string, Promise<void>>()
   private readonly logs = new Map<string, LocalModelAssetLog>()
   private transformersModulePromise: Promise<TransformersModule> | null = null
 
@@ -413,6 +414,18 @@ export class LocalModelAssetService {
       )
     }
     await this.store.writeAll(nextStates)
+  }
+
+  async waitForModelTask(modelId: string): Promise<void> {
+    await this.sessionTasks.get(modelId)
+  }
+
+  async close(): Promise<void> {
+    const sessions = [...this.sessions.values()]
+    for (const session of sessions) {
+      session.abortController.abort()
+    }
+    await Promise.allSettled(this.sessionTasks.values())
   }
 
   private async searchRemote(
@@ -706,15 +719,21 @@ export class LocalModelAssetService {
       files: nextState.files,
       updatedAt: this.now(),
     })
-    void this.performDownload(modelId, sessionId, abortController.signal, nextState).catch(
-      (error) =>
-        void this.finishDownload(
+    const task = this.performDownload(modelId, sessionId, abortController.signal, nextState)
+      .catch((error) =>
+        this.finishDownload(
           modelId,
           sessionId,
           false,
           error instanceof Error ? error.message : String(error)
         )
-    )
+      )
+      .finally(() => {
+        if (this.sessionTasks.get(modelId) === task) {
+          this.sessionTasks.delete(modelId)
+        }
+      })
+    this.sessionTasks.set(modelId, task)
     return { sessionId }
   }
 
@@ -1082,28 +1101,40 @@ async function downloadHuggingFaceFileToCacheDirWithProgress(input: {
       if (resumeBytes !== null && resumeBytes > 0) {
         await input.onProgress(Math.min(resumeBytes, totalBytes))
       }
-      const blob = await downloadFile({
-        repo: input.repo,
-        path: input.path,
-        revision,
-        hubUrl: input.hubUrl,
-        fetch: input.fetch,
-        downloadInfo: info,
-        xet: false,
-      })
-      if (!blob) {
-        throw new Error(`Invalid response for file ${input.path}.`)
-      }
-
-      const downloadBlob =
-        resumeBytes && resumeBytes > 0 ? blob.slice(resumeBytes, totalBytes) : blob
-      await appendBlobToIncompleteFile({
-        blob: downloadBlob,
+      const downloadedViaFetch = await streamDownloadToIncompleteFile({
+        url: info.url,
         incompletePath: cachePaths.incompletePath,
         startBytes: resumeBytes ?? 0,
         totalBytes,
+        accessToken: undefined,
+        fetch: input.fetch,
+        signal: input.signal,
         onProgress: input.onProgress,
       })
+      if (!downloadedViaFetch) {
+        const blob = await downloadFile({
+          repo: input.repo,
+          path: input.path,
+          revision,
+          hubUrl: input.hubUrl,
+          fetch: input.fetch,
+          downloadInfo: info,
+          xet: false,
+        })
+        if (!blob) {
+          throw new Error(`Invalid response for file ${input.path}.`)
+        }
+
+        const downloadBlob =
+          resumeBytes && resumeBytes > 0 ? blob.slice(resumeBytes, totalBytes) : blob
+        await appendBlobToIncompleteFile({
+          blob: downloadBlob,
+          incompletePath: cachePaths.incompletePath,
+          startBytes: resumeBytes ?? 0,
+          totalBytes,
+          onProgress: input.onProgress,
+        })
+      }
       await finalizeHubCacheFile(cachePaths)
       await input.onProgress(totalBytes)
       return cachePaths.pointerPath
@@ -1186,6 +1217,54 @@ async function appendBlobToIncompleteFile(input: {
     await reader.cancel().catch(() => undefined)
     await fileHandle.close()
   }
+}
+
+async function streamDownloadToIncompleteFile(input: {
+  url: string
+  incompletePath: string
+  startBytes: number
+  totalBytes: number
+  accessToken?: string
+  fetch: typeof fetch
+  signal: AbortSignal
+  onProgress: (downloadedBytes: number) => Promise<void>
+}): Promise<boolean> {
+  const headers = new Headers()
+  if (input.accessToken) {
+    headers.set('Authorization', `Bearer ${input.accessToken}`)
+  }
+  if (input.startBytes > 0) {
+    headers.set('Range', `bytes=${input.startBytes}-`)
+  }
+  const response = await input.fetch(input.url, {
+    method: 'GET',
+    headers,
+    signal: input.signal,
+  })
+  if (!response.ok && response.status !== 206) {
+    throw new Error(`Invalid response for file download: status ${response.status}.`)
+  }
+  if (!response.body) {
+    return false
+  }
+
+  await mkdir(dirname(input.incompletePath), { recursive: true })
+  const fileHandle = await open(input.incompletePath, input.startBytes > 0 ? 'a' : 'w')
+  const reader = response.body.getReader()
+  let downloadedBytes = input.startBytes
+  try {
+    while (true) {
+      const result = await reader.read()
+      if (result.done) break
+      await fileHandle.write(result.value)
+      downloadedBytes += result.value.byteLength
+      await input.onProgress(Math.min(downloadedBytes, input.totalBytes))
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined)
+    await fileHandle.close()
+  }
+  return true
 }
 
 async function finalizeHubCacheFile(input: {

--- a/packages/server/src/local-model-subscription-transport.test.ts
+++ b/packages/server/src/local-model-subscription-transport.test.ts
@@ -102,12 +102,7 @@ async function createIsolatedProjectDir(): Promise<{
     translationCacheDatabasePath: join(runtimeDir, 'translation-cache.sqlite'),
     localModelCacheDir: join(runtimeDir, 'translation-engines', 'local', 'hf-cache'),
     localModelAssetIndexPath: join(runtimeDir, 'translation-engines', 'local', 'models.json'),
-    localModelFetchCachePath: join(
-      runtimeDir,
-      'translation-engines',
-      'local',
-      'fetch-cache.json'
-    ),
+    localModelFetchCachePath: join(runtimeDir, 'translation-engines', 'local', 'fetch-cache.json'),
   }
   await writeFile(
     runtimePaths.globalSettingsPath,
@@ -217,12 +212,49 @@ describe('localModels.subscribeLogs transport', () => {
 
   it('streams byte-level download progress events to a real tRPC WebSocket client', async () => {
     coreMockState.initWatcherPool.mockResolvedValue(undefined)
-    hubMock.downloadFile.mockImplementation(async (input: { path: string }) =>
-      createMockDownloadBlob(
-        input.path === 'onnx/encoder_model_q4.onnx'
-          ? [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8, 9, 10])]
-          : [new Uint8Array(10)]
-      )
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+        if (url.includes('/api/models/') && url.includes('/tree/')) {
+          return Response.json([
+            { path: 'config.json', type: 'file', size: 10 },
+            { path: 'onnx/encoder_model_q4.onnx', type: 'file', size: 10 },
+            { path: 'onnx/decoder_model_merged_q4.onnx', type: 'file', size: 10 },
+          ])
+        }
+        if (url.includes('/resolve/main/onnx/encoder_model_q4.onnx')) {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                controller.enqueue(new Uint8Array([1, 2, 3, 4]))
+                await new Promise((resolve) => setTimeout(resolve, 20))
+                controller.enqueue(new Uint8Array([5, 6, 7, 8, 9, 10]))
+                controller.close()
+              },
+            }),
+            {
+              status: (init?.headers && new Headers(init.headers).get('Range') !== null
+                ? 206
+                : 200) as 200 | 206,
+              headers: {
+                'Content-Length': '10',
+                'Content-Range': 'bytes 0-9/10',
+              },
+            }
+          )
+        }
+        if (url.includes('/resolve/main/')) {
+          return new Response(new Uint8Array(10), {
+            status: 200,
+            headers: {
+              'Content-Length': '10',
+            },
+          })
+        }
+        return originalFetch(input, init)
+      })
     )
 
     const { projectDir, runtimePaths } = await createIsolatedProjectDir()
@@ -355,23 +387,56 @@ describe('localModels.subscribeLogs transport', () => {
   it('auto-resumes a retryable stream failure and keeps streaming progress events to the client', async () => {
     coreMockState.initWatcherPool.mockResolvedValue(undefined)
     let encoderAttempts = 0
-    hubMock.downloadFile.mockImplementation(async (input: { path: string }) => {
-      if (input.path === 'onnx/encoder_model_q4.onnx') {
-        encoderAttempts += 1
-        if (encoderAttempts === 1) {
-          return createMockDownloadBlobWithFailure({
-            chunks: [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8, 9, 10])],
-            failAfterChunkCount: 1,
-            error: new TypeError('fetch failed'),
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+        if (url.includes('/api/models/') && url.includes('/tree/')) {
+          return Response.json([
+            { path: 'config.json', type: 'file', size: 10 },
+            { path: 'onnx/encoder_model_q4.onnx', type: 'file', size: 10 },
+            { path: 'onnx/decoder_model_merged_q4.onnx', type: 'file', size: 10 },
+          ])
+        }
+        if (url.includes('/resolve/main/onnx/encoder_model_q4.onnx')) {
+          encoderAttempts += 1
+          const range = init?.headers ? new Headers(init.headers).get('Range') : null
+          if (encoderAttempts === 1) {
+            return new Response(
+              new ReadableStream<Uint8Array>({
+                start(controller) {
+                  controller.enqueue(new Uint8Array([1, 2, 3, 4]))
+                  controller.error(new TypeError('fetch failed'))
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  'Content-Length': '10',
+                },
+              }
+            )
+          }
+          return new Response(new Uint8Array([5, 6, 7, 8, 9, 10]), {
+            status: range ? 206 : 200,
+            headers: {
+              'Content-Length': '6',
+              'Content-Range': 'bytes 4-9/10',
+            },
           })
         }
-      }
-      return createMockDownloadBlob(
-        input.path === 'onnx/encoder_model_q4.onnx'
-          ? [new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8, 9, 10])]
-          : [new Uint8Array(10)]
-      )
-    })
+        if (url.includes('/resolve/main/')) {
+          return new Response(new Uint8Array(10), {
+            status: 200,
+            headers: {
+              'Content-Length': '10',
+            },
+          })
+        }
+        return originalFetch(input, init)
+      })
+    )
 
     const { projectDir, runtimePaths } = await createIsolatedProjectDir()
     const port = await findAvailablePort(34_710, 100)
@@ -434,17 +499,27 @@ describe('localModels.subscribeLogs transport', () => {
             bytesDownloaded: log.bytesDownloaded,
             progress: log.progress,
           })
-          const resumedMidStreamEvents = events.filter(
+          const sawRetryNotice = events.some(
+            (event) =>
+              event.message ===
+              'Connection interrupted while downloading onnx/encoder_model_q4.onnx. Retrying automatically in 500 ms.'
+          )
+          const sawResumedMidStreamEvent = events.some(
             (event) =>
               event.message === 'Downloading onnx/encoder_model_q4.onnx.' &&
-              event.bytesDownloaded === 14
+              typeof event.bytesDownloaded === 'number' &&
+              event.bytesDownloaded > 10 &&
+              event.bytesDownloaded < 20 &&
+              typeof event.progress === 'number' &&
+              event.progress > 0.33 &&
+              event.progress < 0.67
           )
           const sawCompleted = events.some(
             (event) =>
               event.status === 'downloaded' &&
               event.message === 'Local model onnx-community/opus-mt-en-zh is ready.'
           )
-          if (resumedMidStreamEvents.length >= 2 && sawCompleted) {
+          if (sawRetryNotice && sawResumedMidStreamEvent && sawCompleted) {
             subscription.unsubscribe()
             resolve(events)
           }
@@ -464,16 +539,27 @@ describe('localModels.subscribeLogs transport', () => {
 
     const events = await withTimeout(receivedLogs, 'resumed download progress logs')
     expect(encoderAttempts).toBe(2)
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: 'downloading',
+          message:
+            'Connection interrupted while downloading onnx/encoder_model_q4.onnx. Retrying automatically in 500 ms.',
+        }),
+      ])
+    )
     expect(
-      events.filter(
+      events.some(
         (event) =>
           event.message === 'Downloading onnx/encoder_model_q4.onnx.' &&
-          event.bytesDownloaded === 14 &&
+          event.bytesDownloaded !== undefined &&
+          event.bytesDownloaded > 10 &&
+          event.bytesDownloaded < 20 &&
           event.progress !== undefined &&
-          event.progress > 0.4 &&
-          event.progress < 0.5
+          event.progress > 0.33 &&
+          event.progress < 0.67
       )
-    ).toHaveLength(2)
+    ).toBe(true)
     expect(events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -486,79 +572,3 @@ describe('localModels.subscribeLogs transport', () => {
     )
   })
 })
-
-function createMockDownloadBlob(chunks: Uint8Array[]): Blob {
-  return new MockDownloadBlob(chunks)
-}
-
-function createMockDownloadBlobWithFailure(input: {
-  chunks: Uint8Array[]
-  failAfterChunkCount: number
-  error: Error
-}): Blob {
-  return new MockDownloadBlob(input.chunks, {
-    failAfterChunkCount: input.failAfterChunkCount,
-    error: input.error,
-  })
-}
-
-class MockDownloadBlob extends Blob {
-  constructor(
-    private readonly chunks: Uint8Array[],
-    private readonly options?: {
-      failAfterChunkCount?: number
-      error?: Error
-    }
-  ) {
-    super([])
-  }
-
-  override get size(): number {
-    return this.chunks.reduce((total, chunk) => total + chunk.byteLength, 0)
-  }
-
-  override slice(start = 0, end = this.size): Blob {
-    return new MockDownloadBlob(sliceChunks(this.chunks, start, end))
-  }
-
-  override stream(): ReadableStream<Uint8Array> {
-    const chunks = this.chunks.map((chunk) => chunk.slice())
-    const failAfterChunkCount = this.options?.failAfterChunkCount
-    const error = this.options?.error ?? new Error('Mock download failed.')
-    let chunkIndex = 0
-    return new ReadableStream<Uint8Array>({
-      async pull(controller) {
-        if (failAfterChunkCount !== undefined && chunkIndex >= failAfterChunkCount) {
-          controller.error(error)
-          return
-        }
-        const chunk = chunks[chunkIndex]
-        if (!chunk) {
-          controller.close()
-          return
-        }
-        chunkIndex += 1
-        if (chunkIndex > 1) {
-          await new Promise((resolve) => setTimeout(resolve, 20))
-        }
-        controller.enqueue(chunk)
-      },
-    })
-  }
-}
-
-function sliceChunks(chunks: ReadonlyArray<Uint8Array>, start: number, end: number): Uint8Array[] {
-  const next: Uint8Array[] = []
-  let offset = 0
-  for (const chunk of chunks) {
-    const chunkStart = offset
-    const chunkEnd = offset + chunk.byteLength
-    offset = chunkEnd
-    if (end <= chunkStart || start >= chunkEnd) continue
-    const from = Math.max(0, start - chunkStart)
-    const to = Math.min(chunk.byteLength, end - chunkStart)
-    if (from >= to) continue
-    next.push(chunk.slice(from, to))
-  }
-  return next
-}

--- a/packages/server/src/local-model-subscription-transport.test.ts
+++ b/packages/server/src/local-model-subscription-transport.test.ts
@@ -1,5 +1,5 @@
 import { createTRPCClient, createWSClient, httpBatchLink, wsLink } from '@trpc/client'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -56,7 +56,6 @@ import { startServer, type AppRouter, type RunningServer } from './server.js'
 const runningServers: RunningServer[] = []
 const tempDirs: string[] = []
 const wsClients: Array<ReturnType<typeof createWSClient>> = []
-const originalHome = process.env.HOME
 const originalFetch = globalThis.fetch
 
 beforeEach(() => {
@@ -86,22 +85,44 @@ beforeEach(() => {
 afterEach(async () => {
   await Promise.all(wsClients.splice(0).map((client) => client.close()))
   await Promise.all(runningServers.splice(0).map((server) => server.close()))
-  if (originalHome === undefined) {
-    delete process.env.HOME
-  } else {
-    process.env.HOME = originalHome
-  }
-  await Promise.all(tempDirs.splice(0).map((dir) => removeDirWithRetry(dir)))
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
   vi.unstubAllGlobals()
   vi.clearAllMocks()
 })
 
-async function createIsolatedProjectDir(): Promise<string> {
-  const homeDir = await mkdtemp(join(tmpdir(), 'openspecui-subscription-home-'))
+async function createIsolatedProjectDir(): Promise<{
+  projectDir: string
+  runtimePaths: NonNullable<Parameters<typeof startServer>[0]['runtimePaths']>
+}> {
+  const runtimeDir = await mkdtemp(join(tmpdir(), 'openspecui-subscription-runtime-'))
   const projectDir = await mkdtemp(join(tmpdir(), 'openspecui-subscription-project-'))
-  tempDirs.push(homeDir, projectDir)
-  process.env.HOME = homeDir
-  return projectDir
+  tempDirs.push(runtimeDir, projectDir)
+  const runtimePaths = {
+    globalSettingsPath: join(runtimeDir, 'settings.json'),
+    translationCacheDatabasePath: join(runtimeDir, 'translation-cache.sqlite'),
+    localModelCacheDir: join(runtimeDir, 'translation-engines', 'local', 'hf-cache'),
+    localModelAssetIndexPath: join(runtimeDir, 'translation-engines', 'local', 'models.json'),
+    localModelFetchCachePath: join(
+      runtimeDir,
+      'translation-engines',
+      'local',
+      'fetch-cache.json'
+    ),
+  }
+  await writeFile(
+    runtimePaths.globalSettingsPath,
+    JSON.stringify({
+      translationEngines: {
+        local: {
+          model: 'onnx-community/opus-mt-en-zh',
+          selectedGroupId: 'q4',
+          hfEndpoint: 'https://hf-mirror.com/',
+        },
+      },
+    }),
+    'utf8'
+  )
+  return { projectDir, runtimePaths }
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = 5_000): Promise<T> {
@@ -120,32 +141,12 @@ function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = 5_000): 
   })
 }
 
-async function removeDirWithRetry(dir: string, attempts = 5): Promise<void> {
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    try {
-      await rm(dir, { recursive: true, force: true })
-      return
-    } catch (error) {
-      if (!isRetryableDirCleanupError(error) || attempt === attempts - 1) {
-        throw error
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)))
-    }
-  }
-}
-
-function isRetryableDirCleanupError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  const code = 'code' in error ? error.code : undefined
-  return code === 'EBUSY' || code === 'ENOTEMPTY' || code === 'EPERM'
-}
-
 describe('localModels.subscribeLogs transport', () => {
   it('streams sequential delete lifecycle events to a real tRPC WebSocket client', async () => {
     coreMockState.initWatcherPool.mockResolvedValue(undefined)
-    const projectDir = await createIsolatedProjectDir()
+    const { projectDir, runtimePaths } = await createIsolatedProjectDir()
     const port = await findAvailablePort(34_600, 100)
-    const server = await startServer({ projectDir, port, enableWatcher: false })
+    const server = await startServer({ projectDir, port, enableWatcher: false, runtimePaths })
     runningServers.push(server)
 
     const wsClient = createWSClient({
@@ -224,9 +225,9 @@ describe('localModels.subscribeLogs transport', () => {
       )
     )
 
-    const projectDir = await createIsolatedProjectDir()
+    const { projectDir, runtimePaths } = await createIsolatedProjectDir()
     const port = await findAvailablePort(34_700, 100)
-    const server = await startServer({ projectDir, port, enableWatcher: false })
+    const server = await startServer({ projectDir, port, enableWatcher: false, runtimePaths })
     runningServers.push(server)
 
     const wsClient = createWSClient({
@@ -372,9 +373,9 @@ describe('localModels.subscribeLogs transport', () => {
       )
     })
 
-    const projectDir = await createIsolatedProjectDir()
+    const { projectDir, runtimePaths } = await createIsolatedProjectDir()
     const port = await findAvailablePort(34_710, 100)
-    const server = await startServer({ projectDir, port, enableWatcher: false })
+    const server = await startServer({ projectDir, port, enableWatcher: false, runtimePaths })
     runningServers.push(server)
 
     const wsClient = createWSClient({

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -54,7 +54,11 @@ import { DocumentService } from './document-service.js'
 import { buildEntityReadOptions } from './entity-read-options.js'
 import { createHookRuntime } from './hook-runtime.js'
 import { LocalModelAssetService } from './local-model-asset-service.js'
-import { getDefaultLocalModelCacheDir, getDefaultLocalModelIndexPath } from './local-model-cache-path.js'
+import {
+  getDefaultLocalModelCacheDir,
+  getDefaultLocalModelFetchCachePath,
+  getDefaultLocalModelIndexPath,
+} from './local-model-cache-path.js'
 import { NotificationService } from './notification-service.js'
 import { findAvailablePort } from './port-utils.js'
 import { ProjectRecoveryService } from './project-recovery-service.js'
@@ -96,6 +100,14 @@ export interface ServerConfig {
   corsOrigins?: string[]
   /** Optional worktree handoff provider for runtimes that can spawn sibling instances */
   gitWorktreeHandoff?: GitWorktreeHandoffService
+  /** Optional path overrides for isolated runtimes and tests */
+  runtimePaths?: {
+    globalSettingsPath?: string
+    translationCacheDatabasePath?: string
+    localModelCacheDir?: string
+    localModelAssetIndexPath?: string
+    localModelFetchCachePath?: string
+  }
 }
 
 /**
@@ -104,7 +116,7 @@ export interface ServerConfig {
 export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
   const adapter = new OpenSpecAdapter(config.projectDir)
   const configManager = new ConfigManager(config.projectDir)
-  const globalSettingsManager = new GlobalSettingsManager()
+  const globalSettingsManager = new GlobalSettingsManager(config.runtimePaths?.globalSettingsPath)
   const cliExecutor = new CliExecutor(configManager, config.projectDir)
   const kernel = config.kernel
   const hookRuntime = createHookRuntime(config.projectDir)
@@ -116,20 +128,21 @@ export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
   })
   const notificationService = new NotificationService()
   const customSoundService = new CustomSoundService()
+  const translationCacheDatabasePath =
+    config.runtimePaths?.translationCacheDatabasePath ?? getDefaultTranslationCacheDatabasePath()
   let translationCacheAdapterPromise: ReturnType<
     typeof createRuntimeSqliteTranslationCacheAdapter
   > | null = null
   const getTranslationCacheAdapter = () => {
-    translationCacheAdapterPromise ??= createRuntimeSqliteTranslationCacheAdapter(
-      getDefaultTranslationCacheDatabasePath()
-    )
+    translationCacheAdapterPromise ??=
+      createRuntimeSqliteTranslationCacheAdapter(translationCacheDatabasePath)
     return translationCacheAdapterPromise
   }
   const translationCacheService = new TranslationCacheService({
     configManager,
     globalSettingsManager,
     adapter: {
-      databasePath: getDefaultTranslationCacheDatabasePath(),
+      databasePath: translationCacheDatabasePath,
       init: async () => (await getTranslationCacheAdapter()).init(),
       read: async (keyHash, now) => (await getTranslationCacheAdapter()).read(keyHash, now),
       write: async (input, now) => (await getTranslationCacheAdapter()).write(input, now),
@@ -146,14 +159,19 @@ export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
       console.warn('Translation cache write failed:', error)
     },
   })
-  const nmtModelCacheDir = getDefaultLocalModelCacheDir()
-  const nmtModelIndexPath = getDefaultLocalModelIndexPath()
+  const nmtModelCacheDir =
+    config.runtimePaths?.localModelCacheDir ?? getDefaultLocalModelCacheDir()
+  const nmtModelIndexPath =
+    config.runtimePaths?.localModelAssetIndexPath ?? getDefaultLocalModelIndexPath()
+  const nmtModelFetchCachePath =
+    config.runtimePaths?.localModelFetchCachePath ?? getDefaultLocalModelFetchCachePath()
   const translationEngineService = new TranslationEngineService({
     projectDir: config.projectDir,
     configManager,
     globalSettingsManager,
     localCacheDir: nmtModelCacheDir,
     localAssetIndexPath: nmtModelIndexPath,
+    localFetchCachePath: nmtModelFetchCachePath,
   })
   const localModelAssetService = new LocalModelAssetService({
     projectDir: config.projectDir,
@@ -161,6 +179,7 @@ export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
     globalSettingsManager,
     cacheDir: nmtModelCacheDir,
     indexPath: nmtModelIndexPath,
+    fetchCachePath: nmtModelFetchCachePath,
   })
 
   // Create file watcher if enabled

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -134,8 +134,9 @@ export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
     typeof createRuntimeSqliteTranslationCacheAdapter
   > | null = null
   const getTranslationCacheAdapter = () => {
-    translationCacheAdapterPromise ??=
-      createRuntimeSqliteTranslationCacheAdapter(translationCacheDatabasePath)
+    translationCacheAdapterPromise ??= createRuntimeSqliteTranslationCacheAdapter(
+      translationCacheDatabasePath
+    )
     return translationCacheAdapterPromise
   }
   const translationCacheService = new TranslationCacheService({
@@ -159,8 +160,7 @@ export function createServer(config: ServerConfig & { kernel: OpsxKernel }) {
       console.warn('Translation cache write failed:', error)
     },
   })
-  const nmtModelCacheDir =
-    config.runtimePaths?.localModelCacheDir ?? getDefaultLocalModelCacheDir()
+  const nmtModelCacheDir = config.runtimePaths?.localModelCacheDir ?? getDefaultLocalModelCacheDir()
   const nmtModelIndexPath =
     config.runtimePaths?.localModelAssetIndexPath ?? getDefaultLocalModelIndexPath()
   const nmtModelFetchCachePath =
@@ -516,6 +516,7 @@ export async function startServer(
     close: async () => {
       kernel.dispose()
       await server.hookRuntime.dispose()
+      await server.createContext().localModelAssetService.close()
       server.translationCacheService.close()
       wsServer.close()
       httpServer.close()


### PR DESCRIPTION
## Summary
- stream Local-Transformers downloads from the real fetch body instead of waiting for blob completion
- preserve Range-based resume semantics and wait for in-flight download tasks during server shutdown
- add a minor changeset for `@openspecui/server`

## Verification
- `pnpm format:check`
- `pnpm lint:ci`
- `pnpm --filter @openspecui/server typecheck`
- `pnpm --filter @openspecui/web typecheck`
- `pnpm --filter @openspecui/server exec vitest run src/local-model-asset-service.test.ts src/local-model-subscription-transport.test.ts`
- `pnpm --filter @openspecui/web exec vitest run src/routes/settings.test.tsx --project unit --testTimeout 20000`

## Release note
- changeset is `minor` only; no major version bump
