### PR TITLE
fix(stores): drop redundant Refresh button

### DIFF
--- a/.changeset/drop-stores-refresh-button.md
+++ b/.changeset/drop-stores-refresh-button.md
@@ -1,0 +1,7 @@
+---
+'@openspecui/web': patch
+---
+
+Remove the Stores panel Refresh button. The panel already auto-updates via the
+server-pushed subscription, so the manual control was redundant (and its
+refresh-key re-mount was unnecessary complexity).

--- a/openspec/changes/drop-stores-refresh-button/.openspec.yaml
+++ b/openspec/changes/drop-stores-refresh-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-06-29

--- a/openspec/changes/drop-stores-refresh-button/loop/checkpoints.md
+++ b/openspec/changes/drop-stores-refresh-button/loop/checkpoints.md
@@ -1,0 +1,22 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively
+- [x] 1.2 Research facts recorded
+- [x] 1.3 Plan reviewed and approved
+- [x] 1.4 Spec delta authored (opsx-ui-views MODIFY)
+
+## 2. Implementation
+
+- [x] 2.1 Remove Refresh button + refreshKey hack; simplify StoresList to direct subscription
+- [x] 2.2 Progress synchronized with implementation artifact
+
+## 3. PR and Release Gates
+
+- [x] 3.1 Changeset included (`@openspecui/web` patch)
+- [x] 3.2 CI-equivalent local checks passed
+- [ ] 3.3 PR checks passed
+
+## 4. Merge Readiness
+
+- [ ] 4.1 OpenSpec archive flow completed
+- [ ] 4.2 PR merge approved

--- a/openspec/changes/drop-stores-refresh-button/loop/implementation.md
+++ b/openspec/changes/drop-stores-refresh-button/loop/implementation.md
@@ -1,0 +1,22 @@
+## Implementation State
+
+Status: **Implemented** — local checks pass.
+
+Completed:
+
+- [x] 删除 `stores-list.tsx` 的 Refresh 按钮、`useState`/`refreshKey`、`StoresSubscriptionBody`/`StoresSubscriptionBodyInner` 中间层；`StoresList` 直接订阅。清理 import（`RefreshCw`、`useState`）。
+- [x] `.changeset/drop-stores-refresh-button.md`（web patch）。
+- [x] 本地 CI 检查通过（typecheck/test 534/format/lint）+ `openspec validate --strict`。
+
+## Decisions Taken
+
+- 订阅已自动推送，手动刷新是冗余 + hacky 实现，直接移除。
+- spec 同步：reactive 刷新场景去掉 manual refresh 要求，并显式声明不暴露轮询细节。
+
+## Divergence Notes
+
+- （none）
+
+## Loopback Triggers
+
+- （none）

--- a/openspec/changes/drop-stores-refresh-button/loop/intake.md
+++ b/openspec/changes/drop-stores-refresh-button/loop/intake.md
@@ -1,0 +1,20 @@
+## User Input
+
+> Store 页面的 Refresh 按钮是不是可以删掉了
+
+## Objective Scope
+
+- 删除 Stores 面板的 Refresh 按钮。订阅已是 server 端每 5 秒自动推送，手动刷新价值很低，且当前实现用 refreshKey 重建整个订阅子树（hacky）。
+- 同步更新 `opsx-ui-views` spec 的 "Refresh store list reactively" 场景，去掉 manual refresh 要求。
+
+## Non-Goals
+
+- 不改 server 端 `stores.subscribe` 的轮询行为（仍每 5s 推送）。
+- 不改其它面板的刷新机制。
+- 不改 beta 容错范式（异常一/异常二处理不变）。
+
+## Acceptance Boundary
+
+- Stores 面板无 Refresh 按钮，无 refreshKey 重建逻辑；订阅挂载即拿首推，之后自动更新。
+- `openspec validate drop-stores-refresh-button --type change --strict` 通过。
+- 本地 CI 等价检查通过；含 `.changeset/*.md`（web patch）。

--- a/openspec/changes/drop-stores-refresh-button/loop/research-plan.md
+++ b/openspec/changes/drop-stores-refresh-button/loop/research-plan.md
@@ -1,0 +1,28 @@
+## Research Findings
+
+- `packages/web/src/routes/stores-list.tsx` 当前有一个 Refresh 按钮，onClick 递增 `refreshKey`，通过 `key={refreshKey}` 重建 `StoresSubscriptionBodyInner` 子树来重建订阅。
+- 订阅（`useStoresSubscription` → `stores.subscribe`）在挂载时立即拿首推，之后由 server 每 5s 推送。手动刷新仅是"提前几秒"拿到下一次推送，价值低。
+- spec `opsx-ui-views › Stores Discovery Panel (Beta) › Refresh store list reactively` 当前要求 `SHALL offer a manual refresh control`，删除按钮需同步改 spec。
+
+## Decision & Plan (For Approval)
+
+- 删除 Refresh 按钮及其 `useState`/`refreshKey`/`StoresSubscriptionBody`/`StoresSubscriptionBodyInner` 中间层，`StoresList` 直接订阅渲染（恢复最简形式）。
+- spec delta：MODIFY `opsx-ui-views` 的 Stores Discovery Panel，把 reactive 刷新场景改为"不暴露轮询细节、不提供手动刷新控件"。
+- 测试不变（已 mock `useStoresSubscription`，不依赖按钮）；清理 import（`RefreshCw`、`useState`）。
+
+## Capability Impact
+
+### Modified Behavior
+
+- Stores 面板移除 Refresh 按钮，纯靠订阅自动更新。
+
+## Risks and Mitigations
+
+| 风险             | 缓解                                                                |
+| ---------------- | ------------------------------------------------------------------- |
+| 用户想要立即刷新 | server 每 5s 推送，等待极短；如未来确需可再加 server 端触发式刷新。 |
+
+## Verification Strategy
+
+- `pnpm --filter @openspecui/web typecheck`、`test`、`format:check`、`lint:ci`。
+- `openspec validate drop-stores-refresh-button --type change --strict`。

--- a/openspec/changes/drop-stores-refresh-button/specs/opsx-ui-views/spec.md
+++ b/openspec/changes/drop-stores-refresh-button/specs/opsx-ui-views/spec.md
@@ -1,0 +1,55 @@
+# opsx-ui-views Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Stores Discovery Panel (Beta)
+
+OpenSpecUI SHALL provide a read-only Stores panel, gated behind a visible Beta badge, that lists machine-registered OpenSpec stores and their health. The panel SHALL follow the beta feature fault-tolerance model: it never crashes, it shows objective errors with version source on data-incompatible failures, and it hides its entry on command-change failures. It SHALL NOT mutate store registrations or switch the active project root.
+
+#### Scenario: Show registered stores
+
+- **GIVEN** at least one store is registered and the CLI returns compatible data
+- **WHEN** the user opens the Stores panel
+- **THEN** the UI SHALL list each store's id and root path
+- **AND** SHALL display health facts derived from `openspec store doctor --json`
+
+#### Scenario: Display Beta badge
+
+- **GIVEN** the Stores panel is rendered
+- **WHEN** the user views the panel title or navigation entry
+- **THEN** the UI SHALL show a visible Beta badge
+
+#### Scenario: Show data-incompatible error with version source
+
+- **GIVEN** the CLI returns a structurally incompatible stores payload (data-incompatible)
+- **WHEN** the Stores panel renders
+- **THEN** the UI SHALL objectively display the error
+- **AND** SHALL show the originating OpenSpec CLI version
+- **AND** SHALL NOT crash or hide the entry
+
+#### Scenario: Hide entry on command-change failure
+
+- **GIVEN** the `store list`/`doctor` command is missing or its usage has changed (command-unavailable)
+- **WHEN** the navigation is composed
+- **THEN** the UI SHALL hide the Stores entry
+
+#### Scenario: Refresh store list reactively
+
+- **GIVEN** the Stores panel is open
+- **WHEN** the local store registry changes
+- **THEN** the UI SHALL update via a polling subscription (the registry lives outside the project directory) that the server polls and pushes to the frontend
+- **AND** SHALL NOT expose polling cadence or registry-location details to the user
+- **AND** SHALL NOT offer a manual refresh control
+
+#### Scenario: Restrict to live mode
+
+- **GIVEN** OpenSpecUI runs in static/SSG mode
+- **WHEN** the navigation is composed
+- **THEN** the UI SHALL NOT render the Stores panel or include stores data in the static snapshot
+
+#### Scenario: Read-only guarantee
+
+- **GIVEN** the Stores panel is displayed
+- **WHEN** the user interacts with any store entry
+- **THEN** the UI SHALL only show details (no setup/register/unregister/remove actions in this phase)
+- **AND** SHALL NOT change the active project directory

--- a/packages/web/src/routes/stores-list.tsx
+++ b/packages/web/src/routes/stores-list.tsx
@@ -1,8 +1,7 @@
 import { Badge } from '@/components/badge'
 import { isStaticMode } from '@/lib/static-mode'
 import { useStoresSubscription } from '@/lib/use-subscription'
-import { AlertCircle, RefreshCw, Store } from 'lucide-react'
-import { useState } from 'react'
+import { AlertCircle, Store } from 'lucide-react'
 
 import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
 
@@ -15,12 +14,12 @@ import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-
  *  - 异常二（command-unavailable）：入口本身在 nav 层隐藏（见 useStoresVisibility），
  *    即使渲染到这里也给出最简提示而非崩溃。
  *
- * 数据由 server 端轮询 registry 并推送（订阅），前端不感知轮询细节。仅 live 模式可见。
+ * 数据由 server 端轮询 registry 并推送（订阅），前端只消费推送结果，不感知轮询细节、无手动刷新。仅 live 模式可见。
  */
 export function StoresList() {
   const staticMode = isStaticMode()
-  // 手动刷新：递增 refreshKey 重新挂载订阅子树，触发 server 立即推送一次最新数据。
-  const [refreshKey, setRefreshKey] = useState(0)
+  const { data, isLoading } = useStoresSubscription()
+  const loading = isLoading && data === undefined
 
   if (staticMode) {
     return (
@@ -33,38 +32,17 @@ export function StoresList() {
 
   return (
     <div className="space-y-6 p-4">
-      <div className="flex items-center justify-between">
-        <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
-          <Store className="h-6 w-6 shrink-0" />
-          Stores
-          <Badge tone="subtle" size="xs">
-            Beta
-          </Badge>
-        </h1>
-        <button
-          onClick={() => setRefreshKey((k) => k + 1)}
-          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs"
-          title="Refresh stores"
-        >
-          <RefreshCw className="h-3.5 w-3.5" />
-          Refresh
-        </button>
-      </div>
+      <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
+        <Store className="h-6 w-6 shrink-0" />
+        Stores
+        <Badge tone="subtle" size="xs">
+          Beta
+        </Badge>
+      </h1>
 
-      <StoresSubscriptionBody refreshKey={refreshKey} />
+      <StoresBody data={data} loading={loading} />
     </div>
   )
-}
-
-function StoresSubscriptionBody({ refreshKey }: { refreshKey: number }) {
-  // key 变化时整个子树重新挂载，从而重建订阅并立即拿到一次最新推送。
-  return <StoresSubscriptionBodyInner key={refreshKey} />
-}
-
-function StoresSubscriptionBodyInner() {
-  const { data, isLoading } = useStoresSubscription()
-  const loading = isLoading && data === undefined
-  return <StoresBody data={data} loading={loading} />
 }
 
 function StoresBody({


### PR DESCRIPTION
The Stores panel already auto-updates via the server-pushed subscription (every 5s), so the manual Refresh button was redundant — and its refresh-key re-mount was unnecessary complexity.

## Changes
- Removed the Refresh button, the / plumbing, and the / intermediate components.  now subscribes directly.
- Spec (): dropped the manual-refresh requirement; states polling details are not exposed to the user.

## Local checks (all green)
- 
> openspecui-monorepo@0.0.0 format:check /Users/kzf/Dev/GitHub/jixoai-labs/openspecui
> tsx scripts/format-check.ts

[format:check] No changed files require Prettier check. /  /  /  (534 passed) ✅
- Change 'drop-stores-refresh-button' is valid ✅

Includes  ( patch).