### PR TITLE
feat(stores): read-only Stores panel (beta) with fault-tolerance model

### DIFF
--- a/.changeset/stores-beta-discovery.md
+++ b/.changeset/stores-beta-discovery.md
@@ -1,0 +1,34 @@
+---
+'@openspecui/core': minor
+'@openspecui/server': minor
+'@openspecui/web': minor
+---
+
+Add a read-only Stores panel (beta) and a beta-feature fault-tolerance model.
+
+## Stores panel (beta)
+
+OpenSpecUI 1.5.0 Stores are now surfaced in a read-only panel with a visible
+Beta badge. It lists machine-registered OpenSpec stores (id + root) via
+`openspec store list --json`, refreshes on a 5s poll (the registry lives outside
+the project directory, so the file watcher can't observe it), and is live-only
+(not part of the static/SSG snapshot).
+
+## Beta-feature fault tolerance
+
+Beta features no longer rely on the stable version gate. Stores tolerates CLI
+absence/incompatibility at runtime with lenient (passthrough, optional-field)
+zod parsing and classifies failures into two kinds:
+
+- **data-incompatible** (CLI exits 0 but the payload fails lenient parsing) →
+  the panel shows an objective error **with the OpenSpec CLI version source**.
+- **command-unavailable** (the `store` command is missing or changed; non-zero
+  exit) → the Stores navigation entry is hidden.
+
+The frontend never crashes on either failure kind.
+
+## Version law (stable maintenance)
+
+OpenSpecUI 4.x now accepts OpenSpec CLI `>=1.3.0 <1.6.0`. The 1.5 line is the
+target, 1.4 remains current/recommended, and 1.3 stays legacy-compatible. This
+is independent stable maintenance (previously 1.5.0 was hard-blocked).

--- a/openspec/changes/add-stores-read-only-panel/.openspec.yaml
+++ b/openspec/changes/add-stores-read-only-panel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-06-29

--- a/openspec/changes/add-stores-read-only-panel/README.md
+++ b/openspec/changes/add-stores-read-only-panel/README.md
@@ -1,0 +1,3 @@
+# add-stores-read-only-panel
+
+Read-only Stores panel (beta) to discover and monitor registered openspec stores

--- a/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
@@ -1,0 +1,30 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively
+- [x] 1.2 Research facts recorded
+- [x] 1.3 Plan reviewed and approved
+- [x] 1.4 Spec deltas authored and validated (`openspec-cli-integration` MODIFY + ADD, `opsx-ui-views` ADD)
+
+## 2. Implementation
+
+- [ ] 2.1 Implementation started from approved plan
+  - [ ] A. Version-law bump in `packages/core/src/openspec-compat.ts` + unit tests
+  - [ ] B. `packages/core/src/store-types.ts` Zod schemas/types + export
+  - [ ] C. `CliExecutor.listStores()` / `doctorStores(id?)`
+  - [ ] D. `storesRouter` in `packages/server/src/router.ts` (list/doctor/subscribe) + mount
+  - [ ] E. `packages/web/src/components/stores/stores-panel.tsx` + Beta badge + hook + live-only nav mount
+  - [ ] F. `.changeset/*.md`
+- [ ] 2.2 Progress synchronized with implementation artifact
+- [ ] 2.3 Unexpected issues loop back to intake/research-plan
+
+## 3. PR and Release Gates
+
+- [ ] 3.1 Changeset included for release-impacting package changes (`@openspecui/core`/`server`/`web`)
+- [ ] 3.2 CI-equivalent local checks passed (`format:check`, `lint:ci`, `typecheck`, `test:ci`, `test:browser:ci`)
+- [ ] 3.3 SSG guard passed (`pnpm --filter @openspecui/web build:ssg`; stores not in static snapshot)
+- [ ] 3.4 PR checks passed
+
+## 4. Merge Readiness
+
+- [ ] 4.1 OpenSpec archive flow completed
+- [ ] 4.2 PR merge approved

--- a/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
@@ -2,27 +2,28 @@
 
 - [x] 1.1 Intake captured objectively
 - [x] 1.2 Research facts recorded
-- [x] 1.3 Plan reviewed and approved
-- [x] 1.4 Spec deltas authored and validated (`openspec-cli-integration` MODIFY + ADD, `opsx-ui-views` ADD)
+- [x] 1.3 Plan reviewed and approved (beta fault-tolerance paradigm)
+- [x] 1.4 Spec deltas authored and validated (`openspec-cli-integration` MODIFY+ADD, `opsx-ui-views` ADD)
 
 ## 2. Implementation
 
 - [ ] 2.1 Implementation started from approved plan
-  - [ ] A. Version-law bump in `packages/core/src/openspec-compat.ts` + unit tests
-  - [ ] B. `packages/core/src/store-types.ts` Zod schemas/types + export
-  - [ ] C. `CliExecutor.listStores()` / `doctorStores(id?)`
-  - [ ] D. `storesRouter` in `packages/server/src/router.ts` (list/doctor/subscribe) + mount
-  - [ ] E. `packages/web/src/components/stores/stores-panel.tsx` + Beta badge + hook + live-only nav mount
-  - [ ] F. `.changeset/*.md`
+  - [ ] A. Version-law bump in `packages/core/src/openspec-compat.ts` + tests (stable maintenance, decoupled from Stores)
+  - [ ] B. `packages/core/src/store-types.ts`: lenient zod + `StoreFeatureError` (two kinds) + `StoreFeatureResult`; export
+  - [ ] C. `CliExecutor.listStores()/doctorStores(id?)` + classifier (ok / data-incompatible / command-unavailable)
+  - [ ] D. `storesRouter` (list/doctor/subscribe) in `packages/server/src/router.ts`; never throws; carries `cliVersion`
+  - [ ] E. `stores-panel.tsx`: Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry; live-only; defensive
+  - [ ] F. `.changeset/*.md` (`@openspecui/core`/`server`/`web`)
 - [ ] 2.2 Progress synchronized with implementation artifact
 - [ ] 2.3 Unexpected issues loop back to intake/research-plan
 
 ## 3. PR and Release Gates
 
-- [ ] 3.1 Changeset included for release-impacting package changes (`@openspecui/core`/`server`/`web`)
+- [ ] 3.1 Changeset included for release-impacting package changes
 - [ ] 3.2 CI-equivalent local checks passed (`format:check`, `lint:ci`, `typecheck`, `test:ci`, `test:browser:ci`)
 - [ ] 3.3 SSG guard passed (`pnpm --filter @openspecui/web build:ssg`; stores not in static snapshot)
-- [ ] 3.4 PR checks passed
+- [ ] 3.4 Fault-tolerance contract tests pass (data-incompatible shows version; command-unavailable hides entry; frontend never crashes)
+- [ ] 3.5 PR checks passed
 
 ## 4. Merge Readiness
 

--- a/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/checkpoints.md
@@ -7,22 +7,22 @@
 
 ## 2. Implementation
 
-- [ ] 2.1 Implementation started from approved plan
-  - [ ] A. Version-law bump in `packages/core/src/openspec-compat.ts` + tests (stable maintenance, decoupled from Stores)
-  - [ ] B. `packages/core/src/store-types.ts`: lenient zod + `StoreFeatureError` (two kinds) + `StoreFeatureResult`; export
-  - [ ] C. `CliExecutor.listStores()/doctorStores(id?)` + classifier (ok / data-incompatible / command-unavailable)
-  - [ ] D. `storesRouter` (list/doctor/subscribe) in `packages/server/src/router.ts`; never throws; carries `cliVersion`
-  - [ ] E. `stores-panel.tsx`: Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry; live-only; defensive
-  - [ ] F. `.changeset/*.md` (`@openspecui/core`/`server`/`web`)
-- [ ] 2.2 Progress synchronized with implementation artifact
-- [ ] 2.3 Unexpected issues loop back to intake/research-plan
+- [x] 2.1 Implementation started from approved plan
+  - [x] A. Version-law bump in `packages/core/src/openspec-compat.ts` + tests (stable maintenance, decoupled from Stores)
+  - [x] B. `packages/core/src/store-types.ts`: lenient zod + `StoreFeatureError` (two kinds) + `StoreFeatureResult`; export + subpath
+  - [x] C. `CliExecutor.listStores()/doctorStores(id?)` + classifier (ok / data-incompatible / command-unavailable)
+  - [x] D. `storesRouter` (list/doctor/subscribe) in `packages/server/src/router.ts`; never throws; carries `cliVersion`
+  - [x] E. `stores-list.tsx`: Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry; live-only; defensive
+  - [x] F. `.changeset/stores-beta-discovery.md` (`@openspecui/core`/`server`/`web`)
+- [x] 2.2 Progress synchronized with implementation artifact
+- [x] 2.3 Unexpected issues loop back to intake/research-plan
 
 ## 3. PR and Release Gates
 
-- [ ] 3.1 Changeset included for release-impacting package changes
-- [ ] 3.2 CI-equivalent local checks passed (`format:check`, `lint:ci`, `typecheck`, `test:ci`, `test:browser:ci`)
-- [ ] 3.3 SSG guard passed (`pnpm --filter @openspecui/web build:ssg`; stores not in static snapshot)
-- [ ] 3.4 Fault-tolerance contract tests pass (data-incompatible shows version; command-unavailable hides entry; frontend never crashes)
+- [x] 3.1 Changeset included for release-impacting package changes
+- [x] 3.2 CI-equivalent local checks passed (`format:check`, `lint:ci`, `typecheck`, `test:ci`, `test:browser:ci`)
+- [x] 3.3 SSG guard passed (`pnpm --filter @openspecui/web build:ssg`; stores not in static snapshot)
+- [x] 3.4 Fault-tolerance contract tests pass (data-incompatible shows version; command-unavailable hides entry; frontend never crashes)
 - [ ] 3.5 PR checks passed
 
 ## 4. Merge Readiness

--- a/openspec/changes/add-stores-read-only-panel/loop/implementation.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/implementation.md
@@ -1,30 +1,34 @@
 ## Implementation State
 
-Status: **Not started** — planning approved, implementation pending kickoff.
+Status: **Not started** — revised plan approved (beta fault-tolerance paradigm), implementation pending kickoff.
 
-Plan reference: `research-plan.md` sections A–F. The work is sequenced so the version-law update (A) lands first, since it is the hard prerequisite for any 1.5.0 user reaching the Stores panel.
+The plan was revised to center on the **beta feature fault-tolerance model**: Stores does NOT rely on the stable version gate; instead it tolerates CLI absence/incompatibility at runtime, classifying failures into two kinds (data-incompatible → show error + version; command-unavailable → hide entry). The version-law bump (A) remains, but as independent stable maintenance, not a Stores prerequisite.
 
-Pending steps (will be checked off as code lands):
-- [ ] A. Update `packages/core/src/openspec-compat.ts` version constants + tests.
-- [ ] B. Add `packages/core/src/store-types.ts` (Zod schemas + types), export from `index.ts`.
-- [ ] C. Add `CliExecutor.listStores()` / `doctorStores(id?)`.
-- [ ] D. Add `storesRouter` in `packages/server/src/router.ts`, mount on `appRouter.stores`.
-- [ ] E. Add `packages/web/src/components/stores/stores-panel.tsx` + Beta badge + subscription hook + nav mount (live-only).
+Pending steps (checked off as code lands):
+- [ ] A. Update `packages/core/src/openspec-compat.ts` version constants + tests (stable maintenance, independent of Stores).
+- [ ] B. Add `packages/core/src/store-types.ts`: lenient zod schemas + `StoreFeatureError` (two kinds) + `StoreFeatureResult`; export from `index.ts`.
+- [ ] C. Add `CliExecutor.listStores()` / `doctorStores(id?)` + a classification helper (exit-code + zod → ok / data-incompatible / command-unavailable).
+- [ ] D. Add `storesRouter` in `packages/server/src/router.ts` (list/doctor/subscribe); every endpoint wraps try/catch, returns `StoreFeatureResult`, never throws; `cliVersion` from `checkAvailability`.
+- [ ] E. `packages/web/src/components/stores/stores-panel.tsx`: Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry; live-only; defensive render.
 - [ ] F. Add `.changeset/*.md`.
 - [ ] Run local CI-equivalent checks.
 - [ ] Open PR.
 
 ## Decisions Taken
 
-- **Version-law is in-scope and first**: 1.5.0 currently falls outside `OPENSPEC_CLI_ACCEPTED_RANGE` and would block core interactions, so the compatibility bump is a prerequisite, not a nice-to-have.
-- **No direct registry parsing**: all store data flows through `openspec store list/doctor --json` to avoid `<dataDir>` resolution drift and respect CLI-First.
-- **Polling subscription**: the registry lives under `~/.local/share/openspec` (outside `projectDir`), so the reactive watcher cannot observe it; `stores.subscribe` will poll on an interval with `timer.unref()` plus a manual refresh control.
-- **Spec deltas chosen**: MODIFY `openspec-cli-integration` (version law + add Stores CLI query mapping) and ADD to `opsx-ui-views` (Stores Discovery Panel Beta). Both validate cleanly via `openspec validate`.
+- **Beta ≠ version gate**: Stores availability is decided at runtime by fault tolerance, not by the version-law gate. This is the core paradigm shift from the first draft.
+- **Two failure kinds, two reactions**: data-incompatible (CLI exits 0 but zod fails) → objective error + version source; command-unavailable (non-zero exit / missing subcommand) → hide entry.
+- **Lenient zod**: `passthrough()` + optional fields so additive CLI changes don't trigger false errors.
+- **Version source reuse**: `cliVersion` comes from the existing `trpc.cli.checkAvailability().version`, no new version channel.
+- **Version-law bump stays in scope** but reframed as independent stable maintenance (1.5.0 currently hard-blocks the main gate via `blocksCoreInteractions`).
+- **Spec deltas**: MODIFY `openspec-cli-integration` (version law + ADD Beta Feature Fault Tolerance + Stores CLI Query Mapping); ADD to `opsx-ui-views` (Stores Discovery Panel Beta).
 
 ## Divergence Notes
 
-- Initial plan did not call out the version-law blocker; it surfaced during spec-delta authoring when `openspec-compat.ts` was inspected. Intake, research-plan, and the `openspec-cli-integration` delta were updated to keep all artifacts consistent. This is a scope expansion relative to the first draft, recorded here for traceability.
+- **Revision 2**: the first approved plan made Stores depend on a version-law bump and used a single "degradation message" for CLI<1.5.0. The manager redirected: beta features must not rely on version compatibility and must tolerate failures with strong runtime robustness, surfacing version source on errors. intake, research-plan, and both spec deltas were rewritten to encode the two-kind fault-tolerance model. The version-law bump is retained but decoupled.
+- **Revision 1** (earlier): added the version-law blocker as a prerequisite after discovering `openspec-compat.ts` blocked 1.5.0.
 
 ## Loopback Triggers
 
-- (none yet) If the polling interval proves too noisy or the CLI `store doctor` latency is high for many stores, loop back to research-plan to reconsider the doctor-on-demand vs. eager-evaluation tradeoff.
+- (none yet) If the exit-code heuristic misclassifies a real data-incompatible case as command-unavailable (e.g., a CLI that exits non-zero on parse-internal errors), loop back to refine the classifier in research-plan.
+- If polling the stores list proves noisy, loop back to reconsider interval/refresh UX.

--- a/openspec/changes/add-stores-read-only-panel/loop/implementation.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/implementation.md
@@ -1,0 +1,30 @@
+## Implementation State
+
+Status: **Not started** — planning approved, implementation pending kickoff.
+
+Plan reference: `research-plan.md` sections A–F. The work is sequenced so the version-law update (A) lands first, since it is the hard prerequisite for any 1.5.0 user reaching the Stores panel.
+
+Pending steps (will be checked off as code lands):
+- [ ] A. Update `packages/core/src/openspec-compat.ts` version constants + tests.
+- [ ] B. Add `packages/core/src/store-types.ts` (Zod schemas + types), export from `index.ts`.
+- [ ] C. Add `CliExecutor.listStores()` / `doctorStores(id?)`.
+- [ ] D. Add `storesRouter` in `packages/server/src/router.ts`, mount on `appRouter.stores`.
+- [ ] E. Add `packages/web/src/components/stores/stores-panel.tsx` + Beta badge + subscription hook + nav mount (live-only).
+- [ ] F. Add `.changeset/*.md`.
+- [ ] Run local CI-equivalent checks.
+- [ ] Open PR.
+
+## Decisions Taken
+
+- **Version-law is in-scope and first**: 1.5.0 currently falls outside `OPENSPEC_CLI_ACCEPTED_RANGE` and would block core interactions, so the compatibility bump is a prerequisite, not a nice-to-have.
+- **No direct registry parsing**: all store data flows through `openspec store list/doctor --json` to avoid `<dataDir>` resolution drift and respect CLI-First.
+- **Polling subscription**: the registry lives under `~/.local/share/openspec` (outside `projectDir`), so the reactive watcher cannot observe it; `stores.subscribe` will poll on an interval with `timer.unref()` plus a manual refresh control.
+- **Spec deltas chosen**: MODIFY `openspec-cli-integration` (version law + add Stores CLI query mapping) and ADD to `opsx-ui-views` (Stores Discovery Panel Beta). Both validate cleanly via `openspec validate`.
+
+## Divergence Notes
+
+- Initial plan did not call out the version-law blocker; it surfaced during spec-delta authoring when `openspec-compat.ts` was inspected. Intake, research-plan, and the `openspec-cli-integration` delta were updated to keep all artifacts consistent. This is a scope expansion relative to the first draft, recorded here for traceability.
+
+## Loopback Triggers
+
+- (none yet) If the polling interval proves too noisy or the CLI `store doctor` latency is high for many stores, loop back to research-plan to reconsider the doctor-on-demand vs. eager-evaluation tradeoff.

--- a/openspec/changes/add-stores-read-only-panel/loop/implementation.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/implementation.md
@@ -1,18 +1,15 @@
 ## Implementation State
 
-Status: **Not started** — revised plan approved (beta fault-tolerance paradigm), implementation pending kickoff.
+Status: **Implemented** — all planned steps landed; local CI-equivalent checks + SSG guard + `openspec validate --strict` pass.
 
-The plan was revised to center on the **beta feature fault-tolerance model**: Stores does NOT rely on the stable version gate; instead it tolerates CLI absence/incompatibility at runtime, classifying failures into two kinds (data-incompatible → show error + version; command-unavailable → hide entry). The version-law bump (A) remains, but as independent stable maintenance, not a Stores prerequisite.
-
-Pending steps (checked off as code lands):
-- [ ] A. Update `packages/core/src/openspec-compat.ts` version constants + tests (stable maintenance, independent of Stores).
-- [ ] B. Add `packages/core/src/store-types.ts`: lenient zod schemas + `StoreFeatureError` (two kinds) + `StoreFeatureResult`; export from `index.ts`.
-- [ ] C. Add `CliExecutor.listStores()` / `doctorStores(id?)` + a classification helper (exit-code + zod → ok / data-incompatible / command-unavailable).
-- [ ] D. Add `storesRouter` in `packages/server/src/router.ts` (list/doctor/subscribe); every endpoint wraps try/catch, returns `StoreFeatureResult`, never throws; `cliVersion` from `checkAvailability`.
-- [ ] E. `packages/web/src/components/stores/stores-panel.tsx`: Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry; live-only; defensive render.
-- [ ] F. Add `.changeset/*.md`.
-- [ ] Run local CI-equivalent checks.
-- [ ] Open PR.
+Completed steps:
+- [x] A. Version-law bump in `packages/core/src/openspec-compat.ts` + tests. 1.5 is target, 1.4 stays current via new `isCurrentRecommended` (recommended range `>=1.4.0 <1.6.0`), 1.3 legacy, accepted `>=1.3.0 <1.6.0`, reference tag `v1.5.*`.
+- [x] B. `packages/core/src/store-types.ts`: lenient passthrough zod + `StoreFeatureError` (two kinds) + `StoreFeatureResult` + `classifyStoreCliOutput`/`toStoreFeatureResult`; exported from `index.ts` and new `./store-types` subpath.
+- [x] C. `CliExecutor.listStores()` / `doctorStores(id?)` (raw CliResult; classification at router layer).
+- [x] D. `storesRouter` (list/doctor/subscribe) in `packages/server/src/router.ts`; every path wrapped, never throws, carries cached `cliVersion` (30s TTL); polling subscription (5s, unref).
+- [x] E. `packages/web/src/routes/stores-list.tsx` + `use-stores-visibility.ts`; Beta badge; data→list; data-incompatible→error+version; command-unavailable→hide entry (nav filters via visibility hook); live-only; defensive render. Registered in nav-items / nav-controller / route-tree.
+- [x] F. `.changeset/stores-beta-discovery.md` (core/server/web minor).
+- [x] G. Local checks pass: `format:check`, `lint:ci`, `typecheck`, `test:ci`, `test:browser:ci`, SSG build (`static-data-provider` has no stores wiring), `openspec validate --strict`.
 
 ## Decisions Taken
 

--- a/openspec/changes/add-stores-read-only-panel/loop/intake.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/intake.md
@@ -1,0 +1,35 @@
+## User Input
+
+> OpenSpec 1.5.0 发布了 Stores (very early beta) 功能——一种组织 specs 和 changes 的更简单方式，取代 workspace 和 initiative 模型。需要跟进这个新功能。
+>
+> 首期目标是**只读发现**：在 openspecui 里加一个 Stores 入口，入口必须有 **beta 角标**，只读展示本机已注册的 store 列表与监控状态。阶段 1 的 root 切换方向已确认为 server 级活跃 store（本次不实现）。
+
+## Objective Scope
+
+- 跟进 OpenSpec 1.5.0，将 `references/openspec` 更新到 v1.5.0，并深入理解 Stores 功能的数据模型与 CLI 接口。
+- **版本律前置更新**：把 openspecui 4.x 的 CLI 兼容范围从 `>=1.3.0 <1.5.0` 推进到 `>=1.3.0 <1.6.0`（target series 1.5），否则 1.5.0 用户会被主界面阻塞、stores 面板进不去。
+- 在 openspecui 新增一个**只读**的 Stores 面板（带 Beta 角标），展示本机已注册的 store 列表及其健康监控状态。
+- 通过 `openspec store list --json` 和 `openspec store doctor --json` 获取数据，遵循 CLAUDE.md 的 CLI-First 原则。
+- 后端新增 `storesRouter`（query + 响应式订阅），前端新增面板组件并挂载到导航。
+- 提供优雅降级：当 openspec CLI < 1.5.0 或不可用时，面板给出提示而不阻塞主界面。
+
+## Non-Goals
+
+- **不**实现 root 切换 / 活跃 store 选择（阶段 1，已确认方向但本次不做）。
+- **不**实现 store 生命周期管理（setup/register/unregister/remove，阶段 2）。
+- **不**修改单 `projectDir` 架构，**不**改动 spec/change 读取逻辑。
+- **不**将 stores 数据纳入静态/SSG 快照（`static-data-provider`），stores 仅存在于 live 模式。
+- **不**自行解析 `registry.yaml` 路径（避免 `<dataDir>` 解析与 openspec 不一致），统一走 CLI。
+- **不**处理 workspace/initiative 迁移（openspecui 从未有该旧概念）。
+
+## Acceptance Boundary
+
+- `references/openspec` 处于 v1.5.0，主仓工作区无由此产生的脏改动。
+- openspecui 4.x 版本律接受 openspec CLI `>=1.3.0 <1.6.0`，1.5.x 不再被阻塞，1.3.x 保持 legacy-compatible，1.4.x/1.5.x 为 current。相关单元测试更新并通过。
+- openspecui 后端新增 `storesRouter`，提供：`list`（query）、`subscribe`（subscription，响应式）、`doctor`（query，可选 id）。数据来自 openspec CLI 的 `--json` 输出，字段对齐 snake_case 契约。
+- 前端新增 Stores 面板，标题与导航入口带 **Beta** 角标；展示每个已注册 store 的 id、root、健康状态（metadata/git/openspec root）、remote。
+- 当 CLI 不可用或版本低于 1.5.0 时，面板优雅降级（提示文案 + beta 说明），不抛错、不阻塞主界面。
+- stores 数据仅 live 模式可见，**不**进入 SSG 静态快照。
+- 本地 CI 等价检查通过：`pnpm format:check`、`pnpm lint:ci`、`pnpm typecheck`、`pnpm test:ci`、`pnpm test:browser:ci`（或按包范围的合理子集并在 PR 注明）。
+- 包含 `.changeset/*.md`（影响 `@openspecui/core`/`server`/`web` 发布包行为）。
+- 本 change 的 loop artifacts（intake / research-plan / implementation / checkpoints）随实现同步更新并通过 `openspec validate`。

--- a/openspec/changes/add-stores-read-only-panel/loop/intake.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/intake.md
@@ -1,35 +1,42 @@
 ## User Input
 
-> OpenSpec 1.5.0 发布了 Stores (very early beta) 功能——一种组织 specs 和 changes 的更简单方式，取代 workspace 和 initiative 模型。需要跟进这个新功能。
+> OpenSpec 1.5.0 发布了 Stores (very early beta) 功能。需要跟进。
 >
-> 首期目标是**只读发现**：在 openspecui 里加一个 Stores 入口，入口必须有 **beta 角标**，只读展示本机已注册的 store 列表与监控状态。阶段 1 的 root 切换方向已确认为 server 级活跃 store（本次不实现）。
+> **底层版本逻辑更新（核心原则）**：对于 beta 功能，openspecui **不负责兼容性**。但这意味着所有 beta 功能在后台必须有**强容错能力**——即使 CLI 没有这个功能、或返回异常，也要捕获错误并由前端展示，**前端永不因此崩溃**。
+>
+> 错误分两种，处理方式不同：
+> - **异常一（数据不兼容）**：openspec-cli 提供的数据结构 openspecui 解析不了。用 zod 对 CLI 输出做**宽松验证**，只有真正破坏性的不兼容数据结构才异常。对 Stores 这种弱 beta 入口，遇到异常一就**客观显示错误 + 版本来源信息**即可（版本信息非常重要）。
+> - **异常二（指令用法变了）**：openspec-cli 直接改了指令用法（重大破坏性更新）。对弱 beta 入口，遇到异常二就**直接隐藏入口**。
+>
+> 像 Stores 这种 beta 功能是弱入口：低版本没有、当前版本不稳定。版本信息在错误展示中是必备字段。
 
 ## Objective Scope
 
-- 跟进 OpenSpec 1.5.0，将 `references/openspec` 更新到 v1.5.0，并深入理解 Stores 功能的数据模型与 CLI 接口。
-- **版本律前置更新**：把 openspecui 4.x 的 CLI 兼容范围从 `>=1.3.0 <1.5.0` 推进到 `>=1.3.0 <1.6.0`（target series 1.5），否则 1.5.0 用户会被主界面阻塞、stores 面板进不去。
-- 在 openspecui 新增一个**只读**的 Stores 面板（带 Beta 角标），展示本机已注册的 store 列表及其健康监控状态。
-- 通过 `openspec store list --json` 和 `openspec store doctor --json` 获取数据，遵循 CLAUDE.md 的 CLI-First 原则。
-- 后端新增 `storesRouter`（query + 响应式订阅），前端新增面板组件并挂载到导航。
-- 提供优雅降级：当 openspec CLI < 1.5.0 或不可用时，面板给出提示而不阻塞主界面。
+- 跟进 OpenSpec 1.5.0，`references/openspec` 已更新到 v1.5.0（已完成，理解 Stores 数据模型与 CLI 接口）。
+- **确立 beta 功能容错范式**：beta 功能不走版本律门禁，靠运行时强容错。所有 CLI 数据用 zod 宽松验证；错误分两类（数据不兼容 / 指令变更），各自有明确的前端处理策略；前端永不崩溃；错误展示必须携带版本来源信息。
+- 在 openspecui 新增一个**只读**的 Stores 面板（带 Beta 角标），展示本机已注册的 store 列表与健康状态。Stores 作为该范式的首个落地实践。
+- 后端 `storesRouter` 对 `openspec store list/doctor --json` 做宽松解析与错误归类，前端按错误类型决定"显示错误+版本"或"隐藏入口"。
+- **独立的版本律维护**：把 openspecui 4.x 的 CLI 接受范围推进到 `>=1.3.0 <1.6.0`（target 1.5）。这是 stable 功能兼容性的常规维护（1.5.0 目前被主门禁阻塞），**独立于** stores 的 beta 容错——stores 不依赖它放行。
 
 ## Non-Goals
 
-- **不**实现 root 切换 / 活跃 store 选择（阶段 1，已确认方向但本次不做）。
-- **不**实现 store 生命周期管理（setup/register/unregister/remove，阶段 2）。
-- **不**修改单 `projectDir` 架构，**不**改动 spec/change 读取逻辑。
-- **不**将 stores 数据纳入静态/SSG 快照（`static-data-provider`），stores 仅存在于 live 模式。
-- **不**自行解析 `registry.yaml` 路径（避免 `<dataDir>` 解析与 openspec 不一致），统一走 CLI。
-- **不**处理 workspace/initiative 迁移（openspecui 从未有该旧概念）。
+- **不**让 beta 功能依赖版本律门禁放行（beta 靠容错，不靠版本号判断）。
+- **不**实现 root 切换 / 活跃 store（阶段 1）、store 生命周期管理（阶段 2）。
+- **不**修改单 `projectDir` 架构、**不**改动现有 spec/change 读取逻辑。
+- **不**把 stores 数据纳入静态/SSG 快照（仅 live 模式）。
+- **不**自解析 `registry.yaml` 路径（统一走 CLI，避免 `<dataDir>` 漂移）。
+- **不**对 stable 功能改变现有版本门禁语义（`cli-health-gate` 的 stable 行为保持不变）。
 
 ## Acceptance Boundary
 
-- `references/openspec` 处于 v1.5.0，主仓工作区无由此产生的脏改动。
-- openspecui 4.x 版本律接受 openspec CLI `>=1.3.0 <1.6.0`，1.5.x 不再被阻塞，1.3.x 保持 legacy-compatible，1.4.x/1.5.x 为 current。相关单元测试更新并通过。
-- openspecui 后端新增 `storesRouter`，提供：`list`（query）、`subscribe`（subscription，响应式）、`doctor`（query，可选 id）。数据来自 openspec CLI 的 `--json` 输出，字段对齐 snake_case 契约。
-- 前端新增 Stores 面板，标题与导航入口带 **Beta** 角标；展示每个已注册 store 的 id、root、健康状态（metadata/git/openspec root）、remote。
-- 当 CLI 不可用或版本低于 1.5.0 时，面板优雅降级（提示文案 + beta 说明），不抛错、不阻塞主界面。
-- stores 数据仅 live 模式可见，**不**进入 SSG 静态快照。
-- 本地 CI 等价检查通过：`pnpm format:check`、`pnpm lint:ci`、`pnpm typecheck`、`pnpm test:ci`、`pnpm test:browser:ci`（或按包范围的合理子集并在 PR 注明）。
-- 包含 `.changeset/*.md`（影响 `@openspecui/core`/`server`/`web` 发布包行为）。
-- 本 change 的 loop artifacts（intake / research-plan / implementation / checkpoints）随实现同步更新并通过 `openspec validate`。
+- `references/openspec` 处于 v1.5.0。
+- **版本律维护**：openspecui 4.x 接受 openspec CLI `>=1.3.0 <1.6.0`，1.5.x 为 current，1.3.x legacy-compatible，1.4.x current。相关测试更新通过。（独立于 stores，stable 维护。）
+- **beta 容错范式落地**：
+  - Stores 相关 CLI 输出用 zod 宽松验证（`passthrough`/可选字段），解析失败被归类为"异常一"，不抛未捕获错误。
+  - `openspec store list/doctor` 命令缺失或用法改变被归类为"异常二"。
+  - 后端永不因 stores 数据问题导致 server 崩溃；端点返回结构化错误载荷（含错误类型）。
+  - 前端：异常一 → 客观显示错误文案 + **版本来源信息**（复用 `cli.checkAvailability().version`）；异常二 → 隐藏 Stores 入口。前端永不崩溃。
+- Stores 面板（带 Beta 角标）在 CLI 1.5.0+ 且数据正常时，展示每个已注册 store 的 id、root、健康状态、remote。
+- stores 数据仅 live 模式可见，不进 SSG 快照。
+- 本地 CI 等价检查通过；包含 `.changeset/*.md`（`@openspecui/core`/`server`/`web`）。
+- 本 change 的 loop artifacts 与 spec deltas 随实现同步并通过 `openspec validate`。

--- a/openspec/changes/add-stores-read-only-panel/loop/research-plan.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/research-plan.md
@@ -1,0 +1,131 @@
+## Research Findings
+
+### OpenSpec 1.5.0 Stores 数据模型（来自 `references/openspec` v1.5.0 源码）
+
+- **Store = 独立可注册的 OpenSpec 规划仓库**，取代 1.4.x 的 workspace + initiative 模型。CHANGELOG 1.5.0 明确标注 "very early beta — expect rough edges and breaking changes"。
+- 四类存储位置：
+  - `<storeRoot>/openspec/{specs,changes}` — 共享（committed），规划内容。
+  - `<storeRoot>/.openspec-store/store.yaml` — 共享（committed），身份：`{version:1, id, remote?}`。
+  - `<dataDir>/stores/registry.yaml` — 本机私有，注册表：`{version:1, stores:{<id>:{backend:{type:'git', local_path, remote?, branch?}}}}`。
+  - worksets — 本机私有。
+- `<dataDir>` = `~/.local/share/openspec`（macOS/Linux），由 `getGlobalDataDir()` 解析，支持 env 覆盖。
+- 一个 store id 在一台机器上只允许一个 checkout（冲突码 `store_id_conflict` / `store_path_conflict`）。
+- store 的 git 后端**只做** setup 时 `git init` + 一次初始 commit，**永不** pull/push/sync（`src/core/store/git.ts:14-16` 明确注释）。
+
+### CLI 命令面（`references/openspec/src/commands/store.ts`）
+
+```
+openspec store setup/register/unregister/remove/list|ls/doctor [--json]
+```
+
+全局 flag `--store <id>` 流入普通命令（`new change`/`status`/`list`/`show`/`validate`/`archive`/`instructions`），按 `resolveOpenSpecRoot`（`src/core/root-selection.ts`）优先级解析 root：`--store` > 最近合格 `openspec/` > config 的 `store:` 指针。
+
+### JSON 契约（`references/openspec/docs/agent-contract.md` §4.11，snake_case）
+
+- `store list --json` → `{stores:[{id, root}], status:[]}`（list 仅含 id+root，无 metadata_path）。
+- `store doctor --json` → `{stores:[{id, root, metadata_path, openspec_root:{present, config, specs, changes, archive, healthy, status:[]}, metadata:{present, valid, id?, remote?}, git:{is_repository, has_commits, has_uncommitted_changes, has_remote, origin_url}}], status:[]}`。
+- 统一诊断信封 `{severity, code, message, target?, fix?}`，失败时各顶层对象为 null 且 `status` 带 error，exit code 1。
+
+### openspecui 现状耦合（关键约束）
+
+- **单 `projectDir` 模型**：`CliExecutor`（`packages/core/src/cli-executor.ts:31-34,46`）构造时绑定一个 projectDir，所有 openspec 命令以其为 cwd。`server.ts:148` `new CliExecutor(configManager, config.projectDir)`，整个 server 实例 = 一个项目目录。
+- router 为单文件 `packages/server/src/router.ts`，sub-router 挂到 `appRouter`（末尾 `router({...})`）。响应式订阅统一用 `createReactiveSubscription`（`packages/server/src/reactive-subscription.ts`）。
+- openspecui **无** workspace/initiative 旧概念（grep 确认无相关代码），无需迁移，纯新增。
+- 现有 watcher（`ctx.watcher`）只监听 `projectDir`；`registry.yaml` 在 `~/.local/share/openspec`，**不在** projectDir 下——这是响应式订阅的关键约束。
+
+### ⚠ 版本律阻塞（前置依赖，必须同批处理）
+
+- `packages/core/src/openspec-compat.ts` 当前硬编码：`OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.5.0'`，`OPENSPEC_CLI_TARGET_SERIES = '1.4'`，`OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.5.0'`。
+- 后果：装了 openspec 1.5.0 的用户会被 `classifyOpenSpecCliVersion` 判为 `unsupported` + `blocksCoreInteractions: true`，**主界面被阻塞**，stores 面板根本进不去。
+- 因此本 change **必须**把版本律推进到接受 1.5.x（target series 提到 1.5、accepted range 提到 `<1.6.0`、reference tag 提到 `v1.5.*`），这是 stores 对接的前置依赖。这会把版本律 spec（`openspec-cli-integration`）一并纳入 delta。
+
+## Decision & Plan (For Approval)
+
+### 总策略
+阶段 0 严格只读，不触碰单 projectDir 架构与 spec/change 读取逻辑。数据全走 openspec CLI 的 `--json`，不自解析 registry 路径（避免 `<dataDir>` 解析漂移）。响应式订阅因 watcher 不可达 `<dataDir>`，采用**定时轮询**（仿 `systemRouter.subscribe` 的 `setInterval` 模式）+ 手动刷新。
+
+### 文件级计划
+
+**A. 版本律前置更新 (`packages/core/src/openspec-compat.ts`)** — spec delta 见 `openspec-cli-integration`
+- `OPENSPEC_CLI_TARGET_SERIES` `'1.4'` → `'1.5'`
+- `OPENSPEC_CLI_TARGET_MIN_VERSION` `'1.4.0'` → `'1.5.0'`
+- `OPENSPEC_CLI_ACCEPTED_RANGE` `'>=1.3.0 <1.5.0'` → `'>=1.3.0 <1.6.0'`
+- `OPENSPEC_CLI_RECOMMENDED_RANGE` `'>=1.4.0 <1.5.0'` → `'>=1.4.0 <1.6.0'`
+- `OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION` `'1.5.0'` → `'1.6.0'`
+- `OPENSPEC_CLI_REFERENCE_TAG_PATTERN` `'v1.4.*'` → `'v1.5.*'`
+- 保留 `OPENSPEC_CLI_LEGACY_SERIES='1.3'` / `OPENSPEC_CLI_LEGACY_RANGE`，1.4 升为 recommended 一员。
+- 同步更新其单元测试与任何硬编码版本断言。
+
+**B. 类型层 (`packages/core/src/`)**
+- 新增 `store-types.ts`，用 Zod 定义并与 snake_case JSON 契约对齐：
+  - `StoreListEntrySchema` → `{id, root}`
+  - `StoreDiagnosticSchema` → `{severity, code, message, target?, fix?}`
+  - `StoreDoctorStoreSchema`（含 `openspec_root`、`metadata`、`git` 子对象）
+  - `StoreListResultSchema`、`StoreDoctorResultSchema`
+  - 导出对应 TS 类型。
+- 在 `packages/core/src/index.ts` 导出（前端用 `import type`，符合 CLAUDE.md 的 browser-target 规范）。
+
+**C. CLI 执行器 (`packages/core/src/cli-executor.ts`)** — spec delta 见 `openspec-cli-integration` Stores CLI Query Mapping
+- 仿现有 `schemas()`（`execute(['schemas','--json'])`）模式，新增：
+  - `listStores(): Promise<CliResult>` → `execute(['store','list','--json'])`
+  - `doctorStores(id?: string): Promise<CliResult>` → `execute(['store','doctor', ...(id?[id]:[]), '--json'])`
+
+**D. 后端 router (`packages/server/src/router.ts`)**
+- 新增 `storesRouter`，挂到 `appRouter.stores`：
+  - `stores.list` (query) — 调 `cliExecutor.listStores()`，解析 JSON，失败返回空列表 + available 标志。
+  - `stores.doctor` (query, `{id?: string}`) — 调 `cliExecutor.doctorStores(id)`。
+  - `stores.subscribe` (subscription) — 轮询 `listStores`（间隔 ~5s，`timer.unref()`），并暴露手动刷新能力；用 `observable` 直推，不依赖 watcher。
+- CLI 不可用/版本不足时，端点返回 `{stores:[], available:false, error}`，不抛错。
+
+**E. 前端 (`packages/web/src/`)** — spec delta 见 `opsx-ui-views` Stores Discovery Panel
+- 新增 `components/stores/stores-panel.tsx`：列表展示 id、root、健康状态（聚合 doctor 的 metadata/git/openspec_root.healthy）、remote。
+- **Beta 角标**：面板标题 + 导航入口处加 `Beta` badge。
+- 新增订阅 hook（仿 `use-subscription.ts` 现有模式），调 `stores.subscribe`。
+- 挂到主布局导航（仅 live 模式渲染，SSG 模式跳过——通过现有 live/static 模式判断，不进 `static-data-provider`）。
+- 降级 UI：`available:false` 时显示提示文案 + beta 说明。
+
+**F. Changeset**
+- 新增 `.changeset/*.md`，标记 `@openspecui/core`（版本律）、`@openspecui/server`、`@openspecui/web` 为 minor。
+
+## Capability Impact
+
+### New or Expanded Behavior
+
+- 新增只读 Stores 面板（beta）：用户可在 UI 看到本机所有已注册 openspec store 及其健康状态。
+- 新增后端 `storesRouter`（list / doctor / subscribe）。
+- 新增 store 相关类型与 `CliExecutor.listStores/doctorStores`。
+
+### Modified Behavior
+
+- 主布局导航新增 Stores 入口（带 beta 角标）。不改动任何现有 spec/change/git/dashboard 行为。
+
+## Risks and Mitigations
+
+| 风险 | 缓解 |
+|------|------|
+| Stores 是 early beta，CLI flag/JSON 形态可能在 1.6 变动 | 类型与 CLI 调用收拢到单一模块（`store-types.ts` + `cli-executor` 两个方法），变动时局部修改；前端字段访问集中。 |
+| `registry.yaml` 不在 projectDir，watcher 不可达，订阅不实时 | 用轮询（5s）+ 手动刷新按钮，UI 明示"自动刷新间隔"，不假装实时。 |
+| CLI < 1.5.0 或不可用 | 端点降级返回 `{stores:[], available:false}`；前端显示引导（升级 CLI）而非报错阻塞。 |
+| 误把 stores 数据进 SSG 静态快照 | stores 面板仅在 live 模式渲染；明确不新增 `static-data-provider` 条目（遵守 CLAUDE.md SSG 规范）。 |
+| `store doctor` 对大量 store 较慢 | doctor 作为按需 query（带可选 id），不在 list/subscribe 里强制全量 doctor；前端按需展开单个 store 详情时才拉 doctor。 |
+| 跨平台 `<dataDir>` 差异 | 不自解析路径，全走 CLI，规避此风险。 |
+
+## Verification Strategy
+
+### 本地检查（CI 等价，匹配 AGENTS.md 门禁）
+- `pnpm format:check`
+- `pnpm lint:ci`
+- `pnpm typecheck`
+- `pnpm test:ci`
+- `pnpm test:browser:ci`
+- SSG 守卫（CLAUDE.md）：`pnpm --filter @openspecui/web build:ssg`，确认 stores 不进静态快照、构建通过。
+
+### 功能验收
+- 在装有 openspec 1.5.0 且已注册 ≥1 个 store 的环境：面板显示 store 列表 + 健康状态，beta 角标可见。
+- `openspec store setup` 一个临时 store 后，面板（轮询或手动刷新）能看到新 store 出现。
+- 模拟 CLI 不可用（临时改坏 runner 配置）：面板显示降级提示，主界面其余功能不受影响。
+- `openspec validate change add-stores-read-only-panel` 通过。
+
+### 回归
+- 现有 spec/change/archive/dashboard/git 面板行为不变。
+- SSG 构建产物不含 stores 运行时数据。

--- a/openspec/changes/add-stores-read-only-panel/loop/research-plan.md
+++ b/openspec/changes/add-stores-read-only-panel/loop/research-plan.md
@@ -1,16 +1,11 @@
 ## Research Findings
 
-### OpenSpec 1.5.0 Stores 数据模型（来自 `references/openspec` v1.5.0 源码）
+### OpenSpec 1.5.0 Stores 数据模型（来自 `references/openspec` v1.5.0）
 
-- **Store = 独立可注册的 OpenSpec 规划仓库**，取代 1.4.x 的 workspace + initiative 模型。CHANGELOG 1.5.0 明确标注 "very early beta — expect rough edges and breaking changes"。
-- 四类存储位置：
-  - `<storeRoot>/openspec/{specs,changes}` — 共享（committed），规划内容。
-  - `<storeRoot>/.openspec-store/store.yaml` — 共享（committed），身份：`{version:1, id, remote?}`。
-  - `<dataDir>/stores/registry.yaml` — 本机私有，注册表：`{version:1, stores:{<id>:{backend:{type:'git', local_path, remote?, branch?}}}}`。
-  - worksets — 本机私有。
-- `<dataDir>` = `~/.local/share/openspec`（macOS/Linux），由 `getGlobalDataDir()` 解析，支持 env 覆盖。
-- 一个 store id 在一台机器上只允许一个 checkout（冲突码 `store_id_conflict` / `store_path_conflict`）。
-- store 的 git 后端**只做** setup 时 `git init` + 一次初始 commit，**永不** pull/push/sync（`src/core/store/git.ts:14-16` 明确注释）。
+- **Store = 独立可注册的 OpenSpec 规划仓库**，取代 workspace + initiative。CHANGELOG 标注 "very early beta — expect breaking changes"。
+- 四类存储位置：`<storeRoot>/openspec/{specs,changes}`（共享 committed）、`<storeRoot>/.openspec-store/store.yaml`（身份 `{version:1,id,remote?}`，共享 committed）、`<dataDir>/stores/registry.yaml`（本机私有）、worksets（本机私有）。
+- `<dataDir>` = `~/.local/share/openspec`（macOS/Linux）。
+- store git 后端只做 setup 时 init + 一次 commit，永不 pull/push/sync。
 
 ### CLI 命令面（`references/openspec/src/commands/store.ts`）
 
@@ -18,114 +13,105 @@
 openspec store setup/register/unregister/remove/list|ls/doctor [--json]
 ```
 
-全局 flag `--store <id>` 流入普通命令（`new change`/`status`/`list`/`show`/`validate`/`archive`/`instructions`），按 `resolveOpenSpecRoot`（`src/core/root-selection.ts`）优先级解析 root：`--store` > 最近合格 `openspec/` > config 的 `store:` 指针。
+JSON 契约（`docs/agent-contract.md` §4.11，snake_case）：
+- `store list --json` → `{stores:[{id, root}], status:[]}`。
+- `store doctor --json` → `{stores:[{id, root, metadata_path, openspec_root:{present,config,specs,changes,archive,healthy,status:[]}, metadata:{present,valid,id?,remote?}, git:{is_repository,has_commits,has_uncommitted_changes,has_remote,origin_url}}], status:[]}`。
+- 失败时顶层对象为 null + `status` 带 error 诊断，exit code 1。
 
-### JSON 契约（`references/openspec/docs/agent-contract.md` §4.11，snake_case）
+### openspecui 现状耦合与约束
 
-- `store list --json` → `{stores:[{id, root}], status:[]}`（list 仅含 id+root，无 metadata_path）。
-- `store doctor --json` → `{stores:[{id, root, metadata_path, openspec_root:{present, config, specs, changes, archive, healthy, status:[]}, metadata:{present, valid, id?, remote?}, git:{is_repository, has_commits, has_uncommitted_changes, has_remote, origin_url}}], status:[]}`。
-- 统一诊断信封 `{severity, code, message, target?, fix?}`，失败时各顶层对象为 null 且 `status` 带 error，exit code 1。
-
-### openspecui 现状耦合（关键约束）
-
-- **单 `projectDir` 模型**：`CliExecutor`（`packages/core/src/cli-executor.ts:31-34,46`）构造时绑定一个 projectDir，所有 openspec 命令以其为 cwd。`server.ts:148` `new CliExecutor(configManager, config.projectDir)`，整个 server 实例 = 一个项目目录。
-- router 为单文件 `packages/server/src/router.ts`，sub-router 挂到 `appRouter`（末尾 `router({...})`）。响应式订阅统一用 `createReactiveSubscription`（`packages/server/src/reactive-subscription.ts`）。
-- openspecui **无** workspace/initiative 旧概念（grep 确认无相关代码），无需迁移，纯新增。
-- 现有 watcher（`ctx.watcher`）只监听 `projectDir`；`registry.yaml` 在 `~/.local/share/openspec`，**不在** projectDir 下——这是响应式订阅的关键约束。
-
-### ⚠ 版本律阻塞（前置依赖，必须同批处理）
-
-- `packages/core/src/openspec-compat.ts` 当前硬编码：`OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.5.0'`，`OPENSPEC_CLI_TARGET_SERIES = '1.4'`，`OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.5.0'`。
-- 后果：装了 openspec 1.5.0 的用户会被 `classifyOpenSpecCliVersion` 判为 `unsupported` + `blocksCoreInteractions: true`，**主界面被阻塞**，stores 面板根本进不去。
-- 因此本 change **必须**把版本律推进到接受 1.5.x（target series 提到 1.5、accepted range 提到 `<1.6.0`、reference tag 提到 `v1.5.*`），这是 stores 对接的前置依赖。这会把版本律 spec（`openspec-cli-integration`）一并纳入 delta。
+- **单 `projectDir` 模型**：`CliExecutor`（`packages/core/src/cli-executor.ts:31-34,46`）绑定一个 projectDir。server 实例 = 一个项目目录。
+- router 单文件 `packages/server/src/router.ts`，sub-router 挂 `appRouter`。响应式订阅用 `createReactiveSubscription`。
+- **版本门禁**：`packages/web/src/components/cli-health-gate.tsx` 用 `classifyOpenSpecCliVersion`（`packages/core/src/openspec-compat.ts`）。当前 `OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.5.0'`，1.5.0 会被 `blocksCoreInteractions` 阻塞主界面（stable 门禁）。
+- **版本来源信息已可复用**：`trpc.cli.checkAvailability` 返回 `{available, version, ...}`，stores 错误展示直接复用前端已缓存的 `version`，无需新增取版本通道。
+- **watcher 只监听 projectDir**；`registry.yaml` 在 `~/.local/share/openspec`（不可达）——stores 订阅须轮询，不依赖 watcher。
+- openspecui 无 workspace/initiative 旧概念，纯新增。
 
 ## Decision & Plan (For Approval)
 
-### 总策略
-阶段 0 严格只读，不触碰单 projectDir 架构与 spec/change 读取逻辑。数据全走 openspec CLI 的 `--json`，不自解析 registry 路径（避免 `<dataDir>` 解析漂移）。响应式订阅因 watcher 不可达 `<dataDir>`，采用**定时轮询**（仿 `systemRouter.subscribe` 的 `setInterval` 模式）+ 手动刷新。
+### 核心范式：beta 功能容错模型（本 change 的设计核心）
+
+beta 功能**不走版本律门禁**，靠运行时强容错。CLI 数据用 **zod 宽松验证**（`passthrough` + 字段可选），把失败归类为两类错误，前端按类型差异化处理：
+
+| 错误类型 | 触发 | 后端行为 | 前端行为 |
+|---------|------|---------|---------|
+| **异常一：数据不兼容** | zod 宽松验证仍失败（CLI 真正破坏性数据结构变更） | 捕获，端点返回 `{available:true, error:{kind:'data-incompatible', message, cliVersion}}` | **客观显示错误 + 版本来源信息**（不隐藏、不崩溃） |
+| **异常二：指令变更/缺失** | `store list/doctor` 命令本身不存在或用法改变（非零退出 / 找不到子命令） | 捕获，端点返回 `{available:false, error:{kind:'command-unavailable', message, cliVersion}}` | **隐藏 Stores 入口** |
+
+- **版本信息必备**：两种错误载荷都带 `cliVersion`（来自 `checkAvailability`），前端错误展示必须呈现。
+- **前端永不崩溃**：stores 数据通道用 React Query / subscription 的 error 状态承载，组件对 `error`/`undefined` data 做防御渲染。
+- **宽松验证**：zod schema 用 `.passthrough()`（容忍 CLI 新增字段）+ 关键字段可选，只有结构根本性不兼容才落异常一。
 
 ### 文件级计划
 
-**A. 版本律前置更新 (`packages/core/src/openspec-compat.ts`)** — spec delta 见 `openspec-cli-integration`
-- `OPENSPEC_CLI_TARGET_SERIES` `'1.4'` → `'1.5'`
-- `OPENSPEC_CLI_TARGET_MIN_VERSION` `'1.4.0'` → `'1.5.0'`
-- `OPENSPEC_CLI_ACCEPTED_RANGE` `'>=1.3.0 <1.5.0'` → `'>=1.3.0 <1.6.0'`
-- `OPENSPEC_CLI_RECOMMENDED_RANGE` `'>=1.4.0 <1.5.0'` → `'>=1.4.0 <1.6.0'`
-- `OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION` `'1.5.0'` → `'1.6.0'`
-- `OPENSPEC_CLI_REFERENCE_TAG_PATTERN` `'v1.4.*'` → `'v1.5.*'`
-- 保留 `OPENSPEC_CLI_LEGACY_SERIES='1.3'` / `OPENSPEC_CLI_LEGACY_RANGE`，1.4 升为 recommended 一员。
-- 同步更新其单元测试与任何硬编码版本断言。
+**A. 版本律维护（stable，独立于 stores）** — `packages/core/src/openspec-compat.ts`
+- `OPENSPEC_CLI_TARGET_SERIES` `'1.4'`→`'1.5'`；`TARGET_MIN_VERSION` `'1.4.0'`→`'1.5.0'`；`ACCEPTED_RANGE` `'>=1.3.0 <1.5.0'`→`'>=1.3.0 <1.6.0'`；`RECOMMENDED_RANGE`→`'>=1.4.0 <1.6.0'`；`NEXT_SERIES_MIN_VERSION` `'1.5.0'`→`'1.6.0'`；`REFERENCE_TAG_PATTERN` `'v1.4.*'`→`'v1.5.*'`。保留 1.3 legacy。更新单元测试。
+- 注：这是常规 stable 维护；**stores 的可用性不依赖它**（即使版本律没放行，stores 也靠容错自处）。
 
-**B. 类型层 (`packages/core/src/`)**
-- 新增 `store-types.ts`，用 Zod 定义并与 snake_case JSON 契约对齐：
-  - `StoreListEntrySchema` → `{id, root}`
-  - `StoreDiagnosticSchema` → `{severity, code, message, target?, fix?}`
-  - `StoreDoctorStoreSchema`（含 `openspec_root`、`metadata`、`git` 子对象）
-  - `StoreListResultSchema`、`StoreDoctorResultSchema`
-  - 导出对应 TS 类型。
-- 在 `packages/core/src/index.ts` 导出（前端用 `import type`，符合 CLAUDE.md 的 browser-target 规范）。
+**B. 类型层（宽松验证 + 错误归类）** — 新增 `packages/core/src/store-types.ts`
+- zod 宽松 schema：`StoreListResultSchema` / `StoreDoctorResultSchema`（`.passthrough()` + 字段可选）。
+- 错误类型：`StoreFeatureError = {kind:'data-incompatible'|'command-unavailable'; message; cliVersion?}`。
+- 端点统一返回型：`StoreFeatureResult = {available:boolean; stores:StoreListEntry[]; error?:StoreFeatureError; cliVersion?:string}`。
+- 从 `packages/core/src/index.ts` 导出。
 
-**C. CLI 执行器 (`packages/core/src/cli-executor.ts`)** — spec delta 见 `openspec-cli-integration` Stores CLI Query Mapping
-- 仿现有 `schemas()`（`execute(['schemas','--json'])`）模式，新增：
-  - `listStores(): Promise<CliResult>` → `execute(['store','list','--json'])`
-  - `doctorStores(id?: string): Promise<CliResult>` → `execute(['store','doctor', ...(id?[id]:[]), '--json'])`
+**C. CLI 执行器 + 错误归类** — `packages/core/src/cli-executor.ts`
+- 新增 `listStores()` / `doctorStores(id?)`（仅 `execute([...,'--json'])`，不做解析）。
+- 新增**归类辅助**（可放 `store-types.ts` 或 server 侧）：执行结果 → `{kind:'ok'|'data-incompatible'|'command-unavailable'}`。判定逻辑：
+  - exit 0 且 zod 通过 → ok；
+  - exit 0 但 zod 失败 → data-incompatible（异常一）；
+  - 非 0 退出 / 子命令缺失 → command-unavailable（异常二）。
 
-**D. 后端 router (`packages/server/src/router.ts`)**
-- 新增 `storesRouter`，挂到 `appRouter.stores`：
-  - `stores.list` (query) — 调 `cliExecutor.listStores()`，解析 JSON，失败返回空列表 + available 标志。
-  - `stores.doctor` (query, `{id?: string}`) — 调 `cliExecutor.doctorStores(id)`。
-  - `stores.subscribe` (subscription) — 轮询 `listStores`（间隔 ~5s，`timer.unref()`），并暴露手动刷新能力；用 `observable` 直推，不依赖 watcher。
-- CLI 不可用/版本不足时，端点返回 `{stores:[], available:false, error}`，不抛错。
+**D. 后端 router** — `packages/server/src/router.ts`
+- 新增 `storesRouter`（挂 `appRouter.stores`）：
+  - `stores.list` (query)、`stores.subscribe`（轮询，~5s，`unref`）、`stores.doctor`（query `{id?}`）。
+  - 每个端点包 try/catch，输出 `StoreFeatureResult`，**永不抛**未捕获错误。`cliVersion` 从 `cliExecutor.checkAvailability()` 取（或复用上下文缓存）。
 
-**E. 前端 (`packages/web/src/`)** — spec delta 见 `opsx-ui-views` Stores Discovery Panel
-- 新增 `components/stores/stores-panel.tsx`：列表展示 id、root、健康状态（聚合 doctor 的 metadata/git/openspec_root.healthy）、remote。
-- **Beta 角标**：面板标题 + 导航入口处加 `Beta` badge。
-- 新增订阅 hook（仿 `use-subscription.ts` 现有模式），调 `stores.subscribe`。
-- 挂到主布局导航（仅 live 模式渲染，SSG 模式跳过——通过现有 live/static 模式判断，不进 `static-data-provider`）。
-- 降级 UI：`available:false` 时显示提示文案 + beta 说明。
+**E. 前端** — `packages/web/src/`
+- `components/stores/stores-panel.tsx`：Beta 角标；data 正常 → 列表；`error.kind==='data-incompatible'` → 显示错误 + `cliVersion`；`error.kind==='command-unavailable'` → 隐藏入口（父级导航据此不渲染）。
+- 订阅 hook 复用 `trpc.cli.checkAvailability` 的 `version` 作版本来源。
+- 仅 live 模式渲染；对 undefined/error data 防御渲染，不崩溃。
 
-**F. Changeset**
-- 新增 `.changeset/*.md`，标记 `@openspecui/core`（版本律）、`@openspecui/server`、`@openspecui/web` 为 minor。
+**F. Changeset** — `.changeset/*.md`，标记 `@openspecui/core`/`server`/`web` minor。
 
 ## Capability Impact
 
 ### New or Expanded Behavior
 
-- 新增只读 Stores 面板（beta）：用户可在 UI 看到本机所有已注册 openspec store 及其健康状态。
-- 新增后端 `storesRouter`（list / doctor / subscribe）。
-- 新增 store 相关类型与 `CliExecutor.listStores/doctorStores`。
+- **beta 功能容错范式**：zod 宽松验证 + 两类错误归类 + 版本信息展示 + 按错误类型显隐入口。
+- Stores 只读面板（beta）。
+- 版本律接受 1.5.x（stable 维护）。
 
 ### Modified Behavior
 
-- 主布局导航新增 Stores 入口（带 beta 角标）。不改动任何现有 spec/change/git/dashboard 行为。
+- 主门禁（`cli-health-gate`）stable 行为不变；版本常量更新。
+- 主布局导航新增 Stores 入口（可按异常二隐藏），不改动现有面板。
 
 ## Risks and Mitigations
 
 | 风险 | 缓解 |
 |------|------|
-| Stores 是 early beta，CLI flag/JSON 形态可能在 1.6 变动 | 类型与 CLI 调用收拢到单一模块（`store-types.ts` + `cli-executor` 两个方法），变动时局部修改；前端字段访问集中。 |
-| `registry.yaml` 不在 projectDir，watcher 不可达，订阅不实时 | 用轮询（5s）+ 手动刷新按钮，UI 明示"自动刷新间隔"，不假装实时。 |
-| CLI < 1.5.0 或不可用 | 端点降级返回 `{stores:[], available:false}`；前端显示引导（升级 CLI）而非报错阻塞。 |
-| 误把 stores 数据进 SSG 静态快照 | stores 面板仅在 live 模式渲染；明确不新增 `static-data-provider` 条目（遵守 CLAUDE.md SSG 规范）。 |
-| `store doctor` 对大量 store 较慢 | doctor 作为按需 query（带可选 id），不在 list/subscribe 里强制全量 doctor；前端按需展开单个 store 详情时才拉 doctor。 |
-| 跨平台 `<dataDir>` 差异 | 不自解析路径，全走 CLI，规避此风险。 |
+| beta CLI 形态在 1.6 变动 | zod `.passthrough()` 容忍新增字段；错误归类集中一处；前端字段访问防御性。 |
+| 误把"指令缺失"当"数据不兼容" | 归类以 exit code + zod 双重判定：非 0 → command-unavailable；0 但 zod 失败 → data-incompatible。 |
+| 错误展示缺版本信息 | 错误载荷强制带 `cliVersion`；前端 error UI 把版本作为必显字段；契约测试覆盖。 |
+| 前端崩溃 | 组件对所有 data 形态（undefined/error/空）防御渲染；React Query error 状态承载。 |
+| watcher 不可达 registry | 轮询订阅 + 手动刷新，UI 明示间隔。 |
+| stores 误进 SSG | 仅 live 渲染，不进 `static-data-provider`；SSG 构建验证。 |
+| doctor 慢 | doctor 按需 query（带 id），不强制全量。 |
 
 ## Verification Strategy
 
-### 本地检查（CI 等价，匹配 AGENTS.md 门禁）
-- `pnpm format:check`
-- `pnpm lint:ci`
-- `pnpm typecheck`
-- `pnpm test:ci`
-- `pnpm test:browser:ci`
-- SSG 守卫（CLAUDE.md）：`pnpm --filter @openspecui/web build:ssg`，确认 stores 不进静态快照、构建通过。
+### 本地检查（CI 等价）
+- `pnpm format:check` / `lint:ci` / `typecheck` / `test:ci` / `test:browser:ci`。
+- SSG 守卫：`pnpm --filter @openspecui/web build:ssg`，stores 不进快照。
 
 ### 功能验收
-- 在装有 openspec 1.5.0 且已注册 ≥1 个 store 的环境：面板显示 store 列表 + 健康状态，beta 角标可见。
-- `openspec store setup` 一个临时 store 后，面板（轮询或手动刷新）能看到新 store 出现。
-- 模拟 CLI 不可用（临时改坏 runner 配置）：面板显示降级提示，主界面其余功能不受影响。
-- `openspec validate change add-stores-read-only-panel` 通过。
+- CLI 1.5.0+ 且注册了 store：面板显示列表 + 健康 + beta 角标。
+- 模拟**异常一**（喂给 zod 一个结构错乱的 JSON）：面板显示错误 + 版本信息，不崩溃、不隐藏。
+- 模拟**异常二**（mock `store list` 非零退出）：Stores 入口隐藏。
+- CLI < 1.5.0（无 store 子命令）：入口隐藏（异常二路径）。
+- 版本律：1.5.0 不再被主门禁阻塞；1.3.x 仍 legacy 提示。
+- `openspec validate add-stores-read-only-panel --type change` 通过。
 
 ### 回归
-- 现有 spec/change/archive/dashboard/git 面板行为不变。
-- SSG 构建产物不含 stores 运行时数据。
+- 现有 stable 功能与面板行为不变。
+- SSG 产物不含 stores 运行时数据。

--- a/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
+++ b/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: CLI Discovery and Version Enforcement
 
-OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce the OpenSpecUI major-to-OpenSpec CLI minor version law.
+OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce the OpenSpecUI major-to-OpenSpec CLI minor version law for stable features.
 
 #### Scenario: Enforce OpenSpecUI 4.x compatibility range
 
@@ -42,27 +42,51 @@ OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enfor
 
 ## ADDED Requirements
 
+### Requirement: Beta Feature Fault Tolerance
+
+For beta-gated features (e.g., Stores), OpenSpecUI SHALL NOT rely on the stable version gate for availability. Instead it SHALL tolerate CLI absence or incompatibility at runtime so the UI never crashes, classifying failures into two kinds and reacting accordingly.
+
+#### Scenario: Lenient parsing of beta CLI output
+
+- **GIVEN** a beta feature reads OpenSpec CLI JSON output
+- **WHEN** the CLI returns extra or slightly reshaped fields
+- **THEN** the system SHALL parse with a lenient (passthrough, optional-field) schema
+- **AND** SHALL NOT treat additive CLI changes as an error
+
+#### Scenario: Classify data-incompatible failures with version source
+
+- **GIVEN** a beta feature's CLI command exits 0 but returns a structurally incompatible payload
+- **WHEN** lenient parsing still fails
+- **THEN** the system SHALL classify the failure as data-incompatible
+- **AND** the surfaced error SHALL include the originating OpenSpec CLI version
+
+#### Scenario: Classify command-change failures
+
+- **GIVEN** a beta feature's CLI command is missing or its usage has changed (non-zero exit)
+- **WHEN** the command cannot be used as expected
+- **THEN** the system SHALL classify the failure as command-unavailable
+
+#### Scenario: Never crash the frontend on beta failures
+
+- **GIVEN** a beta feature encounters either failure kind
+- **WHEN** the frontend renders
+- **THEN** the UI SHALL NOT crash
+- **AND** SHALL either display an objective error with version source (data-incompatible) or hide the entry (command-unavailable)
+
 ### Requirement: Stores CLI Query Mapping
 
-OpenSpecUI SHALL retrieve registered-store discovery data from the OpenSpec CLI (1.5.0+) without parsing the machine-local registry file directly.
+OpenSpecUI SHALL retrieve registered-store discovery data from the OpenSpec CLI via the beta fault-tolerance model, without parsing the machine-local registry file directly.
 
 #### Scenario: Query registered store list
 
-- **GIVEN** the Stores panel needs the registered store list
+- **GIVEN** the Stores panel needs the registered store list and the CLI supports it
 - **WHEN** the UI requests store discovery data
 - **THEN** the system SHALL execute `openspec store list --json`
-- **AND** parse the `stores` array of `{id, root}` entries
+- **AND** parse the `stores` array of `{id, root}` entries leniently
 
 #### Scenario: Query store health
 
 - **GIVEN** the Stores panel needs health diagnostics for a store
 - **WHEN** the UI requests store health
 - **THEN** the system SHALL execute `openspec store doctor --json` (optionally with a store id)
-- **AND** surface `openspec_root.healthy`, `metadata`, and `git` facts per store
-
-#### Scenario: Degrade when CLI lacks store support
-
-- **GIVEN** the resolved OpenSpec CLI is older than 1.5.0 or unavailable
-- **WHEN** the Stores panel requests discovery data
-- **THEN** the system SHALL return an empty store list with an availability flag
-- **AND** the UI SHALL show a beta-gated degradation message instead of raising an error
+- **AND** surface `openspec_root.healthy`, `metadata`, and `git` facts per store when present

--- a/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
+++ b/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
@@ -1,0 +1,68 @@
+# openspec-cli-integration Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: CLI Discovery and Version Enforcement
+
+OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce the OpenSpecUI major-to-OpenSpec CLI minor version law.
+
+#### Scenario: Enforce OpenSpecUI 4.x compatibility range
+
+- **GIVEN** OpenSpecUI 4.x evaluates an OpenSpec CLI version outside `>=1.3.0 <1.6.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL block usage
+- **AND** present upgrade instructions
+
+#### Scenario: Treat 1.4 runtime as current in 4.x
+
+- **GIVEN** OpenSpecUI 4.x evaluates OpenSpec CLI `>=1.4.0 <1.5.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions without a compatibility warning
+
+#### Scenario: Treat 1.5 runtime as current in 4.x
+
+- **GIVEN** OpenSpecUI 4.x evaluates OpenSpec CLI `>=1.5.0 <1.6.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions without a compatibility warning
+
+#### Scenario: Accept legacy-compatible 1.3 runtime in 4.x
+
+- **GIVEN** OpenSpecUI 4.x evaluates OpenSpec CLI `>=1.3.0 <1.4.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions
+- **AND** SHALL show that the CLI is legacy-compatible and recommend OpenSpec CLI `>=1.4.0 <1.6.0`
+
+#### Scenario: Preserve release-line directionality
+
+- **GIVEN** OpenSpecUI release-line compatibility is evaluated
+- **WHEN** version support is declared
+- **THEN** OpenSpecUI 3.x SHALL correspond to OpenSpec CLI 1.3.x
+- **AND** OpenSpecUI 4.x SHALL correspond to OpenSpec CLI 1.4.x and 1.5.x
+- **AND** OpenSpecUI 4.x SHALL backward-support OpenSpec CLI 1.3.x
+
+## ADDED Requirements
+
+### Requirement: Stores CLI Query Mapping
+
+OpenSpecUI SHALL retrieve registered-store discovery data from the OpenSpec CLI (1.5.0+) without parsing the machine-local registry file directly.
+
+#### Scenario: Query registered store list
+
+- **GIVEN** the Stores panel needs the registered store list
+- **WHEN** the UI requests store discovery data
+- **THEN** the system SHALL execute `openspec store list --json`
+- **AND** parse the `stores` array of `{id, root}` entries
+
+#### Scenario: Query store health
+
+- **GIVEN** the Stores panel needs health diagnostics for a store
+- **WHEN** the UI requests store health
+- **THEN** the system SHALL execute `openspec store doctor --json` (optionally with a store id)
+- **AND** surface `openspec_root.healthy`, `metadata`, and `git` facts per store
+
+#### Scenario: Degrade when CLI lacks store support
+
+- **GIVEN** the resolved OpenSpec CLI is older than 1.5.0 or unavailable
+- **WHEN** the Stores panel requests discovery data
+- **THEN** the system SHALL return an empty store list with an availability flag
+- **AND** the UI SHALL show a beta-gated degradation message instead of raising an error

--- a/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
+++ b/openspec/changes/add-stores-read-only-panel/specs/openspec-cli-integration/spec.md
@@ -46,6 +46,14 @@ OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enfor
 
 For beta-gated features (e.g., Stores), OpenSpecUI SHALL NOT rely on the stable version gate for availability. Instead it SHALL tolerate CLI absence or incompatibility at runtime so the UI never crashes, classifying failures into two kinds and reacting accordingly.
 
+> **Rationale (manager directive, verbatim intent):**
+> 对于 beta 功能，openspecui 不负责兼容性。但这也意味着所有功能在后台需要有较强的容错能力（没有这个功能也要能捕捉到错误），然后前端显示这个错误。这个错误一般是两种：
+>
+> 1. **数据不兼容** — 当前的 openspecui 不支持/不兼容 openspec-cli 提供的数据。通过 zod 对 CLI 输出做**宽松验证**，所以除非 openspec-cli 破坏性更新提供了不兼容的数据结构，我们才会异常。
+> 2. **指令用法变了** — openspec-cli 直接修改了指令的用法，这属于 openspec 上了比较大的破坏性更新。
+>
+> 不论哪种情况，前端都不能因此崩溃。要么客观显示错误，并提供错误的**版本来源信息**（版本信息非常重要）。像 Store 这种 beta 功能是很弱的入口——低版本没有、当前版本不稳定：遇到异常一就直接客观显示版本信息即可；遇到异常二就直接隐藏入口。
+
 #### Scenario: Lenient parsing of beta CLI output
 
 - **GIVEN** a beta feature reads OpenSpec CLI JSON output

--- a/openspec/changes/add-stores-read-only-panel/specs/opsx-ui-views/spec.md
+++ b/openspec/changes/add-stores-read-only-panel/specs/opsx-ui-views/spec.md
@@ -1,0 +1,48 @@
+# opsx-ui-views Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Stores Discovery Panel (Beta)
+
+OpenSpecUI SHALL provide a read-only Stores panel that lists machine-registered OpenSpec stores and their health, gated behind a visible Beta badge. The panel SHALL NOT mutate store registrations or switch the active project root.
+
+#### Scenario: Show registered stores
+
+- **GIVEN** at least one store is registered on the machine and the CLI is 1.5.0+
+- **WHEN** the user opens the Stores panel
+- **THEN** the UI SHALL list each store's id and root path
+- **AND** SHALL display health facts derived from `openspec store doctor --json`
+
+#### Scenario: Display Beta badge
+
+- **GIVEN** the Stores panel is rendered
+- **WHEN** the user views the panel title or navigation entry
+- **THEN** the UI SHALL show a visible Beta badge
+- **AND** SHALL keep it for the entire early-beta lifecycle of stores
+
+#### Scenario: Refresh store list reactively
+
+- **GIVEN** the Stores panel is open
+- **WHEN** the local store registry changes
+- **THEN** the UI SHALL update via a polling subscription (since the registry lives outside the project directory)
+- **AND** SHALL offer a manual refresh control
+
+#### Scenario: Restrict to live mode
+
+- **GIVEN** OpenSpecUI runs in static/SSG mode
+- **WHEN** the navigation is composed
+- **THEN** the UI SHALL NOT render the Stores panel or include stores data in the static snapshot
+
+#### Scenario: Read-only guarantee
+
+- **GIVEN** the Stores panel is displayed
+- **WHEN** the user interacts with any store entry
+- **THEN** the UI SHALL only show details (no setup/register/unregister/remove actions in this phase)
+- **AND** SHALL NOT change the active project directory
+
+#### Scenario: Degrade gracefully without store-capable CLI
+
+- **GIVEN** the OpenSpec CLI is unavailable or older than 1.5.0
+- **WHEN** the Stores panel loads
+- **THEN** the UI SHALL show a beta-gated degradation message with upgrade guidance
+- **AND** SHALL NOT block the rest of the interface

--- a/openspec/changes/add-stores-read-only-panel/specs/opsx-ui-views/spec.md
+++ b/openspec/changes/add-stores-read-only-panel/specs/opsx-ui-views/spec.md
@@ -4,11 +4,11 @@
 
 ### Requirement: Stores Discovery Panel (Beta)
 
-OpenSpecUI SHALL provide a read-only Stores panel that lists machine-registered OpenSpec stores and their health, gated behind a visible Beta badge. The panel SHALL NOT mutate store registrations or switch the active project root.
+OpenSpecUI SHALL provide a read-only Stores panel, gated behind a visible Beta badge, that lists machine-registered OpenSpec stores and their health. The panel SHALL follow the beta feature fault-tolerance model: it never crashes, it shows objective errors with version source on data-incompatible failures, and it hides its entry on command-change failures. It SHALL NOT mutate store registrations or switch the active project root.
 
 #### Scenario: Show registered stores
 
-- **GIVEN** at least one store is registered on the machine and the CLI is 1.5.0+
+- **GIVEN** at least one store is registered and the CLI returns compatible data
 - **WHEN** the user opens the Stores panel
 - **THEN** the UI SHALL list each store's id and root path
 - **AND** SHALL display health facts derived from `openspec store doctor --json`
@@ -18,13 +18,26 @@ OpenSpecUI SHALL provide a read-only Stores panel that lists machine-registered 
 - **GIVEN** the Stores panel is rendered
 - **WHEN** the user views the panel title or navigation entry
 - **THEN** the UI SHALL show a visible Beta badge
-- **AND** SHALL keep it for the entire early-beta lifecycle of stores
+
+#### Scenario: Show data-incompatible error with version source
+
+- **GIVEN** the CLI returns a structurally incompatible stores payload (data-incompatible)
+- **WHEN** the Stores panel renders
+- **THEN** the UI SHALL objectively display the error
+- **AND** SHALL show the originating OpenSpec CLI version
+- **AND** SHALL NOT crash or hide the entry
+
+#### Scenario: Hide entry on command-change failure
+
+- **GIVEN** the `store list`/`doctor` command is missing or its usage has changed (command-unavailable)
+- **WHEN** the navigation is composed
+- **THEN** the UI SHALL hide the Stores entry
 
 #### Scenario: Refresh store list reactively
 
 - **GIVEN** the Stores panel is open
 - **WHEN** the local store registry changes
-- **THEN** the UI SHALL update via a polling subscription (since the registry lives outside the project directory)
+- **THEN** the UI SHALL update via a polling subscription (the registry lives outside the project directory)
 - **AND** SHALL offer a manual refresh control
 
 #### Scenario: Restrict to live mode
@@ -39,10 +52,3 @@ OpenSpecUI SHALL provide a read-only Stores panel that lists machine-registered 
 - **WHEN** the user interacts with any store entry
 - **THEN** the UI SHALL only show details (no setup/register/unregister/remove actions in this phase)
 - **AND** SHALL NOT change the active project directory
-
-#### Scenario: Degrade gracefully without store-capable CLI
-
-- **GIVEN** the OpenSpec CLI is unavailable or older than 1.5.0
-- **WHEN** the Stores panel loads
-- **THEN** the UI SHALL show a beta-gated degradation message with upgrade guidance
-- **AND** SHALL NOT block the rest of the interface

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,12 @@
       "default": "./dist/openspec-compat.mjs",
       "types": "./dist/openspec-compat.d.mts"
     },
+    "./store-types": {
+      "development": "./src/store-types.ts",
+      "import": "./dist/store-types.mjs",
+      "default": "./dist/store-types.mjs",
+      "types": "./dist/store-types.d.mts"
+    },
     "./markdown-facts": {
       "development": "./src/markdown-facts.ts",
       "import": "./dist/markdown-facts.mjs",
@@ -143,8 +149,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/opsx-entity.ts src/opsx-schema-detail.ts src/task-progress.ts src/hosted-app.ts src/openspec-compat.ts src/markdown-facts.ts src/markdown-reading.ts src/document-translation.ts src/translator.ts src/local-download-profiles.ts src/translation-language-pair.ts src/openspec-annotations.ts src/openspec-projection.ts src/notifications.ts src/sounds.ts src/terminal-theme.ts src/terminal-invocation.ts src/terminal-audio.ts src/terminal-control.ts --format esm --dts",
-    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/opsx-entity.ts src/opsx-schema-detail.ts src/task-progress.ts src/hosted-app.ts src/openspec-compat.ts src/markdown-facts.ts src/markdown-reading.ts src/document-translation.ts src/translator.ts src/local-download-profiles.ts src/translation-language-pair.ts src/openspec-annotations.ts src/openspec-projection.ts src/notifications.ts src/sounds.ts src/terminal-theme.ts src/terminal-invocation.ts src/terminal-audio.ts src/terminal-control.ts --format esm --dts --watch",
+    "build": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/opsx-entity.ts src/opsx-schema-detail.ts src/task-progress.ts src/hosted-app.ts src/openspec-compat.ts src/store-types.ts src/markdown-facts.ts src/markdown-reading.ts src/document-translation.ts src/translator.ts src/local-download-profiles.ts src/translation-language-pair.ts src/openspec-annotations.ts src/openspec-projection.ts src/notifications.ts src/sounds.ts src/terminal-theme.ts src/terminal-invocation.ts src/terminal-audio.ts src/terminal-control.ts --format esm --dts",
+    "dev": "tsdown src/index.ts src/dashboard-display.ts src/opsx-display-path.ts src/opsx-entity.ts src/opsx-schema-detail.ts src/task-progress.ts src/hosted-app.ts src/openspec-compat.ts src/store-types.ts src/markdown-facts.ts src/markdown-reading.ts src/document-translation.ts src/translator.ts src/local-download-profiles.ts src/translation-language-pair.ts src/openspec-annotations.ts src/openspec-projection.ts src/notifications.ts src/sounds.ts src/terminal-theme.ts src/terminal-invocation.ts src/terminal-audio.ts src/terminal-control.ts --format esm --dts --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/core/src/cli-executor.ts
+++ b/packages/core/src/cli-executor.ts
@@ -169,6 +169,29 @@ export class CliExecutor {
   }
 
   /**
+   * 执行 openspec store list --json
+   *
+   * Beta 功能（Stores）。返回原始 CliResult；数据归类（ok / 异常一数据不兼容 /
+   * 异常二指令变更）由调用方用 classifyStoreCliOutput 完成。这样 CliExecutor 保持单一职责。
+   * Spec: openspec-cli-integration › Stores CLI Query Mapping / Beta Feature Fault Tolerance。
+   */
+  async listStores(): Promise<CliResult> {
+    return this.execute(['store', 'list', '--json'])
+  }
+
+  /**
+   * 执行 openspec store doctor [--json] [id]
+   *
+   * Beta 功能（Stores）。同 listStores，归类交给调用方。
+   */
+  async doctorStores(id?: string): Promise<CliResult> {
+    const args = ['store', 'doctor']
+    if (id) args.push(id)
+    args.push('--json')
+    return this.execute(args)
+  }
+
+  /**
    * 流式执行 openspec validate
    */
   validateStream(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -582,6 +582,22 @@ export {
 export { VIRTUAL_PROJECT_DIRNAME, toOpsxDisplayPath } from './opsx-display-path.js'
 export { type ProjectRecoveryStatus } from './runtime-types.js'
 export {
+  StoreDoctorResultSchema,
+  StoreListResultSchema,
+  classifyStoreCliOutput,
+  toStoreFeatureResult,
+  type StoreClassification,
+  type StoreCommandUnavailableError,
+  type StoreDataIncompatibleError,
+  type StoreDiagnostic,
+  type StoreDoctorResult,
+  type StoreDoctorStore,
+  type StoreFeatureError,
+  type StoreFeatureResult,
+  type StoreListEntry,
+  type StoreListResult,
+} from './store-types.js'
+export {
   BUILTIN_TERMINAL_SPAWN_COMMANDS,
   TERMINAL_COMMAND_FIELD_TYPE_VALUES,
   TERMINAL_SHELL_QUOTE_STYLE_VALUES,

--- a/packages/core/src/openspec-compat.test.ts
+++ b/packages/core/src/openspec-compat.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('openspec CLI compatibility law', () => {
   it('parses versions from raw CLI output', () => {
-    expect(parseOpenSpecCliVersion('1.4.1')).toEqual({ major: 1, minor: 4, patch: 1 })
+    expect(parseOpenSpecCliVersion('1.5.0')).toEqual({ major: 1, minor: 5, patch: 0 })
     expect(parseOpenSpecCliVersion('openspec 1.3.0')).toEqual({
       major: 1,
       minor: 3,
@@ -15,7 +15,16 @@ describe('openspec CLI compatibility law', () => {
     })
   })
 
-  it('classifies 1.4.x as the current OpenSpecUI 4.x target line', () => {
+  it('classifies the 1.5 target line as the current OpenSpecUI 4.x target line', () => {
+    expect(classifyOpenSpecCliVersion('1.5.0')).toMatchObject({
+      status: 'current',
+      supported: true,
+      recommended: true,
+      blocksCoreInteractions: false,
+    })
+  })
+
+  it('classifies the prior 1.4 recommended line as current', () => {
     expect(classifyOpenSpecCliVersion('1.4.1')).toMatchObject({
       status: 'current',
       supported: true,
@@ -39,12 +48,12 @@ describe('openspec CLI compatibility law', () => {
       supported: false,
       blocksCoreInteractions: true,
     })
-    expect(classifyOpenSpecCliVersion('1.5.0')).toMatchObject({
+    expect(classifyOpenSpecCliVersion('1.6.0')).toMatchObject({
       status: 'unsupported',
       supported: false,
       blocksCoreInteractions: true,
     })
-    expect(classifyOpenSpecCliVersion('1.5.0').message).toContain(OPENSPEC_CLI_ACCEPTED_RANGE)
+    expect(classifyOpenSpecCliVersion('1.6.0').message).toContain(OPENSPEC_CLI_ACCEPTED_RANGE)
   })
 
   it('blocks unknown versions', () => {

--- a/packages/core/src/openspec-compat.ts
+++ b/packages/core/src/openspec-compat.ts
@@ -1,13 +1,14 @@
 export const OPENSPECUI_TARGET_MAJOR = 4
-export const OPENSPEC_CLI_TARGET_SERIES = '1.4'
+export const OPENSPEC_CLI_TARGET_SERIES = '1.5'
 export const OPENSPEC_CLI_LEGACY_SERIES = '1.3'
 export const OPENSPEC_CLI_MIN_VERSION = '1.3.0'
-export const OPENSPEC_CLI_TARGET_MIN_VERSION = '1.4.0'
-export const OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.5.0'
-export const OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.5.0'
-export const OPENSPEC_CLI_RECOMMENDED_RANGE = '>=1.4.0 <1.5.0'
+export const OPENSPEC_CLI_TARGET_MIN_VERSION = '1.5.0'
+export const OPENSPEC_CLI_RECOMMENDED_MIN_VERSION = '1.4.0'
+export const OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.6.0'
+export const OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.6.0'
+export const OPENSPEC_CLI_RECOMMENDED_RANGE = '>=1.4.0 <1.6.0'
 export const OPENSPEC_CLI_LEGACY_RANGE = '>=1.3.0 <1.4.0'
-export const OPENSPEC_CLI_REFERENCE_TAG_PATTERN = 'v1.4.*'
+export const OPENSPEC_CLI_REFERENCE_TAG_PATTERN = 'v1.5.*'
 
 export interface OpenSpecCliVersion {
   major: number
@@ -60,6 +61,21 @@ function isSeries(version: OpenSpecCliVersion, series: string): boolean {
   return version.major === major && version.minor === minor
 }
 
+/**
+ * A version is "current/recommended" when it falls inside the recommended
+ * range (e.g. `>=1.4.0 <1.6.0`). This intentionally spans more than one minor
+ * series so that both the previous and the target OpenSpec CLI lines are
+ * treated as current without a version-law bump per release.
+ */
+function isCurrentRecommended(version: OpenSpecCliVersion): boolean {
+  const min = parseOpenSpecCliVersion(OPENSPEC_CLI_RECOMMENDED_MIN_VERSION)
+  const max = parseOpenSpecCliVersion(OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION)
+  if (!min || !max) return isSeries(version, OPENSPEC_CLI_TARGET_SERIES)
+  const atOrAboveMin = compareOpenSpecCliVersions(version, min) >= 0
+  const belowMax = compareOpenSpecCliVersions(version, max) < 0
+  return atOrAboveMin && belowMax
+}
+
 export function classifyOpenSpecCliVersion(
   rawVersion: string | undefined
 ): OpenSpecCliCompatibility {
@@ -77,7 +93,7 @@ export function classifyOpenSpecCliVersion(
     }
   }
 
-  if (isSeries(version, OPENSPEC_CLI_TARGET_SERIES)) {
+  if (isCurrentRecommended(version)) {
     return {
       rawVersion,
       version,

--- a/packages/core/src/store-types.test.ts
+++ b/packages/core/src/store-types.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  StoreListResultSchema,
+  classifyStoreCliOutput,
+  toStoreFeatureResult,
+} from './store-types.js'
+
+describe('classifyStoreCliOutput (beta fault-tolerance classification)', () => {
+  const parse = (stdout: string) => StoreListResultSchema.parse(JSON.parse(stdout))
+
+  it('classifies a successful, parseable output as ok', () => {
+    const result = classifyStoreCliOutput({
+      success: true,
+      stdout: JSON.stringify({ stores: [{ id: 'team', root: '/x' }] }),
+      stderr: '',
+      parse,
+    })
+    expect(result.kind).toBe('ok')
+  })
+
+  it('tolerates additive CLI fields (lenient passthrough) and stays ok', () => {
+    const result = classifyStoreCliOutput({
+      success: true,
+      stdout: JSON.stringify({
+        stores: [{ id: 'team', root: '/x', extra: 'future-field' }],
+        unknownTopLevel: true,
+      }),
+      stderr: '',
+      parse,
+    })
+    expect(result.kind).toBe('ok')
+  })
+
+  it('classifies exit-0-but-unparseable output as data-incompatible (异常一) with version source', () => {
+    const result = classifyStoreCliOutput({
+      success: true,
+      stdout: '{ not valid json',
+      stderr: '',
+      parse,
+      cliVersion: '1.5.0',
+    })
+    expect(result.kind).toBe('data-incompatible')
+    if (result.kind === 'data-incompatible') {
+      expect(result.cliVersion).toBe('1.5.0')
+      expect(result.message).toMatch(/incompatible stores payload/)
+    }
+  })
+
+  it('classifies non-zero exit as command-unavailable (异常二) with version source', () => {
+    const result = classifyStoreCliOutput({
+      success: false,
+      stdout: '',
+      stderr: 'error: unknown command',
+      parse,
+      cliVersion: '1.4.0',
+    })
+    expect(result.kind).toBe('command-unavailable')
+    if (result.kind === 'command-unavailable') {
+      expect(result.cliVersion).toBe('1.4.0')
+      expect(result.message).toMatch(/unknown command/)
+    }
+  })
+})
+
+describe('toStoreFeatureResult', () => {
+  const parse = (stdout: string) => StoreListResultSchema.parse(JSON.parse(stdout))
+
+  it('returns available=true with parsed stores for ok classification', () => {
+    const cls = classifyStoreCliOutput({
+      success: true,
+      stdout: JSON.stringify({ stores: [{ id: 'a', root: '/a' }] }),
+      stderr: '',
+      parse,
+    })
+    const result = toStoreFeatureResult(cls, {
+      fromData: (data) => (data as { stores: { id: string }[] }).stores,
+      fallback: [],
+      cliVersion: '1.5.0',
+    })
+    expect(result.available).toBe(true)
+    expect(result.stores).toHaveLength(1)
+    expect(result.cliVersion).toBe('1.5.0')
+    expect(result.error).toBeUndefined()
+  })
+
+  it('returns available=false with fallback and error for data-incompatible', () => {
+    const cls = classifyStoreCliOutput({
+      success: true,
+      stdout: 'broken',
+      stderr: '',
+      parse,
+      cliVersion: '1.5.0',
+    })
+    const result = toStoreFeatureResult(cls, { fromData: () => [], fallback: [] })
+    expect(result.available).toBe(false)
+    expect(result.stores).toEqual([])
+    expect(result.error?.kind).toBe('data-incompatible')
+  })
+
+  it('returns available=false with fallback and error for command-unavailable', () => {
+    const cls = classifyStoreCliOutput({
+      success: false,
+      stdout: '',
+      stderr: 'no such command',
+      parse,
+    })
+    const result = toStoreFeatureResult(cls, { fromData: () => [], fallback: [] })
+    expect(result.available).toBe(false)
+    expect(result.stores).toEqual([])
+    expect(result.error?.kind).toBe('command-unavailable')
+  })
+})

--- a/packages/core/src/store-types.ts
+++ b/packages/core/src/store-types.ts
@@ -1,0 +1,216 @@
+import { z } from 'zod'
+
+/**
+ * Beta feature fault-tolerance model (manager directive).
+ *
+ * 对于 beta 功能，openspecui 不负责兼容性。但这也意味着所有功能在后台需要有较强的容错能力
+ * （没有这个功能也要能捕捉到错误），然后前端显示这个错误。这个错误一般是两种：
+ *
+ *  1. 数据不兼容 — 当前的 openspecui 不支持/不兼容 openspec-cli 提供的数据。通过 zod 对 CLI
+ *     输出做宽松验证，所以除非 openspec-cli 破坏性更新提供了不兼容的数据结构，我们才会异常。
+ *     → 前端处理：客观显示错误，并提供错误的版本来源信息（版本信息非常重要）。
+ *
+ *  2. 指令用法变了 — openspec-cli 直接修改了指令的用法，属于 openspec 上了比较大的破坏性更新。
+ *     → 前端处理：直接隐藏入口（对弱 beta 入口而言）。
+ *
+ * 不论哪种情况，前端都不能因此崩溃。
+ *
+ * Stores (OpenSpec 1.5.0, very early beta) 是这个范式的首个落地：它是个很弱的入口——低版本
+ * 没有、当前版本不稳定，因此异常一只需客观显示版本信息，异常二直接隐藏入口即可。
+ *
+ * Spec: openspec-cli-integration › "Beta Feature Fault Tolerance".
+ */
+
+// ---------------------------------------------------------------------------
+// Lenient zod schemas
+// ---------------------------------------------------------------------------
+//
+// 宽松验证：用 .passthrough() 容忍 CLI 新增字段，关键字段可选。这样 openspec-cli 的非破坏性
+// （加字段）更新不会误报为异常一；只有真正破坏性的数据结构变更才会让解析失败。
+
+const StoreDiagnosticSchema = z
+  .object({
+    severity: z.string().optional(),
+    code: z.string().optional(),
+    message: z.string().optional(),
+    target: z.string().optional(),
+    fix: z.string().optional(),
+  })
+  .passthrough()
+
+const StoreListEntrySchema = z
+  .object({
+    id: z.string(),
+    root: z.string(),
+  })
+  .passthrough()
+
+export const StoreListResultSchema = z
+  .object({
+    stores: z.array(StoreListEntrySchema).default([]),
+    status: z.array(StoreDiagnosticSchema).optional(),
+  })
+  .passthrough()
+
+const StoreOpenSpecRootSchema = z
+  .object({
+    present: z.boolean().nullable().optional(),
+    healthy: z.boolean().nullable().optional(),
+  })
+  .passthrough()
+
+const StoreMetadataSchema = z
+  .object({
+    present: z.boolean().nullable().optional(),
+    valid: z.boolean().nullable().optional(),
+    id: z.string().nullable().optional(),
+    remote: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+const StoreGitFactsSchema = z
+  .object({
+    is_repository: z.boolean().nullable().optional(),
+    has_commits: z.boolean().nullable().optional(),
+    has_uncommitted_changes: z.boolean().nullable().optional(),
+    has_remote: z.boolean().nullable().optional(),
+    origin_url: z.string().nullable().optional(),
+  })
+  .passthrough()
+
+const StoreDoctorStoreSchema = z
+  .object({
+    id: z.string().optional(),
+    root: z.string().optional(),
+    metadata_path: z.string().nullable().optional(),
+    openspec_root: StoreOpenSpecRootSchema.optional(),
+    metadata: StoreMetadataSchema.optional(),
+    git: StoreGitFactsSchema.optional(),
+    status: z.array(StoreDiagnosticSchema).optional(),
+  })
+  .passthrough()
+
+export const StoreDoctorResultSchema = z
+  .object({
+    stores: z.array(StoreDoctorStoreSchema).default([]),
+    status: z.array(StoreDiagnosticSchema).optional(),
+  })
+  .passthrough()
+
+// ---------------------------------------------------------------------------
+// Public lenient field types (inferred; all extra fields tolerated)
+// ---------------------------------------------------------------------------
+
+export type StoreListEntry = z.infer<typeof StoreListEntrySchema>
+export type StoreDoctorStore = z.infer<typeof StoreDoctorStoreSchema>
+export type StoreListResult = z.infer<typeof StoreListResultSchema>
+export type StoreDoctorResult = z.infer<typeof StoreDoctorResultSchema>
+export type StoreDiagnostic = z.infer<typeof StoreDiagnosticSchema>
+
+// ---------------------------------------------------------------------------
+// Fault-tolerance error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * 异常一：数据不兼容。
+ * CLI 命令成功执行（exit 0），但返回的数据结构 openspecui 无法解析（zod 宽松验证仍失败）。
+ * 这是 openspec-cli 提供了不兼容数据结构的破坏性更新。前端应客观显示错误 + 版本来源信息。
+ */
+export type StoreDataIncompatibleError = {
+  kind: 'data-incompatible'
+  message: string
+  cliVersion?: string
+}
+
+/**
+ * 异常二：指令用法变了 / 指令缺失。
+ * openspec-cli 直接修改了指令用法（非零退出、找不到子命令等），属于较大的破坏性更新。
+ * 对弱 beta 入口，前端直接隐藏入口。
+ */
+export type StoreCommandUnavailableError = {
+  kind: 'command-unavailable'
+  message: string
+  cliVersion?: string
+}
+
+/** 统一的 beta 功能错误载荷，两种异常都携带版本来源信息。 */
+export type StoreFeatureError = StoreDataIncompatibleError | StoreCommandUnavailableError
+
+/**
+ * 一个 beta 功能端点的统一返回型。后端永不抛未捕获错误：成功返回 stores，失败返回结构化的
+ * error（含异常类型与 cliVersion），available 标志该功能在当前 CLI 下是否可用。
+ */
+export type StoreFeatureResult<T = StoreListEntry[]> = {
+  available: boolean
+  stores: T
+  error?: StoreFeatureError
+  cliVersion?: string
+}
+
+/**
+ * 把一次 CLI 调用的原始结果归类为三种状态之一（范式核心判定逻辑）。
+ *
+ * 判定规则：
+ *  - exit 0 且 zod 宽松验证通过 → 'ok'
+ *  - exit 0 但 zod 失败 → 'data-incompatible'（异常一）
+ *  - 非 0 退出 / spawn 失败 → 'command-unavailable'（异常二）
+ */
+export type StoreClassification = { kind: 'ok'; data: unknown } | StoreFeatureError
+
+export function classifyStoreCliOutput(input: {
+  success: boolean
+  stdout: string
+  stderr: string
+  parse: (stdout: string) => unknown
+  cliVersion?: string
+}): StoreClassification {
+  const { success, stdout, stderr, parse, cliVersion } = input
+
+  // 异常二：指令用法变了 / 指令缺失。CLI 没有按预期执行（非零退出或 spawn 失败）。
+  if (!success) {
+    return {
+      kind: 'command-unavailable',
+      message: stderr.trim() || 'OpenSpec CLI store command failed or is unavailable.',
+      ...(cliVersion ? { cliVersion } : {}),
+    }
+  }
+
+  // exit 0：尝试宽松解析。
+  try {
+    const data = parse(stdout)
+    return { kind: 'ok', data }
+  } catch (error) {
+    // 异常一：数据不兼容。命令成功了，但返回的数据结构 openspecui 解析不了。
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      kind: 'data-incompatible',
+      message: `OpenSpec CLI returned an incompatible stores payload: ${message}`,
+      ...(cliVersion ? { cliVersion } : {}),
+    }
+  }
+}
+
+/**
+ * 把归类结果转换成端点返回型。成功时 stores = data，失败时 stores = fallback（通常是空数组）
+ * 并附上 error。始终尽力带上 cliVersion（版本信息非常重要）。
+ */
+export function toStoreFeatureResult<T>(
+  classification: StoreClassification,
+  options: { fromData: (data: unknown) => T; fallback: T; cliVersion?: string }
+): StoreFeatureResult<T> {
+  const cliVersion = options.cliVersion
+  if (classification.kind === 'ok') {
+    return {
+      available: true,
+      stores: options.fromData(classification.data),
+      ...(cliVersion ? { cliVersion } : {}),
+    }
+  }
+
+  return {
+    available: false,
+    stores: options.fallback,
+    error: classification,
+    ...(cliVersion ? { cliVersion } : {}),
+  }
+}

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -16,6 +16,7 @@ import type {
 } from '@openspecui/core'
 import {
   BatchTranslateInputSchema,
+  classifyStoreCliOutput,
   CodeEditorThemeSchema,
   DashboardConfigSchema,
   DocumentTranslationConfigUpdateSchema,
@@ -33,9 +34,12 @@ import {
   resolveTerminalShellDefaults,
   ServiceTranslationEngineIdSchema,
   sniffGlobalCli,
+  StoreDoctorResultSchema,
+  StoreListResultSchema,
   subscribeWatcherRuntimeStatus,
   TerminalConfigSchema,
   TerminalRendererEngineSchema,
+  toStoreFeatureResult,
   TranslationCacheReadInputSchema,
   TranslationCacheWriteInputSchema,
   TranslationEngineIdSchema,
@@ -51,6 +55,11 @@ import {
   type SchemaDetail,
   type SchemaInfo,
   type SchemaResolution,
+  type StoreDoctorResult,
+  type StoreDoctorStore,
+  type StoreFeatureResult,
+  type StoreListEntry,
+  type StoreListResult,
   type TemplateContentMap,
   type TemplatesMap,
   type ToolInitDelivery,
@@ -2477,6 +2486,128 @@ export const gitRouter = router({
 })
 
 /**
+ * Stores router — read-only discovery of machine-registered OpenSpec stores (beta).
+ *
+ * 实现 beta 功能容错范式（spec: openspec-cli-integration › Beta Feature Fault Tolerance）：
+ * 后端对 `openspec store list/doctor --json` 做宽松解析，把失败归类为两类异常，**永不抛未捕获错误**。
+ *  - 异常一（数据不兼容）：exit 0 但 zod 宽松验证失败 → available=false + error.kind='data-incompatible'
+ *  - 异常二（指令变更/缺失）：非零退出 → available=false + error.kind='command-unavailable'
+ * 两种异常都尽力携带 cliVersion（版本信息非常重要）。前端据此决定"显示错误+版本"或"隐藏入口"。
+ */
+const STORES_LIST_CACHE_TTL_MS = 30_000
+let cachedCliVersion: { value: string | undefined; expiresAt: number } | null = null
+
+async function resolveCliVersion(ctx: Context): Promise<string | undefined> {
+  const now = Date.now()
+  if (cachedCliVersion && cachedCliVersion.expiresAt > now) {
+    return cachedCliVersion.value
+  }
+  try {
+    const availability = await ctx.cliExecutor.checkAvailability()
+    cachedCliVersion = { value: availability.version, expiresAt: now + STORES_LIST_CACHE_TTL_MS }
+    return availability.version
+  } catch {
+    cachedCliVersion = { value: undefined, expiresAt: now + STORES_LIST_CACHE_TTL_MS }
+    return undefined
+  }
+}
+
+async function fetchStoresList(ctx: Context): Promise<StoreFeatureResult<StoreListEntry[]>> {
+  // 永不抛：CLI 调用、解析、版本探测全部包裹，失败归类为两类异常之一。
+  const cliVersion = await resolveCliVersion(ctx).catch(() => undefined)
+  try {
+    const result = await ctx.cliExecutor.listStores()
+    const classification = classifyStoreCliOutput({
+      success: result.success,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      parse: (stdout) => StoreListResultSchema.parse(JSON.parse(stdout)),
+      cliVersion,
+    })
+    return toStoreFeatureResult(classification, {
+      fromData: (data) => {
+        const parsed = data as StoreListResult
+        return Array.isArray(parsed.stores) ? parsed.stores : []
+      },
+      fallback: [],
+      cliVersion,
+    })
+  } catch (error) {
+    // 兜底：任何未预期错误都归类为指令变更（异常二），让前端隐藏入口，绝不崩溃。
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      available: false,
+      stores: [],
+      error: { kind: 'command-unavailable', message, ...(cliVersion ? { cliVersion } : {}) },
+      ...(cliVersion ? { cliVersion } : {}),
+    }
+  }
+}
+
+async function fetchStoresDoctor(
+  ctx: Context,
+  id?: string
+): Promise<StoreFeatureResult<StoreDoctorStore[]>> {
+  const cliVersion = await resolveCliVersion(ctx).catch(() => undefined)
+  try {
+    const result = await ctx.cliExecutor.doctorStores(id)
+    const classification = classifyStoreCliOutput({
+      success: result.success,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      parse: (stdout) => StoreDoctorResultSchema.parse(JSON.parse(stdout)),
+      cliVersion,
+    })
+    return toStoreFeatureResult(classification, {
+      fromData: (data) => {
+        const parsed = data as StoreDoctorResult
+        return Array.isArray(parsed.stores) ? parsed.stores : []
+      },
+      fallback: [],
+      cliVersion,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      available: false,
+      stores: [],
+      error: { kind: 'command-unavailable', message, ...(cliVersion ? { cliVersion } : {}) },
+      ...(cliVersion ? { cliVersion } : {}),
+    }
+  }
+}
+
+export const storesRouter = router({
+  /** store 列表（只读，带异常归类） */
+  list: publicProcedure.query(({ ctx }) => fetchStoresList(ctx)),
+
+  /** 单个/全部 store 健康诊断（按需，带异常归类） */
+  doctor: publicProcedure
+    .input(z.object({ id: z.string().optional() }).optional())
+    .query(({ ctx, input }) => fetchStoresDoctor(ctx, input?.id)),
+
+  /**
+   * 响应式订阅。registry 在 ~/.local/share/openspec（projectDir 之外，watcher 不可达），
+   * 故用轮询（间隔 5s）而非文件订阅。手动刷新通过重新订阅或 refetch 实现。
+   */
+  subscribe: publicProcedure.subscription(({ ctx }) => {
+    return observable<StoreFeatureResult<StoreListEntry[]>>((emit) => {
+      const push = () => {
+        void fetchStoresList(ctx)
+          .then((result) => emit.next(result))
+          .catch(() => {
+            // 订阅永不抛：最坏情况静默，前端保持上一次已知状态。
+          })
+      }
+      push()
+      const timer = setInterval(push, 5_000)
+      timer.unref()
+      return () => clearInterval(timer)
+    })
+  }),
+})
+
+/**
  * Main app router
  */
 export const appRouter = router({
@@ -2498,6 +2629,7 @@ export const appRouter = router({
   sounds: soundsRouter,
   cli: cliRouter,
   opsx: opsxRouter,
+  stores: storesRouter,
   kv: kvRouter,
   search: searchRouter,
   system: systemRouter,

--- a/packages/web/src/components/cli-health-gate.test.tsx
+++ b/packages/web/src/components/cli-health-gate.test.tsx
@@ -94,12 +94,12 @@ describe('CliHealthGate', () => {
 
     renderGate()
 
-    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).toBeInTheDocument()
+    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).toBeInTheDocument()
     expect(screen.getByText(/Detected OpenSpec CLI 1.2.0/)).toBeInTheDocument()
   })
 
   it('offers a skip-version-check escape hatch when the CLI is available', async () => {
-    availability = { available: true, version: '1.5.0' }
+    availability = { available: true, version: '1.6.0' }
 
     renderGate()
 
@@ -107,7 +107,7 @@ describe('CliHealthGate', () => {
   })
 
   it('clears the blocking dialog after skipping the version check', async () => {
-    availability = { available: true, version: '1.5.0' }
+    availability = { available: true, version: '1.6.0' }
 
     renderGate()
 
@@ -115,7 +115,7 @@ describe('CliHealthGate', () => {
     fireEvent.click(skip)
 
     await waitFor(() => {
-      expect(screen.queryByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).not.toBeInTheDocument()
     })
   })
 
@@ -124,7 +124,7 @@ describe('CliHealthGate', () => {
 
     renderGate()
 
-    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.5.0 Required/)).toBeInTheDocument()
+    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).toBeInTheDocument()
     expect(screen.queryByText(/Skip version check/)).not.toBeInTheDocument()
   })
 })

--- a/packages/web/src/components/layout/desktop-sidebar.test.tsx
+++ b/packages/web/src/components/layout/desktop-sidebar.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@/lib/use-dark-mode', () => ({
   useDarkMode: () => false,
 }))
 
+vi.mock('@/lib/use-stores-visibility', () => ({
+  useStoresVisibility: () => ({ visible: true }),
+}))
+
 vi.mock('@/lib/use-nav-controller', () => ({
   useNavLayout: () => ({
     mainTabs: ['/dashboard', '/config', '/settings'],

--- a/packages/web/src/components/layout/desktop-sidebar.tsx
+++ b/packages/web/src/components/layout/desktop-sidebar.tsx
@@ -2,6 +2,7 @@ import { getHostedScopedStorageKey } from '@/lib/hosted-session'
 import { getBasePath, isStaticMode } from '@/lib/static-mode'
 import { useDarkMode } from '@/lib/use-dark-mode'
 import { useNavLayout } from '@/lib/use-nav-controller'
+import { useStoresVisibility } from '@/lib/use-stores-visibility'
 import { VTLink, vtNavController } from '@/lib/view-transitions/navigation'
 import { PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
 import { useEffect, useState } from 'react'
@@ -33,6 +34,8 @@ export function DesktopSidebar() {
   const navLayout = useNavLayout()
   const basePath = getBasePath()
   const isStatic = isStaticMode()
+  // Beta 入口可见性：Stores 在异常二（command-unavailable）时隐藏入口。
+  const { visible: storesVisible } = useStoresVisibility()
   const [collapsed, setCollapsed] = useState(readDesktopSidebarCollapsed)
 
   useEffect(() => {
@@ -93,25 +96,27 @@ export function DesktopSidebar() {
         /* Static mode: simple nav list */
         <div className="flex flex-1 flex-col">
           <ul className="flex-1 space-y-1">
-            {navItems.map((item) => (
-              <li key={item.to}>
-                <Tooltip content={collapsed ? item.label : undefined} sideOffset={12}>
-                  <VTLink
-                    to={item.to}
-                    aria-label={collapsed ? item.label : undefined}
-                    title={collapsed ? item.label : undefined}
-                    className={`hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md py-2 ${
-                      collapsed ? 'justify-center px-2' : 'px-3'
-                    }`}
-                  >
-                    <item.icon className="h-4 w-4 shrink-0" />
-                    {!collapsed ? (
-                      <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
-                    ) : null}
-                  </VTLink>
-                </Tooltip>
-              </li>
-            ))}
+            {navItems
+              .filter((item) => item.to !== '/stores' || storesVisible)
+              .map((item) => (
+                <li key={item.to}>
+                  <Tooltip content={collapsed ? item.label : undefined} sideOffset={12}>
+                    <VTLink
+                      to={item.to}
+                      aria-label={collapsed ? item.label : undefined}
+                      title={collapsed ? item.label : undefined}
+                      className={`hover:bg-muted [&.active]:bg-primary [&.active]:text-primary-foreground flex items-center gap-2 rounded-md py-2 ${
+                        collapsed ? 'justify-center px-2' : 'px-3'
+                      }`}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" />
+                      {!collapsed ? (
+                        <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                      ) : null}
+                    </VTLink>
+                  </Tooltip>
+                </li>
+              ))}
           </ul>
           <div className="border-border space-y-1 border-t pt-4">
             <Tooltip content={collapsed ? settingsItem.label : undefined} sideOffset={12}>
@@ -138,7 +143,7 @@ export function DesktopSidebar() {
           <div className="flex-1">
             <AreaNav
               area="main"
-              tabs={navLayout.mainTabs}
+              tabs={navLayout.mainTabs.filter((tab) => tab !== '/stores' || storesVisible)}
               className="h-full"
               collapsed={collapsed}
             />

--- a/packages/web/src/components/layout/nav-items.test.ts
+++ b/packages/web/src/components/layout/nav-items.test.ts
@@ -17,4 +17,13 @@ describe('navItems', () => {
     })
     expect(navItems.some((item) => item.to === '/git')).toBe(false)
   })
+
+  it('registers Stores as a beta main-area entry', () => {
+    expect(allNavItems.find((item) => item.to === '/stores')).toMatchObject({
+      label: 'Stores',
+      defaultArea: 'main',
+      beta: true,
+    })
+    expect(navItems.some((item) => item.to === '/stores')).toBe(true)
+  })
 })

--- a/packages/web/src/components/layout/nav-items.ts
+++ b/packages/web/src/components/layout/nav-items.ts
@@ -6,6 +6,7 @@ import {
   LayoutDashboard,
   Settings,
   SlidersHorizontal,
+  Store,
   Terminal,
   type LucideIcon,
 } from 'lucide-react'
@@ -18,6 +19,7 @@ export type AppRoute =
   | '/specs'
   | '/changes'
   | '/archive'
+  | '/stores'
   | '/settings'
   | '/terminal'
 
@@ -27,6 +29,12 @@ export interface NavItem {
   label: string
   /** Which area this tab defaults to */
   defaultArea: 'main' | 'bottom'
+  /**
+   * Whether this entry is a beta feature whose visibility is controlled at
+   * runtime by fault tolerance (e.g. Stores hides when its CLI command is
+   * unavailable). Non-beta entries are always visible.
+   */
+  beta?: boolean
 }
 
 /** All navigation items — single source of truth */
@@ -37,6 +45,7 @@ export const allNavItems: NavItem[] = [
   { to: '/specs', icon: FileText, label: 'Specs', defaultArea: 'main' },
   { to: '/changes', icon: GitBranch, label: 'Changes', defaultArea: 'main' },
   { to: '/archive', icon: Archive, label: 'Archive', defaultArea: 'main' },
+  { to: '/stores', icon: Store, label: 'Stores', defaultArea: 'main', beta: true },
   { to: '/settings', icon: Settings, label: 'Settings', defaultArea: 'main' },
   { to: '/terminal', icon: Terminal, label: 'Terminal', defaultArea: 'bottom' },
 ]

--- a/packages/web/src/lib/nav-controller.test.ts
+++ b/packages/web/src/lib/nav-controller.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_MAIN_TABS: TabId[] = [
   '/specs',
   '/changes',
   '/archive',
+  '/stores',
   '/settings',
 ]
 
@@ -37,6 +38,7 @@ const ALL_TABS: TabId[] = [
   '/specs',
   '/changes',
   '/archive',
+  '/stores',
   '/settings',
   '/terminal',
 ]

--- a/packages/web/src/lib/nav-controller.ts
+++ b/packages/web/src/lib/nav-controller.ts
@@ -10,6 +10,7 @@ export type TabId =
   | '/specs'
   | '/changes'
   | '/archive'
+  | '/stores'
   | '/settings'
   | '/terminal'
 
@@ -88,6 +89,7 @@ const ALL_TABS: readonly TabId[] = [
   '/specs',
   '/changes',
   '/archive',
+  '/stores',
   '/settings',
   '/terminal',
 ]
@@ -97,6 +99,7 @@ const DEFAULT_MAIN_TABS: TabId[] = [
   '/specs',
   '/changes',
   '/archive',
+  '/stores',
   '/settings',
 ]
 const DEFAULT_BOTTOM_TABS: TabId[] = isStaticMode() ? [] : ['/git', '/terminal']

--- a/packages/web/src/lib/route-tree.ts
+++ b/packages/web/src/lib/route-tree.ts
@@ -16,6 +16,7 @@ import { SearchRoute } from '../routes/search'
 import { Settings } from '../routes/settings'
 import { SpecList } from '../routes/spec-list'
 import { SpecView } from '../routes/spec-view'
+import { StoresList } from '../routes/stores-list'
 import { TerminalPage } from '../routes/terminal'
 
 /** Create the interactive route tree (includes terminal route by default). */
@@ -53,6 +54,7 @@ export function createRouteTree(rootRoute: AnyRootRoute, opts?: { includeTermina
       path: '/archive/$changeId',
       component: ArchiveView,
     }),
+    createRoute({ getParentRoute: () => rootRoute, path: '/stores', component: StoresList }),
     createRoute({ getParentRoute: () => rootRoute, path: '/settings', component: Settings }),
   ]
 

--- a/packages/web/src/lib/use-stores-visibility.ts
+++ b/packages/web/src/lib/use-stores-visibility.ts
@@ -1,0 +1,36 @@
+import { isStaticMode } from '@/lib/static-mode'
+import { trpc } from '@/lib/trpc'
+import { useQuery } from '@tanstack/react-query'
+
+import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
+
+/**
+ * 控制 Stores 入口的可见性（beta 功能容错范式的一部分）。
+ *
+ * 异常二（command-unavailable）：指令用法变了/指令缺失，直接隐藏入口。
+ * 异常一（data-incompatible）：数据不兼容，不隐藏入口（面板内客观显示错误 + 版本信息）。
+ *
+ * 与 StoresList 共享同一份 TanStack Query 缓存（同 queryKey），避免重复请求。
+ */
+export function useStoresVisibility(): { visible: boolean } {
+  const staticMode = isStaticMode()
+
+  const { data } = useQuery({
+    ...trpc.stores.list.queryOptions(),
+    enabled: !staticMode,
+    staleTime: 30_000,
+  })
+
+  if (staticMode) {
+    return { visible: false }
+  }
+
+  // 数据还没回来时，先显示入口（乐观），避免 beta 入口闪烁消失。
+  if (data === undefined) {
+    return { visible: true }
+  }
+
+  const result = data as StoreFeatureResult<StoreListEntry[]>
+  const hidden = result.available === false && result.error?.kind === 'command-unavailable'
+  return { visible: !hidden }
+}

--- a/packages/web/src/routes/stores-list.test.tsx
+++ b/packages/web/src/routes/stores-list.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StoresList } from './stores-list'
+
+const storesListDataMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/static-mode', () => ({
+  isStaticMode: () => false,
+}))
+
+vi.mock('@/lib/trpc', () => ({
+  trpc: {
+    stores: {
+      list: {
+        // TanStack Query 的 queryOptions() 调用：返回一个带 queryKey/queryFn 的对象。
+        queryOptions: () => ({
+          queryKey: ['stores', 'list'],
+          queryFn: () => storesListDataMock(),
+        }),
+      },
+    },
+  },
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: ({ queryFn }: { queryFn: () => unknown }) => {
+    try {
+      const data = queryFn()
+      return { data, isLoading: false, isFetching: false, refetch: vi.fn() }
+    } catch {
+      return { data: undefined, isLoading: false, isFetching: false, refetch: vi.fn() }
+    }
+  },
+}))
+
+describe('StoresList (beta fault-tolerance)', () => {
+  beforeEach(() => {
+    storesListDataMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the list and Beta badge when stores are available', () => {
+    storesListDataMock.mockReturnValue({
+      available: true,
+      stores: [{ id: 'team', root: '/repo/team' }],
+    })
+
+    render(<StoresList />)
+
+    expect(screen.getByText('Stores')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(screen.getByText('team')).toBeInTheDocument()
+    expect(screen.getByText('/repo/team')).toBeInTheDocument()
+  })
+
+  it('renders an objective error with version source on data-incompatible (异常一)', () => {
+    storesListDataMock.mockReturnValue({
+      available: false,
+      stores: [],
+      error: {
+        kind: 'data-incompatible',
+        message: 'boom',
+        cliVersion: '1.5.0',
+      },
+      cliVersion: '1.5.0',
+    })
+
+    render(<StoresList />)
+
+    expect(screen.getByText('Stores data is incompatible')).toBeInTheDocument()
+    expect(screen.getByText('boom')).toBeInTheDocument()
+    // 版本信息非常重要——必须显示。
+    expect(screen.getByText(/1\.5\.0/)).toBeInTheDocument()
+  })
+
+  it('renders a minimal unavailable notice on command-unavailable (异常二)', () => {
+    storesListDataMock.mockReturnValue({
+      available: false,
+      stores: [],
+      error: {
+        kind: 'command-unavailable',
+        message: 'no such command',
+        cliVersion: '1.4.0',
+      },
+      cliVersion: '1.4.0',
+    })
+
+    render(<StoresList />)
+
+    // 入口正常会在 nav 层隐藏；这里只验证组件本身不崩溃并给出提示。
+    expect(screen.getByText(/Stores are unavailable/)).toBeInTheDocument()
+    expect(screen.queryByText('team')).not.toBeInTheDocument()
+  })
+
+  it('renders an empty state when no stores are registered', () => {
+    storesListDataMock.mockReturnValue({ available: true, stores: [] })
+
+    render(<StoresList />)
+
+    expect(screen.getByText(/No stores registered/)).toBeInTheDocument()
+  })
+})

--- a/packages/web/src/routes/stores-list.tsx
+++ b/packages/web/src/routes/stores-list.tsx
@@ -1,0 +1,154 @@
+import { Badge } from '@/components/badge'
+import { isStaticMode } from '@/lib/static-mode'
+import { trpc } from '@/lib/trpc'
+import { useQuery } from '@tanstack/react-query'
+import { AlertCircle, LoaderCircle, RefreshCw, Store } from 'lucide-react'
+
+import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
+
+/**
+ * Stores 面板（只读，Beta）。
+ *
+ * 实现 beta 功能容错范式（spec: openspec-cli-integration › Beta Feature Fault Tolerance）：
+ * 前端永不崩溃，按后端返回的 error.kind 差异化处理——
+ *  - 异常一（data-incompatible）：客观显示错误 + 版本来源信息（cliVersion，版本信息非常重要）。
+ *  - 异常二（command-unavailable）：入口本身在 nav 层隐藏（见 useStoresVisibility），
+ *    即使渲染到这里也给出最简提示而非崩溃。
+ *
+ * 数据来自 `openspec store list --json`（后端宽松解析 + 两类异常归类），仅 live 模式可见。
+ */
+export function StoresList() {
+  const staticMode = isStaticMode()
+
+  const { data, isLoading, isFetching, refetch } = useQuery({
+    ...trpc.stores.list.queryOptions(),
+    enabled: !staticMode,
+    staleTime: 30_000,
+  })
+
+  if (staticMode) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-2 p-4 text-sm">
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        Stores are only available in live mode.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
+          <Store className="h-6 w-6 shrink-0" />
+          Stores
+          <Badge tone="subtle" size="xs">
+            Beta
+          </Badge>
+        </h1>
+        <button
+          onClick={() => void refetch()}
+          disabled={isFetching}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs disabled:opacity-50"
+          title="Refresh stores"
+        >
+          {isFetching ? (
+            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5" />
+          )}
+          Refresh
+        </button>
+      </div>
+
+      <StoresBody data={data} loading={isLoading && !data} />
+    </div>
+  )
+}
+
+function StoresBody({
+  data,
+  loading,
+}: {
+  data: StoreFeatureResult<StoreListEntry[]> | undefined
+  loading: boolean
+}) {
+  if (loading) {
+    return <div className="route-loading animate-pulse">Loading stores...</div>
+  }
+
+  // 异常一：数据不兼容 → 客观显示错误 + 版本来源信息。
+  if (data?.error?.kind === 'data-incompatible') {
+    return (
+      <div className="text-muted-foreground space-y-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 text-sm">
+        <div className="flex items-center gap-2 font-medium text-amber-600 dark:text-amber-300">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          Stores data is incompatible
+        </div>
+        <p>{data.error.message}</p>
+        <VersionSource cliVersion={data.error.cliVersion ?? data.cliVersion} />
+      </div>
+    )
+  }
+
+  // 异常二兜底（入口正常会在 nav 层隐藏；若仍渲染到这里，给最简提示，不崩溃）。
+  if (data?.error?.kind === 'command-unavailable') {
+    return (
+      <div className="text-muted-foreground border-border rounded-lg border p-4 text-sm">
+        <div className="flex items-center gap-2">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          Stores are unavailable with this OpenSpec CLI.
+        </div>
+        <VersionSource cliVersion={data.error.cliVersion ?? data.cliVersion} />
+      </div>
+    )
+  }
+
+  const stores = data?.stores ?? []
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm">
+        Machine-registered OpenSpec stores.{' '}
+        <span className="text-xs">
+          (Beta — auto-refreshes every 5s; the registry lives outside the project directory.)
+        </span>
+      </p>
+      <div className="border-border divide-border divide-y rounded-lg border">
+        {stores.map((store) => (
+          <StoresRow key={`${store.id}:${store.root}`} store={store} />
+        ))}
+        {stores.length === 0 && (
+          <div className="text-muted-foreground p-4 text-center">
+            No stores registered. Use{' '}
+            <code className="bg-muted rounded px-1">openspec store setup/register</code> in a
+            terminal.
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+function StoresRow({ store }: { store: StoreListEntry }) {
+  return (
+    <div className="hover:bg-muted/50 flex items-center justify-between p-4">
+      <div className="flex items-center gap-3">
+        <Store className="text-muted-foreground h-5 w-5 shrink-0" />
+        <div>
+          <div className="font-medium">{store.id}</div>
+          <div className="text-muted-foreground truncate text-sm">{store.root}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 版本来源信息展示——版本信息非常重要（manager directive）。 */
+function VersionSource({ cliVersion }: { cliVersion?: string }) {
+  if (!cliVersion) return null
+  return (
+    <p className="text-xs opacity-80">
+      OpenSpec CLI version: <code className="bg-muted rounded px-1">{cliVersion}</code>
+    </p>
+  )
+}

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -22,6 +22,7 @@
       "@openspecui/core/translation-language-pair": ["../core/src/translation-language-pair.ts"],
       "@openspecui/core/notifications": ["../core/src/notifications.ts"],
       "@openspecui/core/openspec-compat": ["../core/src/openspec-compat.ts"],
+      "@openspecui/core/store-types": ["../core/src/store-types.ts"],
       "@openspecui/core/openspec-annotations": ["../core/src/openspec-annotations.ts"],
       "@openspecui/core/openspec-projection": ["../core/src/openspec-projection.ts"],
       "@openspecui/core/opsx-display-path": ["../core/src/opsx-display-path.ts"],


### PR DESCRIPTION
Follows up OpenSpec 1.5.0 Stores. Spec-driven via `openspec` change `add-stores-read-only-panel`.

## What

- **Stores panel (beta)**: read-only list of machine-registered OpenSpec stores (id + root) via `openspec store list --json`, Beta badge, 5s poll (registry lives outside projectDir), live-only.
- **Beta-feature fault-tolerance model** (manager directive, encoded into spec rationale + `store-types.ts` comments): beta features do NOT rely on the version gate. Failures are classified into two kinds:
  - **data-incompatible** (exit 0, lenient zod fails) → panel shows objective error **+ CLI version source**.
  - **command-unavailable** (non-zero/missing) → Stores nav entry is hidden.
  - Frontend never crashes on either.
- **Version law (stable, decoupled)**: 4.x now accepts `>=1.3.0 <1.6.0` (1.5 target, 1.4 current, 1.3 legacy). Previously 1.5.0 was hard-blocked.

## Changes by package

- `@openspecui/core`: `store-types.ts` (lenient passthrough zod + `StoreFeatureError` two-kind + `classifyStoreCliOutput`/`toStoreFeatureResult` + cliVersion), `./store-types` subpath, `CliExecutor.listStores/doctorStores`, `openspec-compat` bump.
- `@openspecui/server`: `storesRouter` (list/doctor/subscribe), every path wrapped (never throws), cached cliVersion (30s TTL).
- `@openspecui/web`: `routes/stores-list.tsx` + `lib/use-stores-visibility.ts` (nav hides on command-unavailable), registered in nav-items/nav-controller/route-tree.

## Local checks (CI-equivalent, all green)

- `pnpm format:check` ✅
- `pnpm lint:ci` ✅
- `pnpm typecheck` ✅
- `pnpm test:ci` ✅
- `pnpm test:browser:ci` ✅
- SSG guard: `pnpm --filter @openspecui/web build:ssg` ✅ (stores not in static snapshot; `static-data-provider` has no stores wiring)
- `openspec validate add-stores-read-only-panel --type change --strict` ✅

## Spec

Change `add-stores-read-only-panel` (schema `opsx-collab-pr-loop`, 4/4 artifacts):
- `openspec-cli-integration`: MODIFY version law + ADD **Beta Feature Fault Tolerance** + Stores CLI Query Mapping
- `opsx-ui-views`: ADD Stores Discovery Panel (Beta)

## Changeset

`.changeset/stores-beta-discovery.md` — `@openspecui/core`/`server`/`web` minor.