### PR TITLE
fix(release): restore file preview changeset frontmatter

### DIFF
--- a/.changeset/file-preview-platform.md
+++ b/.changeset/file-preview-platform.md
@@ -1,6 +1,8 @@
-"@openspecui/core": minor
-"@openspecui/server": minor
-"@openspecui/web": minor
-"openspecui": minor
+---
+'@openspecui/core': minor
+'@openspecui/server': minor
+'@openspecui/web': minor
+'openspecui': minor
+---
 
 Add backend-backed folder file preview, edit, and dedicated HTML preview entries for changes and archives.


### PR DESCRIPTION
## Summary
- restore the missing changeset frontmatter delimiters for file-preview-platform
- unblock changeset parsing so changeversion can produce the 3.11.0 release PR

## Verification
- pnpm exec changeset status
- pnpm format:check