### PR TITLE
feat(nav): icon updates + sidebar beta badge

### DIFF
--- a/.changeset/nav-icons-and-beta-badge.md
+++ b/.changeset/nav-icons-and-beta-badge.md
@@ -1,0 +1,14 @@
+---
+"@openspecui/web": minor
+---
+
+Navigation visual improvements.
+
+- **Icon updates**: Changes entry now uses `ListTodo` (was `GitBranch` — a change
+  is a proposal/work unit, not a git branch); Git entry now uses `GitBranch`
+  (was `FileCode2` — it's version control, not a code file); Stores entry uses
+  `Warehouse` (was `Store`), matching the panel title.
+- **Beta badge in the sidebar**: beta entries (Stores) now show a "Beta" pill
+  next to the label when expanded, and a small "β" corner mark on the icon when
+  collapsed (and in the mobile tab bar). Previously the Beta marker only
+  appeared inside the panel.

--- a/packages/web/src/components/layout/area-nav.tsx
+++ b/packages/web/src/components/layout/area-nav.tsx
@@ -4,6 +4,7 @@ import { VTLink, vtNavController } from '@/lib/view-transitions/navigation'
 import { GripVertical } from 'lucide-react'
 import { useCallback, useRef, useState } from 'react'
 import { Tooltip } from '../tooltip'
+import { BetaCornerMark, BetaPill } from './beta-mark'
 import { allNavItems, type NavItem } from './nav-items'
 
 interface AreaNavProps {
@@ -181,9 +182,15 @@ export function AreaNav({ area, tabs, className, useLinks, onNavigate, collapsed
                   {!iconOnly ? (
                     <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
                   ) : null}
-                  <item.icon className="h-4 w-4 shrink-0" />
+                  <span className="relative">
+                    <item.icon className="h-4 w-4 shrink-0" />
+                    {item.beta && iconOnly ? <BetaCornerMark /> : null}
+                  </span>
                   {!iconOnly ? (
-                    <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                    <>
+                      <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                      {item.beta ? <BetaPill /> : null}
+                    </>
                   ) : null}
                 </VTLink>
               </Tooltip>
@@ -208,9 +215,15 @@ export function AreaNav({ area, tabs, className, useLinks, onNavigate, collapsed
                   {!iconOnly ? (
                     <GripVertical className="-ml-2.5 -mr-1.5 h-3 w-3 shrink-0 opacity-0 group-hover:opacity-40" />
                   ) : null}
-                  <item.icon className="h-4 w-4 shrink-0" />
+                  <span className="relative">
+                    <item.icon className="h-4 w-4 shrink-0" />
+                    {item.beta && iconOnly ? <BetaCornerMark /> : null}
+                  </span>
                   {!iconOnly ? (
-                    <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                    <>
+                      <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                      {item.beta ? <BetaPill /> : null}
+                    </>
                   ) : null}
                 </button>
               </Tooltip>

--- a/packages/web/src/components/layout/beta-mark.tsx
+++ b/packages/web/src/components/layout/beta-mark.tsx
@@ -1,0 +1,29 @@
+import { Badge } from '@/components/badge'
+
+/**
+ * 展开态的 beta pill：放在导航项文字之后，与面板内标题的 Badge 保持一致的视觉语言。
+ */
+export function BetaPill() {
+  return (
+    <Badge tone="subtle" size="xs" className="ml-auto" title="Beta feature">
+      Beta
+    </Badge>
+  )
+}
+
+/**
+ * 折叠态（icon-only）的 beta 角标：贴在图标右上角的一个小 "β"。
+ * 信息量高于纯圆点，明确表达 beta；比斜向 ribbon 更适合窄长的侧边栏列表项。
+ *
+ * 父元素需为 `position: relative`。
+ */
+export function BetaCornerMark() {
+  return (
+    <span
+      className="bg-primary text-primary-foreground absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full text-[8px] font-bold italic leading-none"
+      aria-label="Beta feature"
+    >
+      β
+    </span>
+  )
+}

--- a/packages/web/src/components/layout/desktop-sidebar.tsx
+++ b/packages/web/src/components/layout/desktop-sidebar.tsx
@@ -8,6 +8,7 @@ import { PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Tooltip } from '../tooltip'
 import { AreaNav } from './area-nav'
+import { BetaCornerMark, BetaPill } from './beta-mark'
 import { navItems, settingsItem } from './nav-items'
 import { TopLayerEntryButton } from './top-layer-entry-button'
 
@@ -109,9 +110,15 @@ export function DesktopSidebar() {
                         collapsed ? 'justify-center px-2' : 'px-3'
                       }`}
                     >
-                      <item.icon className="h-4 w-4 shrink-0" />
+                      <span className="relative">
+                        <item.icon className="h-4 w-4 shrink-0" />
+                        {item.beta && collapsed ? <BetaCornerMark /> : null}
+                      </span>
                       {!collapsed ? (
-                        <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                        <>
+                          <span className="font-nav text-base tracking-[0.04em]">{item.label}</span>
+                          {item.beta ? <BetaPill /> : null}
+                        </>
                       ) : null}
                     </VTLink>
                   </Tooltip>

--- a/packages/web/src/components/layout/mobile-tabbar.tsx
+++ b/packages/web/src/components/layout/mobile-tabbar.tsx
@@ -1,6 +1,7 @@
 import { isStaticMode } from '@/lib/static-mode'
 import { useNavLayout } from '@/lib/use-nav-controller'
 import { VTLink } from '@/lib/view-transitions/navigation'
+import { BetaCornerMark } from './beta-mark'
 import { allNavItems, mobileNavItems } from './nav-items'
 
 /** Mobile bottom tab bar - quick access to main sections */
@@ -24,7 +25,10 @@ export function MobileTabBar() {
           to={item.to}
           className="text-muted-foreground hover:text-foreground [&.active]:text-primary flex flex-1 flex-col items-center justify-center gap-0.5"
         >
-          <item.icon className="h-5 w-5 shrink-0" />
+          <span className="relative">
+            <item.icon className="h-5 w-5 shrink-0" />
+            {item.beta ? <BetaCornerMark /> : null}
+          </span>
           <span className="font-nav text-[10px] tracking-[0.03em]">{item.label}</span>
         </VTLink>
       ))}

--- a/packages/web/src/components/layout/nav-items.ts
+++ b/packages/web/src/components/layout/nav-items.ts
@@ -1,13 +1,13 @@
 import {
   Archive,
-  FileCode2,
   FileText,
   GitBranch,
   LayoutDashboard,
+  ListTodo,
   Settings,
   SlidersHorizontal,
-  Store,
   Terminal,
+  Warehouse,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -41,11 +41,11 @@ export interface NavItem {
 export const allNavItems: NavItem[] = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard', defaultArea: 'main' },
   { to: '/config', icon: SlidersHorizontal, label: 'Config', defaultArea: 'main' },
-  { to: '/git', icon: FileCode2, label: 'Git', defaultArea: 'bottom' },
+  { to: '/git', icon: GitBranch, label: 'Git', defaultArea: 'bottom' },
   { to: '/specs', icon: FileText, label: 'Specs', defaultArea: 'main' },
-  { to: '/changes', icon: GitBranch, label: 'Changes', defaultArea: 'main' },
+  { to: '/changes', icon: ListTodo, label: 'Changes', defaultArea: 'main' },
   { to: '/archive', icon: Archive, label: 'Archive', defaultArea: 'main' },
-  { to: '/stores', icon: Store, label: 'Stores', defaultArea: 'main', beta: true },
+  { to: '/stores', icon: Warehouse, label: 'Stores', defaultArea: 'main', beta: true },
   { to: '/settings', icon: Settings, label: 'Settings', defaultArea: 'main' },
   { to: '/terminal', icon: Terminal, label: 'Terminal', defaultArea: 'bottom' },
 ]

--- a/packages/web/src/routes/stores-list.tsx
+++ b/packages/web/src/routes/stores-list.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@/components/badge'
 import { isStaticMode } from '@/lib/static-mode'
 import { useStoresSubscription } from '@/lib/use-subscription'
-import { AlertCircle, Store } from 'lucide-react'
+import { AlertCircle, Store, Warehouse } from 'lucide-react'
 
 import type { StoreFeatureResult, StoreListEntry } from '@openspecui/core/store-types'
 
@@ -33,7 +33,7 @@ export function StoresList() {
   return (
     <div className="space-y-6 p-4">
       <h1 className="font-nav flex items-center gap-2 text-2xl font-bold">
-        <Store className="h-6 w-6 shrink-0" />
+        <Warehouse className="h-6 w-6 shrink-0" />
         Stores
         <Badge tone="subtle" size="xs">
           Beta


### PR DESCRIPTION
Two related navigation visual improvements.

## Icon updates
The previous icons mismatched the features:
- **Changes**: `GitBranch` → `ListTodo`. A change is a proposal/work unit (not a git branch); the branch icon was misleading, especially sitting next to the real Git entry.
- **Git**: `FileCode2` → `GitBranch`. The Git panel is version control (commits/worktree/diff), not a code-file browser. Takes over the branch semantics Changes gave up.
- **Stores**: `Store` → `Warehouse`, matching the panel title.

## Beta badge in the sidebar
Previously the Beta marker only appeared inside the Stores panel. It now shows in the nav itself:
- **Expanded**: a subtle `Beta` pill after the label (reuses the existing `Badge`).
- **Collapsed / mobile**: a small `β` corner mark on the icon — more informative than a bare dot, and avoids the cramped feel of a diagonal ribbon on a narrow sidebar row.

Applies to the desktop sidebar (both the static-mode list and the IDE-mode `AreaNav`) and the mobile tab bar.

## Local checks (all green)
- `pnpm format:check` / `lint:ci` / `--filter @openspecui/web typecheck` ✅
- `--filter @openspecui/web test` (534 passed) ✅

Includes `.changeset` (`@openspecui/web` minor).