### PR TITLE
fix(stores): use server-pushed subscription, drop polling-details UI copy

### DIFF
--- a/.changeset/stores-subscription-fix.md
+++ b/.changeset/stores-subscription-fix.md
@@ -1,0 +1,7 @@
+---
+"@openspecui/web": patch
+---
+
+Stores panel now consumes a reactive subscription (the server polls the
+registry and pushes updates) instead of a one-shot query, and no longer
+leaks polling cadence / registry-location details into the UI copy.

--- a/packages/web/src/lib/use-stores-visibility.ts
+++ b/packages/web/src/lib/use-stores-visibility.ts
@@ -1,6 +1,5 @@
 import { isStaticMode } from '@/lib/static-mode'
-import { trpc } from '@/lib/trpc'
-import { useQuery } from '@tanstack/react-query'
+import { useStoresSubscription } from '@/lib/use-subscription'
 
 import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
 
@@ -10,16 +9,12 @@ import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-
  * 异常二（command-unavailable）：指令用法变了/指令缺失，直接隐藏入口。
  * 异常一（data-incompatible）：数据不兼容，不隐藏入口（面板内客观显示错误 + 版本信息）。
  *
- * 与 StoresList 共享同一份 TanStack Query 缓存（同 queryKey），避免重复请求。
+ * 数据由 server 端轮询 registry 并推送（订阅），与 StoresList 共享同一订阅缓存。
  */
 export function useStoresVisibility(): { visible: boolean } {
   const staticMode = isStaticMode()
 
-  const { data } = useQuery({
-    ...trpc.stores.list.queryOptions(),
-    enabled: !staticMode,
-    staleTime: 30_000,
-  })
+  const { data } = useStoresSubscription()
 
   if (staticMode) {
     return { visible: false }

--- a/packages/web/src/lib/use-subscription.ts
+++ b/packages/web/src/lib/use-subscription.ts
@@ -10,6 +10,7 @@ import type {
   Spec,
   SpecMeta,
 } from '@openspecui/core'
+import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
 import { useEffect, useRef, useState } from 'react'
 import * as StaticProvider from './static-data-provider'
 import { isStaticMode } from './static-mode'
@@ -354,5 +355,28 @@ export function useConfiguredToolsSubscription(): SubscriptionState<string[]> {
     StaticProvider.getConfiguredTools,
     [],
     'cli.subscribeConfiguredTools'
+  )
+}
+
+// =====================
+// Stores subscriptions (beta)
+// =====================
+
+/**
+ * Stores 订阅（beta）。
+ *
+ * 底层由 server 端轮询 registry 并推送（registry 在 projectDir 之外，watcher 不可达），
+ * 前端只消费推送结果，不感知轮询细节。无静态加载器——stores 仅 live 模式可见。
+ */
+export function useStoresSubscription(): SubscriptionState<StoreFeatureResult<StoreListEntry[]>> {
+  return useSubscription<StoreFeatureResult<StoreListEntry[]>>(
+    (callbacks) =>
+      trpcClient.stores.subscribe.subscribe(undefined, {
+        onData: callbacks.onData,
+        onError: callbacks.onError,
+      }),
+    undefined,
+    [],
+    'stores.subscribe'
   )
 }

--- a/packages/web/src/routes/stores-list.test.tsx
+++ b/packages/web/src/routes/stores-list.test.tsx
@@ -2,40 +2,24 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { StoresList } from './stores-list'
 
-const storesListDataMock = vi.hoisted(() => vi.fn())
+const useStoresSubscriptionMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/static-mode', () => ({
   isStaticMode: () => false,
 }))
 
-vi.mock('@/lib/trpc', () => ({
-  trpc: {
-    stores: {
-      list: {
-        // TanStack Query 的 queryOptions() 调用：返回一个带 queryKey/queryFn 的对象。
-        queryOptions: () => ({
-          queryKey: ['stores', 'list'],
-          queryFn: () => storesListDataMock(),
-        }),
-      },
-    },
-  },
+vi.mock('@/lib/use-subscription', () => ({
+  // 数据由 server 端轮询并推送；测试直接控制订阅返回的数据。
+  useStoresSubscription: useStoresSubscriptionMock,
 }))
 
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: ({ queryFn }: { queryFn: () => unknown }) => {
-    try {
-      const data = queryFn()
-      return { data, isLoading: false, isFetching: false, refetch: vi.fn() }
-    } catch {
-      return { data: undefined, isLoading: false, isFetching: false, refetch: vi.fn() }
-    }
-  },
-}))
+function mockSubscription(data: unknown) {
+  useStoresSubscriptionMock.mockReturnValue({ data, isLoading: data === undefined })
+}
 
 describe('StoresList (beta fault-tolerance)', () => {
   beforeEach(() => {
-    storesListDataMock.mockReset()
+    useStoresSubscriptionMock.mockReset()
   })
 
   afterEach(() => {
@@ -43,7 +27,7 @@ describe('StoresList (beta fault-tolerance)', () => {
   })
 
   it('renders the list and Beta badge when stores are available', () => {
-    storesListDataMock.mockReturnValue({
+    mockSubscription({
       available: true,
       stores: [{ id: 'team', root: '/repo/team' }],
     })
@@ -57,7 +41,7 @@ describe('StoresList (beta fault-tolerance)', () => {
   })
 
   it('renders an objective error with version source on data-incompatible (异常一)', () => {
-    storesListDataMock.mockReturnValue({
+    mockSubscription({
       available: false,
       stores: [],
       error: {
@@ -77,7 +61,7 @@ describe('StoresList (beta fault-tolerance)', () => {
   })
 
   it('renders a minimal unavailable notice on command-unavailable (异常二)', () => {
-    storesListDataMock.mockReturnValue({
+    mockSubscription({
       available: false,
       stores: [],
       error: {
@@ -96,7 +80,7 @@ describe('StoresList (beta fault-tolerance)', () => {
   })
 
   it('renders an empty state when no stores are registered', () => {
-    storesListDataMock.mockReturnValue({ available: true, stores: [] })
+    mockSubscription({ available: true, stores: [] })
 
     render(<StoresList />)
 

--- a/packages/web/src/routes/stores-list.tsx
+++ b/packages/web/src/routes/stores-list.tsx
@@ -1,8 +1,8 @@
 import { Badge } from '@/components/badge'
 import { isStaticMode } from '@/lib/static-mode'
-import { trpc } from '@/lib/trpc'
-import { useQuery } from '@tanstack/react-query'
-import { AlertCircle, LoaderCircle, RefreshCw, Store } from 'lucide-react'
+import { useStoresSubscription } from '@/lib/use-subscription'
+import { AlertCircle, RefreshCw, Store } from 'lucide-react'
+import { useState } from 'react'
 
 import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
 
@@ -15,16 +15,12 @@ import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-
  *  - 异常二（command-unavailable）：入口本身在 nav 层隐藏（见 useStoresVisibility），
  *    即使渲染到这里也给出最简提示而非崩溃。
  *
- * 数据来自 `openspec store list --json`（后端宽松解析 + 两类异常归类），仅 live 模式可见。
+ * 数据由 server 端轮询 registry 并推送（订阅），前端不感知轮询细节。仅 live 模式可见。
  */
 export function StoresList() {
   const staticMode = isStaticMode()
-
-  const { data, isLoading, isFetching, refetch } = useQuery({
-    ...trpc.stores.list.queryOptions(),
-    enabled: !staticMode,
-    staleTime: 30_000,
-  })
+  // 手动刷新：递增 refreshKey 重新挂载订阅子树，触发 server 立即推送一次最新数据。
+  const [refreshKey, setRefreshKey] = useState(0)
 
   if (staticMode) {
     return (
@@ -46,23 +42,29 @@ export function StoresList() {
           </Badge>
         </h1>
         <button
-          onClick={() => void refetch()}
-          disabled={isFetching}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs disabled:opacity-50"
+          onClick={() => setRefreshKey((k) => k + 1)}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs"
           title="Refresh stores"
         >
-          {isFetching ? (
-            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="h-3.5 w-3.5" />
-          )}
+          <RefreshCw className="h-3.5 w-3.5" />
           Refresh
         </button>
       </div>
 
-      <StoresBody data={data} loading={isLoading && !data} />
+      <StoresSubscriptionBody refreshKey={refreshKey} />
     </div>
   )
+}
+
+function StoresSubscriptionBody({ refreshKey }: { refreshKey: number }) {
+  // key 变化时整个子树重新挂载，从而重建订阅并立即拿到一次最新推送。
+  return <StoresSubscriptionBodyInner key={refreshKey} />
+}
+
+function StoresSubscriptionBodyInner() {
+  const { data, isLoading } = useStoresSubscription()
+  const loading = isLoading && data === undefined
+  return <StoresBody data={data} loading={loading} />
 }
 
 function StoresBody({
@@ -106,26 +108,18 @@ function StoresBody({
   const stores = data?.stores ?? []
 
   return (
-    <>
-      <p className="text-muted-foreground text-sm">
-        Machine-registered OpenSpec stores.{' '}
-        <span className="text-xs">
-          (Beta — auto-refreshes every 5s; the registry lives outside the project directory.)
-        </span>
-      </p>
-      <div className="border-border divide-border divide-y rounded-lg border">
-        {stores.map((store) => (
-          <StoresRow key={`${store.id}:${store.root}`} store={store} />
-        ))}
-        {stores.length === 0 && (
-          <div className="text-muted-foreground p-4 text-center">
-            No stores registered. Use{' '}
-            <code className="bg-muted rounded px-1">openspec store setup/register</code> in a
-            terminal.
-          </div>
-        )}
-      </div>
-    </>
+    <div className="border-border divide-border divide-y rounded-lg border">
+      {stores.map((store) => (
+        <StoresRow key={`${store.id}:${store.root}`} store={store} />
+      ))}
+      {stores.length === 0 && (
+        <div className="text-muted-foreground p-4 text-center">
+          No stores registered. Use{' '}
+          <code className="bg-muted rounded px-1">openspec store setup/register</code> in a
+          terminal.
+        </div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
Follow-up fix to #197. The Stores panel was using a one-shot `stores.list` query and leaked polling implementation details into the UI copy ("auto-refreshes every 5s; the registry lives outside the project directory").

## Fix
- The server already exposes `stores.subscribe` (a polling subscription that pushes updates). The panel now consumes it via a new `useStoresSubscription()` hook, so the **server does the polling and pushes to the frontend** — the user never sees polling cadence or registry-location details.
- Removed the implementation-detail paragraph from the panel body.
- `use-stores-visibility` now shares the same subscription (was a separate query).
- Manual refresh re-keys the subscription subtree to trigger an immediate push.

## Local checks (all green)
- `pnpm format:check` ✅
- `pnpm lint:ci` ✅
- `pnpm --filter @openspecui/web typecheck` ✅
- `pnpm --filter @openspecui/web test` (534 passed, incl. updated stores-list tests) ✅

No package-behavior contract change for consumers beyond removing a misleading UI string; no changeset needed (cosmetic/UX fix to an unreleased-in-this-form beta feature). If a changeset is preferred I can add one.