### PR TITLE
fix(release): normalize published workspace manifests

### DIFF
--- a/.changeset/five-shirts-confess.md
+++ b/.changeset/five-shirts-confess.md
@@ -1,0 +1,6 @@
+---
+'@openspecui/server': minor
+'@openspecui/web': minor
+---
+
+Fix published package staging so public workspace dependencies are rewritten to concrete versions and private translator packages are removed from npm manifests. The server package now bundles its private translator runtime modules so `@openspecui/server` can be installed from npm without unresolved private workspace dependencies.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --no-dts",
+    "build": "tsdown",
     "typecheck": "tsc -p tsconfig.check.json --noEmit",
     "dev": "NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--conditions=development\" tsx watch --include '../core/dist/**' --include '../search/dist/**' src/standalone.ts",
     "test": "vitest run",

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+const bundledPrivateTranslatorPackages = [
+  '@openspecui/local-translator',
+  '@openspecui/openai-completion-translator',
+]
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  dts: false,
+  noExternal: bundledPrivateTranslatorPackages,
+})

--- a/scripts/lib/publish-packages/repository.test.ts
+++ b/scripts/lib/publish-packages/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -70,5 +70,71 @@ describe('preparePublishDirectory', () => {
     expect(prepared.dir).toBe(sourceDir)
     prepared.cleanup()
     rmSync(sourceDir, { force: true, recursive: true })
+  })
+
+  it('replaces publishable workspace ranges and removes private workspace dependencies', () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), 'openspecui-publish-root-'))
+    const packagesDir = join(workspaceRoot, 'packages')
+    const coreDir = join(packagesDir, 'core')
+    const privateDir = join(packagesDir, 'local-translator')
+    const serverDir = join(packagesDir, 'server')
+    for (const dir of [packagesDir, coreDir, privateDir, serverDir]) {
+      mkdirSync(dir, { recursive: true })
+    }
+
+    writeFileSync(
+      join(coreDir, 'package.json'),
+      JSON.stringify({ name: '@openspecui/core', version: '3.9.1' }, null, 2)
+    )
+    writeFileSync(
+      join(privateDir, 'package.json'),
+      JSON.stringify(
+        { name: '@openspecui/local-translator', version: '3.9.1', private: true },
+        null,
+        2
+      )
+    )
+    writeFileSync(
+      join(serverDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: '@openspecui/server',
+          version: '3.9.1',
+          dependencies: {
+            '@openspecui/core': 'workspace:*',
+            '@openspecui/local-translator': 'workspace:*',
+            hono: '^4.7.3',
+          },
+          devDependencies: {
+            '@openspecui/core': 'workspace:*',
+            vitest: '^4.1.0',
+          },
+        },
+        null,
+        2
+      )
+    )
+
+    const prepared = preparePublishDirectory(
+      serverDir,
+      'https://github.com/jixoai/openspecui',
+      workspaceRoot
+    )
+    const stagedManifest = JSON.parse(readFileSync(join(prepared.dir, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+
+    expect(stagedManifest.dependencies).toEqual({
+      '@openspecui/core': '3.9.1',
+      hono: '^4.7.3',
+    })
+    expect(stagedManifest.devDependencies).toEqual({
+      '@openspecui/core': '3.9.1',
+      vitest: '^4.1.0',
+    })
+
+    prepared.cleanup()
+    rmSync(workspaceRoot, { force: true, recursive: true })
   })
 })

--- a/scripts/lib/publish-packages/repository.ts
+++ b/scripts/lib/publish-packages/repository.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -18,7 +18,14 @@ export type PreparedPublishDirectory = {
 }
 
 type PackageManifest = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  private?: boolean
+  name?: string
   repository?: RepositoryValue
+  version?: string
 }
 
 function readManifest(packageDir: string): PackageManifest {
@@ -27,6 +34,79 @@ function readManifest(packageDir: string): PackageManifest {
 
 function writeManifest(packageDir: string, manifest: PackageManifest): void {
   writeFileSync(join(packageDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+function serializeManifest(manifest: PackageManifest): string {
+  return JSON.stringify(manifest, null, 2)
+}
+
+type WorkspacePackageInfo = {
+  name: string
+  private: boolean
+  version: string
+}
+
+function readWorkspacePackages(rootDir: string): Map<string, WorkspacePackageInfo> {
+  const packagesDir = join(rootDir, 'packages')
+  let entries: ReturnType<typeof readdirSync>
+  try {
+    entries = readdirSync(packagesDir, { withFileTypes: true })
+  } catch {
+    return new Map()
+  }
+
+  const packages = new Map<string, WorkspacePackageInfo>()
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const manifestPath = join(packagesDir, entry.name, 'package.json')
+    let manifest: PackageManifest
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as PackageManifest
+    } catch {
+      continue
+    }
+    if (!manifest.name || !manifest.version) continue
+    packages.set(manifest.name, {
+      name: manifest.name,
+      private: manifest.private === true,
+      version: manifest.version,
+    })
+  }
+  return packages
+}
+
+function normalizeDependencyGroup(
+  dependencies: Record<string, string> | undefined,
+  workspacePackages: ReadonlyMap<string, WorkspacePackageInfo>
+): Record<string, string> | undefined {
+  if (!dependencies) return undefined
+  const normalizedEntries = Object.entries(dependencies).flatMap(([name, range]) => {
+    const workspacePackage = workspacePackages.get(name)
+    if (!workspacePackage) return [[name, range] as const]
+    if (workspacePackage.private) return []
+    if (range.startsWith('workspace:')) {
+      return [[name, workspacePackage.version] as const]
+    }
+    return [[name, range] as const]
+  })
+  if (normalizedEntries.length === 0) return undefined
+  return Object.fromEntries(normalizedEntries)
+}
+
+function normalizeManifestDependencies(
+  manifest: PackageManifest,
+  workspacePackages: ReadonlyMap<string, WorkspacePackageInfo>
+): PackageManifest {
+  return {
+    ...manifest,
+    dependencies: normalizeDependencyGroup(manifest.dependencies, workspacePackages),
+    devDependencies: normalizeDependencyGroup(manifest.devDependencies, workspacePackages),
+    optionalDependencies: normalizeDependencyGroup(
+      manifest.optionalDependencies,
+      workspacePackages
+    ),
+    peerDependencies: normalizeDependencyGroup(manifest.peerDependencies, workspacePackages),
+  }
 }
 
 function currentRepositoryUrl(repository: RepositoryValue): string | null {
@@ -86,17 +166,19 @@ export function resolveRepositoryUrl(
 
 export function preparePublishDirectory(
   sourceDir: string,
-  repositoryUrl: string | null
+  repositoryUrl: string | null,
+  workspaceRoot: string = process.cwd()
 ): PreparedPublishDirectory {
-  if (!repositoryUrl) {
-    return {
-      cleanup: () => {},
-      dir: sourceDir,
-    }
-  }
+  const workspacePackages = readWorkspacePackages(workspaceRoot)
+  const sourceManifest = readManifest(sourceDir)
+  const normalizedManifest = normalizeManifestDependencies(sourceManifest, workspacePackages)
+  const shouldInjectRepository =
+    !!repositoryUrl && !currentRepositoryUrl(normalizedManifest.repository)
+  const manifestChanged =
+    serializeManifest(sourceManifest) !== serializeManifest(normalizedManifest) ||
+    shouldInjectRepository
 
-  const manifest = readManifest(sourceDir)
-  if (currentRepositoryUrl(manifest.repository)) {
+  if (!manifestChanged) {
     return {
       cleanup: () => {},
       dir: sourceDir,
@@ -106,16 +188,18 @@ export function preparePublishDirectory(
   const stagedDir = mkdtempSync(join(tmpdir(), 'openspecui-publish-'))
   cpSync(sourceDir, stagedDir, { recursive: true })
 
-  const stagedManifest = readManifest(stagedDir)
-  const repository =
-    stagedManifest.repository && typeof stagedManifest.repository === 'object'
-      ? stagedManifest.repository
-      : {}
-  stagedManifest.repository = {
-    ...repository,
-    type:
-      typeof repository.type === 'string' && repository.type.length > 0 ? repository.type : 'git',
-    url: repositoryUrl,
+  const stagedManifest = normalizeManifestDependencies(readManifest(stagedDir), workspacePackages)
+  if (shouldInjectRepository && repositoryUrl) {
+    const repository =
+      stagedManifest.repository && typeof stagedManifest.repository === 'object'
+        ? stagedManifest.repository
+        : {}
+    stagedManifest.repository = {
+      ...repository,
+      type:
+        typeof repository.type === 'string' && repository.type.length > 0 ? repository.type : 'git',
+      url: repositoryUrl,
+    }
   }
   writeManifest(stagedDir, stagedManifest)
 


### PR DESCRIPTION
## Summary
- normalize staged publish manifests so public workspace dependencies become concrete versions
- remove private workspace packages from published npm manifests
- bundle the private translator runtime modules into `@openspecui/server` so the published server package no longer imports private workspace packages at runtime
- add a minor changeset for the repaired public package publish contract

## Why
The previous `3.9.0` release workflow succeeded, but npm-installed verification exposed a real release defect:
- `@openspecui/server@3.9.0` could not be installed from npm because its published manifest still contained `workspace:*` dependencies and private translator package references

This PR fixes the publish staging law instead of patching around the failed install.

## Verification
- `pnpm format:check`
- `pnpm lint:ci`
- `node node_modules/.pnpm/vitest@4.1.0_@types+node@22.19.1_@vitest+browser-playwright@4.1.0_jsdom@25.0.1_msw@2.12_e87339b96df9a6f1827575e4eef7461c/node_modules/vitest/vitest.mjs run scripts/lib/publish-packages/repository.test.ts scripts/lib/publish-packages/workspace.test.ts`
- `pnpm --filter @openspecui/server build`
- `node -e "import('./packages/server/dist/index.mjs').then(()=>console.log('server dist import ok')).catch((err)=>{console.error(err);process.exit(1)})"`
- tarball smoke through real publish staging:
  - stage with `preparePublishDirectory()`
  - `npm pack <staged-server-dir>`
  - `pnpm add ../openspecui-server-3.9.0.tgz`
  - `import('@openspecui/server')`

## Scope note
This PR is release/publish-contract work. I ran the publish-specific tests plus server build/runtime verification instead of the full browser matrix locally.
