### PR TITLE
fix(translation): harden CT2 loading and segment guards

### DIFF
--- a/.changeset/tiny-camels-smile.md
+++ b/.changeset/tiny-camels-smile.md
@@ -1,0 +1,6 @@
+---
+'openspecui': patch
+'@openspecui/web': patch
+---
+
+Keep the CT2 model download card in a loading state while artifact profiles are still resolving, and ignore malformed translation segments before rendering translated Markdown.

--- a/packages/web/src/components/document-translation-action.test.tsx
+++ b/packages/web/src/components/document-translation-action.test.tsx
@@ -1263,6 +1263,52 @@ The system SHALL detect static rendering mode.
     expect(screen.queryByText('undefined')).toBeNull()
   })
 
+  it('ignores malformed translation segments that would otherwise override a valid heading patch', async () => {
+    translateMarkdownDocumentProgressivelyMock.mockImplementationOnce(async () => ({
+      displayMode: 'direct',
+      sourceLanguage: 'en',
+      targetLanguage: 'zh',
+      segments: [
+        {
+          id: 'valid-heading',
+          sourceStartOffset: 0,
+          sourceEndOffset: 7,
+          sourceKind: 'heading',
+          source: 'Hello',
+          translatorInput: 'Hello',
+          target: '你好',
+          kind: 'heading',
+          sourceLanguage: 'en',
+          targetLanguage: 'zh',
+          status: 'translated',
+        },
+        {
+          id: 'broken-heading',
+          sourceStartOffset: 0,
+          target: '损坏结果',
+          kind: 'heading',
+        },
+      ] as never,
+    }))
+
+    render(
+      <MarkdownViewer
+        markdown={'# Hello'}
+        translationConfig={{
+          enabled: true,
+          targetLanguage: 'zh',
+          displayMode: 'direct',
+          cacheEnabled: false,
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Translate' }))
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: '你好' })).toBeTruthy())
+    expect(screen.queryByRole('heading', { name: '损坏结果' })).toBeNull()
+  })
+
   it('rejects stale late patches after the markdown generation changes', async () => {
     let emitStalePatch: (() => void) | undefined
     let releaseStaleResult: (() => void) | undefined

--- a/packages/web/src/lib/browser-translation.ts
+++ b/packages/web/src/lib/browser-translation.ts
@@ -105,8 +105,40 @@ export interface DocumentTranslationProgressPatch {
   segment: TranslationSegment
 }
 
+function isFiniteTranslationOffset(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function isTranslationSegmentKind(value: unknown): value is TranslationSegment['kind'] {
+  return (
+    value === 'heading' ||
+    value === 'listItem' ||
+    value === 'paragraph' ||
+    value === 'blockquote' ||
+    value === 'text'
+  )
+}
+
 export function isRenderableTranslationSegment(segment: unknown): segment is TranslationSegment {
-  return typeof segment === 'object' && segment !== null && !Array.isArray(segment)
+  if (typeof segment !== 'object' || segment === null || Array.isArray(segment)) return false
+
+  const id = Reflect.get(segment, 'id')
+  const sourceStartOffset = Reflect.get(segment, 'sourceStartOffset')
+  const sourceEndOffset = Reflect.get(segment, 'sourceEndOffset')
+  const sourceKind = Reflect.get(segment, 'sourceKind')
+  const source = Reflect.get(segment, 'source')
+  const translatorInput = Reflect.get(segment, 'translatorInput')
+  const kind = Reflect.get(segment, 'kind')
+
+  return (
+    typeof id === 'string' &&
+    isFiniteTranslationOffset(sourceStartOffset) &&
+    isFiniteTranslationOffset(sourceEndOffset) &&
+    typeof sourceKind === 'string' &&
+    typeof source === 'string' &&
+    typeof translatorInput === 'string' &&
+    isTranslationSegmentKind(kind)
+  )
 }
 
 interface PendingTranslationJob {

--- a/packages/web/src/lib/use-document-translation.ts
+++ b/packages/web/src/lib/use-document-translation.ts
@@ -1,6 +1,7 @@
 import type { DocumentTranslationConfig } from '@openspecui/core/document-translation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
+  isRenderableTranslationSegment,
   translateMarkdownDocumentProgressively,
   type BrowserTranslationStatus,
   type BrowserTranslationSupportTableState,
@@ -303,7 +304,7 @@ export function useDocumentTranslation(
 function isDocumentTranslationSegment(
   segment: unknown
 ): segment is NonNullable<DocumentTranslationResult['segments'][number]> {
-  return typeof segment === 'object' && segment !== null && !Array.isArray(segment)
+  return isRenderableTranslationSegment(segment)
 }
 
 function getDocumentTranslationFailureMessage(result: DocumentTranslationResult): string | null {

--- a/packages/web/src/routes/settings-translation-panel.tsx
+++ b/packages/web/src/routes/settings-translation-panel.tsx
@@ -2836,7 +2836,7 @@ function LocalDownloadFilesCard({
     state?.profileLoad?.status === 'loading'
       ? (state.profileLoad.message ?? 'Loading model files…')
       : null
-  const isResolving = loading && !plan && displayFiles.length === 0
+  const isResolving = displayFiles.length === 0 && (loading || profileLoadMessage !== null)
 
   return (
     <div className="space-y-3">

--- a/packages/web/src/routes/settings.test.tsx
+++ b/packages/web/src/routes/settings.test.tsx
@@ -3574,6 +3574,72 @@ describe('Settings', () => {
     expect(screen.queryByText('model.bin')).toBeNull()
   })
 
+  it('keeps the CT2 download card in loading state when artifact refresh has only produced an empty plan shell', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }))
+    )
+    const modelId = 'ooeoeo/opus-mt-en-zh-ct2-float16'
+    const emptyPlan: TranslationModelDownloadPlan = {
+      modelId,
+      estimatedTotalBytes: 0,
+      selectedGroupId: 'float16',
+      files: [],
+      groups: [],
+    }
+    localCt2ModelsMock.panelState.mockResolvedValue({
+      modelId,
+      selectedGroupId: 'float16',
+      asset: createLocalAssetStateForTest({
+        modelId,
+        status: 'not-downloaded',
+        selected: true,
+        selectedGroupId: 'float16',
+        progress: 0,
+        resumable: false,
+        plan: emptyPlan,
+        files: [],
+        profileLoad: {
+          status: 'loading',
+          message: 'Loading CT2 model artifacts.',
+          updatedAt: 101,
+        },
+        updatedAt: 101,
+      }),
+      downloadPlan: emptyPlan,
+    })
+    useConfigSubscriptionMock.mockReturnValue({
+      data: {
+        translation: {
+          enabled: true,
+          targetLanguage: 'zh',
+          displayMode: 'direct',
+          cacheEnabled: false,
+          engineId: 'local-ct2',
+          engines: {
+            local: {},
+            localCt2: {
+              model: modelId,
+              selectedGroupId: 'float16',
+            },
+            openai: {},
+          },
+        },
+      },
+    })
+    useServerStatusMock.mockReturnValue({ projectDir: '/tmp/project' })
+
+    render(<Settings />)
+
+    await waitFor(() => expect(screen.queryByText('Loading settings...')).toBeNull())
+    expect(await screen.findByText('Loading CT2 model artifacts.')).toBeTruthy()
+    expect(screen.queryByText('No runtime download plan available.')).toBeNull()
+  })
+
   it('does not refresh remote Local model profiles on initial mount when local profiles exist', async () => {
     vi.stubGlobal(
       'matchMedia',


### PR DESCRIPTION
## Summary
- keep the CT2 download card in a loading state while artifact profiles are still resolving, even if the server has already materialized an empty plan shell
- tighten translation segment validation so malformed objects are ignored before they can override valid rendered content
- add a patch changeset for `openspecui` and `@openspecui/web`

## Verification
- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm --filter @openspecui/web test:browser:ci