### PR TITLE
fix: make local transformers runtime on-demand

### DIFF
--- a/.changeset/quiet-ravens-fix-on-demand-runtime.md
+++ b/.changeset/quiet-ravens-fix-on-demand-runtime.md
@@ -1,0 +1,7 @@
+---
+'openspecui': patch
+'@openspecui/server': patch
+'@openspecui/local-translator': patch
+---
+
+Stop preinstalling the Local-Transformers runtime at startup. The runtime is now installed only when the translation settings panel asks for it, so the default install graph no longer pulls in `@huggingface/transformers` or `onnxruntime-node` unless the user opts into that engine.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,10 +38,9 @@
     "@parcel/watcher": "^2.5.1",
     "better-sqlite3": "^12.5.0"
   },
-  "// runtime-note": "The published openspecui package is the production runtime host for heavyweight translation runtimes.",
-  "// bundle-note": "tsdown keeps translator package runtime imports external, so these optionalDependencies are the source of truth for install detection and on-demand installation even though the adapter packages themselves are bundled.",
+  "// runtime-note": "The published openspecui package installs heavyweight translation runtimes only when the user asks for them.",
+  "// bundle-note": "tsdown keeps translator package runtime imports external, so the settings-panel install flow resolves ranges on demand instead of preinstalling them.",
   "optionalDependencies": {
-    "@huggingface/transformers": "~4.2.0",
     "ctranslate2": "workspace:*",
     "node-llama-cpp": "~3.18.1"
   },

--- a/packages/local-translator/package.json
+++ b/packages/local-translator/package.json
@@ -24,11 +24,10 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "// runtime-note": "tsdown keeps the dynamic import for @huggingface/transformers in the built output instead of bundling the heavy runtime into this package.",
-  "// host-note": "The real install gate and optional dependency ownership live on the runtime host packages (openspecui / @openspecui/server). Keep this dependency aligned with the source import, but do not treat this package.json as the final install truth for end users.",
+  "// runtime-note": "tsdown keeps the dynamic import for @huggingface/transformers in the built output; the runtime is installed on demand by the host package.",
+  "// host-note": "The runtime host packages own install detection and on-demand installation. This adapter only loads the runtime lazily at execution time.",
   "dependencies": {
     "@huggingface/hub": "^2.12.0",
-    "@huggingface/transformers": "^4.2.0",
     "@openspecui/core": "workspace:*"
   },
   "devDependencies": {

--- a/packages/local-translator/src/huggingface-transformers.d.ts
+++ b/packages/local-translator/src/huggingface-transformers.d.ts
@@ -1,0 +1,4 @@
+declare module '@huggingface/transformers' {
+  const transformers: unknown
+  export default transformers
+}

--- a/packages/local-translator/src/index.ts
+++ b/packages/local-translator/src/index.ts
@@ -142,7 +142,7 @@ async function loadTranslationPipeline(
   runtimeConfig?: Record<string, unknown>
 ): Promise<TranslationPipeline & { dispose?: () => Promise<void> }> {
   monitor?.setStatus({ message: `Loading local model ${model}.` })
-  const transformers = (await import('@huggingface/transformers')) as TransformersModule
+  const transformers = (await import('@huggingface/transformers')) as unknown as TransformersModule
   if (cacheDir && transformers.env) {
     transformers.env.cacheDir = cacheDir
     transformers.env.localModelPath = join(cacheDir, 'models')

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,10 +37,9 @@
     "ws": "^8.18.0",
     "zod": "^3.24.1"
   },
-  "// runtime-note": "These heavy runtimes are owned by the host package because translation engine installation is lifecycle-managed at the host boundary.",
-  "// bundle-note": "The translator engine packages keep heavyweight runtime imports external in tsdown output, so this host package remains the install/detect truth during development runs even when the translator adapters are bundled.",
+  "// runtime-note": "Translation runtimes are installed on demand from the settings panel instead of being pulled in during startup.",
+  "// bundle-note": "The translator engine packages keep heavyweight runtime imports external in tsdown output, so this host package resolves install ranges on demand when the user chooses a local engine.",
   "optionalDependencies": {
-    "@huggingface/transformers": "~4.2.0",
     "ctranslate2": "workspace:*",
     "node-llama-cpp": "~3.18.1"
   },

--- a/packages/server/src/huggingface-transformers.d.ts
+++ b/packages/server/src/huggingface-transformers.d.ts
@@ -1,0 +1,4 @@
+declare module '@huggingface/transformers' {
+  const transformers: unknown
+  export default transformers
+}

--- a/packages/server/src/local-model-asset-service.ts
+++ b/packages/server/src/local-model-asset-service.ts
@@ -1278,7 +1278,7 @@ export class LocalModelAssetService {
   }
 
   private async loadTransformersModule(): Promise<TransformersModule> {
-    return import('@huggingface/transformers') as Promise<TransformersModule>
+    return import('@huggingface/transformers') as unknown as Promise<TransformersModule>
   }
 }
 

--- a/packages/server/src/runtime-package-host.test.ts
+++ b/packages/server/src/runtime-package-host.test.ts
@@ -82,6 +82,19 @@ describe('readRuntimeHostPackageDependencyRequest', () => {
       })
     ).toBe('@huggingface/transformers@~4.2.0')
   })
+
+  it('falls back to the hardcoded range when the host manifest omits the runtime package', async () => {
+    const dir = await createTempTree()
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'openspecui' }, null, 2))
+
+    expect(
+      readRuntimeHostPackageDependencyRequest({
+        runtimeHost: createRuntimeHostContext(dir),
+        packageName: '@huggingface/transformers',
+        fallbackRange: '~4.2.0',
+      })
+    ).toBe('@huggingface/transformers@~4.2.0')
+  })
 })
 
 describe('hasRuntimePackageDependencyPath', () => {

--- a/packages/web/src/types/huggingface-transformers.d.ts
+++ b/packages/web/src/types/huggingface-transformers.d.ts
@@ -1,0 +1,4 @@
+declare module '@huggingface/transformers' {
+  const transformers: unknown
+  export default transformers
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,6 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
     optionalDependencies:
-      '@huggingface/transformers':
-        specifier: ~4.2.0
-        version: 4.2.0
       ctranslate2:
         specifier: workspace:*
         version: link:../ct2-engine
@@ -314,9 +311,6 @@ importers:
       '@huggingface/hub':
         specifier: ^2.12.0
         version: 2.12.0
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
       '@openspecui/core':
         specifier: workspace:*
         version: link:../core
@@ -457,9 +451,6 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
     optionalDependencies:
-      '@huggingface/transformers':
-        specifier: ~4.2.0
-        version: 4.2.0
       ctranslate2:
         specifier: workspace:*
         version: link:../ct2-engine
@@ -2416,18 +2407,6 @@ packages:
     resolution:
       {
         integrity: sha512-id1Yp40dLFh2Hqy6PFN+9+PEXyKCB13hq6JSe0AkHfq3XVGjQGEO8C0UFVFUlHWCzB7FgI+u/hXn6aeRs/SE9w==,
-      }
-
-  '@huggingface/tokenizers@0.1.3':
-    resolution:
-      {
-        integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==,
-      }
-
-  '@huggingface/transformers@4.2.0':
-    resolution:
-      {
-        integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==,
       }
 
   '@huggingface/xetchunk-wasm@0.0.6':
@@ -4647,66 +4626,6 @@ packages:
         integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==,
       }
 
-  '@protobufjs/aspromise@1.1.2':
-    resolution:
-      {
-        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
-      }
-
-  '@protobufjs/base64@1.1.2':
-    resolution:
-      {
-        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
-      }
-
-  '@protobufjs/codegen@2.0.5':
-    resolution:
-      {
-        integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==,
-      }
-
-  '@protobufjs/eventemitter@1.1.0':
-    resolution:
-      {
-        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
-      }
-
-  '@protobufjs/fetch@1.1.1':
-    resolution:
-      {
-        integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==,
-      }
-
-  '@protobufjs/float@1.0.2':
-    resolution:
-      {
-        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
-      }
-
-  '@protobufjs/inquire@1.1.2':
-    resolution:
-      {
-        integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==,
-      }
-
-  '@protobufjs/path@1.1.2':
-    resolution:
-      {
-        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
-      }
-
-  '@protobufjs/pool@1.1.0':
-    resolution:
-      {
-        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
-      }
-
-  '@protobufjs/utf8@1.1.1':
-    resolution:
-      {
-        integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==,
-      }
-
   '@quansync/fs@0.1.5':
     resolution:
       {
@@ -6256,13 +6175,6 @@ packages:
     engines: { node: '>=0.4.0' }
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution:
-      {
-        integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==,
-      }
-    engines: { node: '>=12.0' }
-
   agent-base@7.1.4:
     resolution:
       {
@@ -6540,13 +6452,6 @@ packages:
         integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==,
       }
     engines: { node: '>=18' }
-
-  boolean@3.2.0:
-    resolution:
-      {
-        integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==,
-      }
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   braces@3.0.3:
     resolution:
@@ -7127,26 +7032,12 @@ packages:
       }
     engines: { node: '>=18' }
 
-  define-data-property@1.1.4:
-    resolution:
-      {
-        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
-      }
-    engines: { node: '>= 0.4' }
-
   define-lazy-prop@3.0.0:
     resolution:
       {
         integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==,
       }
     engines: { node: '>=12' }
-
-  define-properties@1.2.1:
-    resolution:
-      {
-        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
-      }
-    engines: { node: '>= 0.4' }
 
   delayed-stream@1.0.0:
     resolution:
@@ -7190,12 +7081,6 @@ packages:
         integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: '>=8' }
-
-  detect-node@2.1.0:
-    resolution:
-      {
-        integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==,
-      }
 
   devalue@5.8.0:
     resolution:
@@ -7423,12 +7308,6 @@ packages:
         integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==,
       }
 
-  es6-error@4.1.1:
-    resolution:
-      {
-        integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==,
-      }
-
   esbuild@0.25.12:
     resolution:
       {
@@ -7457,13 +7336,6 @@ packages:
       {
         integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
       }
-
-  escape-string-regexp@4.0.0:
-    resolution:
-      {
-        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
-      }
-    engines: { node: '>=10' }
 
   escape-string-regexp@5.0.0:
     resolution:
@@ -7736,12 +7608,6 @@ packages:
       }
     engines: { node: '>=8' }
 
-  flatbuffers@25.9.23:
-    resolution:
-      {
-        integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==,
-      }
-
   form-data@4.0.5:
     resolution:
       {
@@ -7944,20 +7810,6 @@ packages:
       }
     engines: { node: '>= 6' }
 
-  global-agent@3.0.0:
-    resolution:
-      {
-        integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==,
-      }
-    engines: { node: '>=10.0' }
-
-  globalthis@1.0.4:
-    resolution:
-      {
-        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
-      }
-    engines: { node: '>= 0.4' }
-
   globby@11.1.0:
     resolution:
       {
@@ -7985,24 +7837,12 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0 }
 
-  guid-typescript@1.0.9:
-    resolution:
-      {
-        integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==,
-      }
-
   has-flag@4.0.0:
     resolution:
       {
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: '>=8' }
-
-  has-property-descriptors@1.0.2:
-    resolution:
-      {
-        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
-      }
 
   has-symbols@1.1.0:
     resolution:
@@ -8555,12 +8395,6 @@ packages:
         integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==,
       }
 
-  json-stringify-safe@5.0.1:
-    resolution:
-      {
-        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
-      }
-
   json-with-bigint@3.5.8:
     resolution:
       {
@@ -8907,12 +8741,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  long@5.3.2:
-    resolution:
-      {
-        integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
-      }
-
   longest-streak@3.1.0:
     resolution:
       {
@@ -9025,13 +8853,6 @@ packages:
       }
     engines: { node: '>= 20' }
     hasBin: true
-
-  matcher@3.0.0:
-    resolution:
-      {
-        integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==,
-      }
-    engines: { node: '>=10' }
 
   math-intrinsics@1.1.0:
     resolution:
@@ -9648,13 +9469,6 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  object-keys@1.1.1:
-    resolution:
-      {
-        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
-      }
-    engines: { node: '>= 0.4' }
-
   object-treeify@1.1.33:
     resolution:
       {
@@ -9711,31 +9525,6 @@ packages:
     resolution:
       {
         integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==,
-      }
-
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    resolution:
-      {
-        integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==,
-      }
-
-  onnxruntime-common@1.24.3:
-    resolution:
-      {
-        integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==,
-      }
-
-  onnxruntime-node@1.24.3:
-    resolution:
-      {
-        integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==,
-      }
-    os: [win32, darwin, linux]
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    resolution:
-      {
-        integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==,
       }
 
   open@10.2.0:
@@ -10065,12 +9854,6 @@ packages:
     peerDependencies:
       stage-js: ^1.0.0-alpha.12
 
-  platform@1.3.6:
-    resolution:
-      {
-        integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==,
-      }
-
   playwright-core@1.58.2:
     resolution:
       {
@@ -10310,13 +10093,6 @@ packages:
       {
         integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
       }
-
-  protobufjs@7.6.0:
-    resolution:
-      {
-        integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==,
-      }
-    engines: { node: '>=12.0.0' }
 
   proxy-addr@2.0.7:
     resolution:
@@ -10600,13 +10376,6 @@ packages:
       }
     engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
 
-  roarr@2.15.4:
-    resolution:
-      {
-        integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==,
-      }
-    engines: { node: '>=8.0' }
-
   rolldown-plugin-dts@0.18.0:
     resolution:
       {
@@ -10730,12 +10499,6 @@ packages:
         integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
       }
 
-  semver-compare@1.0.0:
-    resolution:
-      {
-        integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==,
-      }
-
   semver@6.3.1:
     resolution:
       {
@@ -10757,13 +10520,6 @@ packages:
         integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
       }
     engines: { node: '>= 18' }
-
-  serialize-error@7.0.1:
-    resolution:
-      {
-        integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==,
-      }
-    engines: { node: '>=10' }
 
   seroval-plugins@1.4.0:
     resolution:
@@ -10983,12 +10739,6 @@ packages:
     resolution:
       {
         integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
-      }
-
-  sprintf-js@1.1.3:
-    resolution:
-      {
-        integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==,
       }
 
   stackback@0.0.2:
@@ -11539,13 +11289,6 @@ packages:
       {
         integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==,
       }
-
-  type-fest@0.13.1:
-    resolution:
-      {
-        integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==,
-      }
-    engines: { node: '>=10' }
 
   type-fest@3.13.1:
     resolution:
@@ -13461,16 +13204,6 @@ snapshots:
 
   '@huggingface/tasks@0.20.25': {}
 
-  '@huggingface/tokenizers@0.1.3': {}
-
-  '@huggingface/transformers@4.2.0':
-    dependencies:
-      '@huggingface/jinja': 0.5.9
-      '@huggingface/tokenizers': 0.1.3
-      onnxruntime-node: 1.24.3
-      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
-      sharp: 0.34.5
-
   '@huggingface/xetchunk-wasm@0.0.6':
     dependencies:
       '@huggingface/blake3-jit': 0.0.2
@@ -14752,28 +14485,6 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.5': {}
-
-  '@protobufjs/eventemitter@1.1.0': {}
-
-  '@protobufjs/fetch@1.1.1':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.1': {}
-
   '@quansync/fs@0.1.5':
     dependencies:
       quansync: 0.2.11
@@ -15644,8 +15355,6 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  adm-zip@0.5.17: {}
-
   agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
@@ -15781,8 +15490,6 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  boolean@3.2.0: {}
 
   braces@3.0.3:
     dependencies:
@@ -16062,19 +15769,7 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   define-lazy-prop@3.0.0: {}
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
@@ -16087,8 +15782,6 @@ snapshots:
   detect-libc@1.0.3: {}
 
   detect-libc@2.1.2: {}
-
-  detect-node@2.1.0: {}
 
   devalue@5.8.0: {}
 
@@ -16188,8 +15881,6 @@ snapshots:
 
   es-toolkit@1.47.0: {}
 
-  es6-error@4.1.1: {}
-
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -16251,8 +15942,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
-
-  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -16433,8 +16122,6 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  flatbuffers@25.9.23: {}
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -16547,20 +16234,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  global-agent@3.0.0:
-    dependencies:
-      boolean: 3.2.0
-      es6-error: 4.1.1
-      matcher: 3.0.0
-      roarr: 2.15.4
-      semver: 7.7.3
-      serialize-error: 7.0.1
-
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
-
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -16576,13 +16249,7 @@ snapshots:
 
   graphql@16.12.0: {}
 
-  guid-typescript@1.0.9: {}
-
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -16914,8 +16581,6 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json-stringify-safe@5.0.1: {}
-
   json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
@@ -17080,8 +16745,6 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
 
-  long@5.3.2: {}
-
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -17133,10 +16796,6 @@ snapshots:
       react: 19.2.0
 
   marked@17.0.1: {}
-
-  matcher@3.0.0:
-    dependencies:
-      escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -17694,8 +17353,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1: {}
-
   object-treeify@1.1.33: {}
 
   obug@2.1.1: {}
@@ -17725,25 +17382,6 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.0.1
       regex-recursion: 6.0.2
-
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
-
-  onnxruntime-common@1.24.3: {}
-
-  onnxruntime-node@1.24.3:
-    dependencies:
-      adm-zip: 0.5.17
-      global-agent: 3.0.0
-      onnxruntime-common: 1.24.3
-
-  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
-    dependencies:
-      flatbuffers: 25.9.23
-      guid-typescript: 1.0.9
-      long: 5.3.2
-      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
-      platform: 1.3.6
-      protobufjs: 7.6.0
 
   open@10.2.0:
     dependencies:
@@ -17939,8 +17577,6 @@ snapshots:
       stage-js: 1.0.1
     optional: true
 
-  platform@1.3.6: {}
-
   playwright-core@1.58.2: {}
 
   playwright@1.58.2:
@@ -18047,21 +17683,6 @@ snapshots:
       signal-exit: 3.0.7
 
   property-information@7.1.0: {}
-
-  protobufjs@7.6.0:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.1
-      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -18252,15 +17873,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  roarr@2.15.4:
-    dependencies:
-      boolean: 3.2.0
-      detect-node: 2.1.0
-      globalthis: 1.0.4
-      json-stringify-safe: 5.0.1
-      semver-compare: 1.0.0
-      sprintf-js: 1.1.3
-
   rolldown-plugin-dts@0.18.0(rolldown@1.0.0-beta.51)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.0
@@ -18386,8 +17998,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver-compare@1.0.0: {}
-
   semver@6.3.1: {}
 
   semver@7.7.3: {}
@@ -18407,10 +18017,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  serialize-error@7.0.1:
-    dependencies:
-      type-fest: 0.13.1
 
   seroval-plugins@1.4.0(seroval@1.4.0):
     dependencies:
@@ -18613,8 +18219,6 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
-
-  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -18938,8 +18542,6 @@ snapshots:
       safe-buffer: 5.2.1
 
   typanion@3.14.0: {}
-
-  type-fest@0.13.1: {}
 
   type-fest@3.13.1: {}
 


### PR DESCRIPTION
## Summary
- remove @huggingface/transformers from the default install graph so onnxruntime-node is no longer pulled in at startup
- keep the Local-Transformers runtime install path on-demand from the settings panel
- add a fallback runtime-host dependency test and module shims for lazy imports

## Validation
- pnpm --filter @openspecui/local-translator test
- pnpm --filter @openspecui/server test -- src/runtime-package-host.test.ts
- pnpm --filter @openspecui/local-translator typecheck
- pnpm --filter @openspecui/server typecheck
- pnpm format:check
- pnpm lint:ci

## Release note
- changeset added for the post-merge versioning flow; the repo's changeversion script runs from main after merge