### PR TITLE
fix(ci): provide gh token for release notes sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,6 @@ jobs:
         run: git push --follow-tags
 
       - name: Sync GitHub Release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: pnpm release:github


### PR DESCRIPTION
## Summary
- pass \ to the release notes sync step so \Manage releases

USAGE
  gh release <command> [flags]

GENERAL COMMANDS
  create:        Create a new release
  list:          List releases in a repository

TARGETED COMMANDS
  delete:        Delete a release
  delete-asset:  Delete an asset from a release
  download:      Download release assets
  edit:          Edit a release
  upload:        Upload assets to a release
  verify:        Verify the attestation for a release
  verify-asset:  Verify that a given asset originated from a release
  view:          View information about a release

FLAGS
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

INHERITED FLAGS
  --help   Show help for command

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` works inside Actions
- keep the change scoped to release automation only

## Verification
- \
> openspecui-monorepo@0.0.0 format:check /Users/kzf/Dev/GitHub/jixoai-labs/openspecui
> tsx scripts/format-check.ts

[format:check] No changed files require Prettier check.
- \Checking formatting...
All matched files use Prettier code style!
- \
> openspecui-monorepo@0.0.0 release:github /Users/kzf/Dev/GitHub/jixoai-labs/openspecui
> bun ./scripts/create-github-release.ts

[release] updating GitHub release openspecui@3.11.1
https://github.com/jixoai/openspecui/releases/tag/openspecui%403.11.1