### PR TITLE
feat(web): add skip-version-check escape hatch to CLI health gate

### DIFF
--- a/.changeset/web-skip-version-check.md
+++ b/.changeset/web-skip-version-check.md
@@ -1,0 +1,15 @@
+---
+"@openspecui/web": patch
+---
+
+Add a "Skip version check" escape hatch to the OpenSpec CLI version gate.
+
+When the CLI is detected but its version is outside the supported range
+(too low or too high), the blocking dialog now offers a "Skip version check"
+button. Clicking it dismisses the gate for the current session so OpenSpecUI
+can be used with an out-of-range CLI version as a temporary workaround — for
+example, when OpenSpec was just upgraded but OpenSpecUI has not caught up.
+
+This is a session-only override (a refresh re-checks the version) and is not
+supported: no compatibility guarantees are made for out-of-range CLI versions.
+The CLI must still be detected/available for the skip option to appear.

--- a/packages/web/src/components/cli-health-gate.test.tsx
+++ b/packages/web/src/components/cli-health-gate.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CliHealthGate } from './cli-health-gate'
 
 interface CliAvailability {
@@ -67,6 +67,10 @@ describe('CliHealthGate', () => {
     availability = { available: true, version: '1.4.1' }
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('does not render for current OpenSpec CLI 1.4.x', async () => {
     renderGate()
 
@@ -92,5 +96,35 @@ describe('CliHealthGate', () => {
 
     expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).toBeInTheDocument()
     expect(screen.getByText(/Detected OpenSpec CLI 1.2.0/)).toBeInTheDocument()
+  })
+
+  it('offers a skip-version-check escape hatch when the CLI is available', async () => {
+    availability = { available: true, version: '1.5.0' }
+
+    renderGate()
+
+    expect(await screen.findByText(/Skip version check/)).toBeInTheDocument()
+  })
+
+  it('clears the blocking dialog after skipping the version check', async () => {
+    availability = { available: true, version: '1.5.0' }
+
+    renderGate()
+
+    const skip = await screen.findByText(/Skip version check/)
+    fireEvent.click(skip)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not offer a skip escape hatch when the CLI is unavailable', async () => {
+    availability = { available: false, error: 'command not found' }
+
+    renderGate()
+
+    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).toBeInTheDocument()
+    expect(screen.queryByText(/Skip version check/)).not.toBeInTheDocument()
   })
 })

--- a/packages/web/src/components/cli-health-gate.tsx
+++ b/packages/web/src/components/cli-health-gate.tsx
@@ -8,7 +8,7 @@ import {
   OPENSPECUI_TARGET_MAJOR,
 } from '@openspecui/core/openspec-compat'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { AlertCircle, Loader2, Terminal } from 'lucide-react'
+import { AlertCircle, Loader2, ShieldAlert, Terminal } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 
 function formatExecutePath(command: string, args: readonly string[] = []): string {
@@ -61,13 +61,17 @@ export function CliHealthGate() {
     },
   })
 
+  // Session-only escape hatch: lets users force OpenSpecUI to work with an
+  // out-of-range OpenSpec CLI version. Not persisted — a refresh re-checks.
+  const [forceBypassed, setForceBypassed] = useState(false)
+
   if (isLoading) {
     return null
   }
 
   const compatibility = classifyOpenSpecCliVersion(data?.version)
 
-  if (data?.available && compatibility.status === 'current') {
+  if (data?.available && (compatibility.status === 'current' || forceBypassed)) {
     return null
   }
 
@@ -139,7 +143,24 @@ export function CliHealthGate() {
             )}
             {checking ? 'Checking...' : 'Recheck'}
           </button>
+          {data?.available && (
+            <button
+              onClick={() => setForceBypassed(true)}
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs underline-offset-2 hover:underline"
+              title="Force OpenSpecUI to run with this OpenSpec CLI version anyway. Not supported."
+            >
+              <ShieldAlert className="h-3.5 w-3.5" />
+              Skip version check
+            </button>
+          )}
         </div>
+        {data?.available && (
+          <p className="text-muted-foreground text-xs">
+            The detected OpenSpec CLI is usable but outside the supported range. You can skip the
+            version check to continue at your own risk; this is a temporary override and is not
+            supported.
+          </p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Adds a session-only "Skip version check" escape hatch to the OpenSpec CLI version gate, so OpenSpecUI can be forced to work with an out-of-range CLI version (too low **or** too high) as a temporary workaround.

## Motivation

The current version gate strictly blocks any CLI version outside the supported range. This is painful in practice when, e.g., someone just upgraded OpenSpec but OpenSpecUI hasn't caught up yet — forcing a temporary, at-your-own-risk usage is a legitimate need. We don't take responsibility for the safety of that usage; we just hand the decision back to the user.

## Changes

- `packages/web/src/components/cli-health-gate.tsx`
  - Added `forceBypassed` local state (session memory only — a refresh re-checks and re-blocks).
  - Pass condition extended from `status === 'current'` to `status === 'current' || forceBypassed`.
  - Added a "Skip version check" link button next to **Recheck**, shown **only when the CLI is actually detected** (`data?.available`). If the CLI can't be found, skipping is meaningless.
  - Added a footer note clarifying this is an unsupported, temporary override.
- `packages/web/src/components/cli-health-gate.test.tsx`
  - Added `afterEach(cleanup)` (the file was missing it; new same-text tests would otherwise hit cross-test DOM leakage).
  - 3 new cases: skip button appears when CLI available; dialog clears after skipping; no skip button when CLI unavailable.

## Design choices

- **Does not touch** core's `classifyOpenSpecCliVersion` — the classification (and thus the version guidance shown) stays honest. The escape hatch is purely a UI-layer override.
- **Not persisted**: deliberately resets on refresh to avoid users silently staying on a risky config.
- **No compatibility backfill**: per the request, no guarantees are made for out-of-range CLI versions.

## Checklist

- [x] \`pnpm format:check\`
- [x] \`pnpm lint:ci\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm --filter @openspecui/web test -- src/components/cli-health-gate.test.tsx\` (6/6 pass)

> Note: a local user-level git hook (\`vite-plus\` / \`vp staged\`) failed on commit because this repo has no root \`vite.config.ts\` with a \`staged\` config — it's unrelated to this change. Committed after verifying all CI-equivalent checks pass locally.