### PR TITLE
feat: target OpenSpec CLI 1.5.x line with OpenSpecUI 5.x

### DIFF
--- a/.changeset/target-cli-15-line-5x.md
+++ b/.changeset/target-cli-15-line-5x.md
@@ -1,0 +1,21 @@
+---
+'@openspecui/core': major
+'@openspecui/server': major
+'@openspecui/web': major
+openspecui: major
+---
+
+Target the OpenSpec CLI 1.5.x line with OpenSpecUI 5.x.
+
+OpenSpecUI follows a strict 1:1 major-to-minor version law: one OpenSpecUI
+major line targets exactly one OpenSpec CLI minor line (2.x→1.2, 3.x→1.3,
+4.x→1.4, 5.x→1.5). This release introduces the 5.x line for OpenSpec CLI 1.5.x.
+
+- OpenSpec CLI `>=1.5.0 <1.6.0` is the current/recommended line.
+- OpenSpec CLI `>=1.4.0 <1.5.0` is accepted as legacy-compatible.
+- OpenSpec CLI 1.3.x and older are no longer supported (each line
+  backward-supports only the previous CLI minor line).
+
+Note: 4.1.0 was published to npm as a transition artifact; 5.0.0 is the
+correct line going forward. The Stores panel (beta) and navigation
+improvements ship on this line.

--- a/openspec/changes/target-openspec-cli-15-line/.openspec.yaml
+++ b/openspec/changes/target-openspec-cli-15-line/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-06-30

--- a/openspec/changes/target-openspec-cli-15-line/loop/checkpoints.md
+++ b/openspec/changes/target-openspec-cli-15-line/loop/checkpoints.md
@@ -1,0 +1,25 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively
+- [x] 1.2 Research facts recorded
+- [x] 1.3 Plan reviewed and approved
+- [x] 1.4 Spec delta authored (openspec-cli-integration MODIFY: 5.x version law)
+
+## 2. Implementation
+
+- [ ] 2.1 openspec-compat.ts constants → 5.x + tests
+- [ ] 2.2 cli-health-gate.test.tsx → 5.x assertions
+- [ ] 2.3 settings.tsx tool-line copy → dynamic constants
+- [ ] 2.4 Progress synchronized with implementation artifact
+
+## 3. PR and Release Gates
+
+- [ ] 3.1 Changeset included (major → 5.0.0)
+- [ ] 3.2 CI-equivalent local checks passed
+- [ ] 3.3 PR checks passed
+
+## 4. Merge Readiness
+
+- [ ] 4.1 OpenSpec archive flow completed
+- [ ] 4.2 PR merge approved
+- [ ] 4.3 changeversion → release workflow publishes 5.0.0

--- a/openspec/changes/target-openspec-cli-15-line/loop/implementation.md
+++ b/openspec/changes/target-openspec-cli-15-line/loop/implementation.md
@@ -1,0 +1,25 @@
+## Implementation State
+
+Status: **Not started** — plan approved, implementation pending kickoff.
+
+Pending:
+
+- [ ] `openspec-compat.ts` 常量改 5.x；测试更新。
+- [ ] `cli-health-gate.test.tsx` 更新（1.5 current、1.4 legacy、1.3 unsupported、范围 `>=1.4.0 <1.6.0`）。
+- [ ] `settings.tsx` 工具线文案动态化。
+- [ ] spec delta + changeset (major)。
+- [ ] 本地 CI + validate。
+
+## Decisions Taken
+
+- 严格 1:1 版本律（回归历史惯例），5.x ↔ 1.5.x，后向仅支持 1.4.x。
+- settings 文案动态引用常量，杜绝未来漏改。
+- 4.1.0 不 unpublish，将错就错。
+
+## Divergence Notes
+
+- PR #197 曾把 1.5 塞进 4.x（错误），导致 4.1.0 发布。本 change 修正为 5.x 并补发 5.0.0。
+
+## Loopback Triggers
+
+- （none）

--- a/openspec/changes/target-openspec-cli-15-line/loop/intake.md
+++ b/openspec/changes/target-openspec-cli-15-line/loop/intake.md
@@ -1,0 +1,25 @@
+## User Input
+
+> 按规范应该是要发布 5.\* 的版本吧？
+
+（4.1.0 已被错误地发布到 npm——它把 Stores / CLI 1.5 特性作为 4.x minor 发布，违反了版本律。决策：将错就错，补发 5.0.0 作为 CLI 1.5.x 对应的正确大版本。）
+
+## Objective Scope
+
+- 修正版本律为 OpenSpecUI 5.x ↔ OpenSpec CLI 1.5.x（严格 1:1，回归历史惯例：2.x→1.2、3.x→1.3、4.x→1.4、5.x→1.5）。
+- `OPENSPECUI_TARGET_MAJOR = 5`；accepted `>=1.4.0 <1.6.0`（1.5 current，1.4 legacy，1.3 及更老 unsupported）；recommended `>=1.5.0 <1.6.0`。
+- 更新所有相关测试与用户可见文案（settings 的工具线说明）。
+- 以 **major** changeset 发布 5.0.0。
+
+## Non-Goals
+
+- 不 npm unpublish 4.1.0（已发布，将错就错；不撤销）。
+- 不改 beta 容错范式、Stores 功能、导航图标/badge。
+- 不改 CLI 调用逻辑。
+
+## Acceptance Boundary
+
+- 版本律实现为 5.x（1.5 current、1.4 legacy-compatible、1.3 unsupported）。
+- `openspec-compat` / `cli-health-gate` / `settings` 测试与文案同步并通过。
+- spec `openspec-cli-integration` 的版本律场景更新为 5.x 严格 1:1，并通过 `openspec validate --strict`。
+- major changeset 生成 5.0.0；release workflow 发布成功。

--- a/openspec/changes/target-openspec-cli-15-line/loop/research-plan.md
+++ b/openspec/changes/target-openspec-cli-15-line/loop/research-plan.md
@@ -1,0 +1,34 @@
+## Research Findings
+
+- 版本律历史惯例（提交 `b8d85f9 feat: target OpenSpec CLI 1.4.x line with OpenSpecUI 4.x`）确认是严格 1:1：每个 OpenSpecUI major 对应一个 CLI minor。
+- 之前的实现（PR #197）错误地把 1.5.x 塞进 4.x accepted range，导致 4.1.0 发布（含 Stores）。
+- `openspec-compat.ts` 用 `isCurrentRecommended`（区间）+ `isSeries(LEGACY_SERIES)` 双分支判定。5.x 下：current=1.5.x，legacy=1.4.x，其余 unsupported。
+- 用户可见文案：`settings.tsx` 硬编码了"OpenSpecUI 4.x uses OpenSpec CLI 1.4.x"——改为动态常量，避免未来再漏改。
+- `cli-health-gate.tsx` 用常量渲染，自动跟随。
+
+## Decision & Plan (For Approval)
+
+- 常量：`TARGET_MAJOR=5`、`LEGACY_SERIES='1.4'`、`MIN_VERSION='1.4.0'`、`RECOMMENDED_MIN_VERSION='1.5.0'`、`ACCEPTED_RANGE='>=1.4.0 <1.6.0'`、`RECOMMENDED_RANGE='>=1.5.0 <1.6.0'`、`LEGACY_RANGE='>=1.4.0 <1.5.0'`。
+- 测试：openspec-compat（1.5 current、1.4 legacy、1.3 unsupported）、cli-health-gate（默认 1.5 current、1.4 legacy、1.3 unsupported、范围 `>=1.4.0 <1.6.0`）。
+- settings.tsx：动态化工具线文案。
+- spec delta：openspec-cli-integration 版本律场景改 5.x 严格 1:1。
+- changeset：major（5.0.0）。
+
+## Capability Impact
+
+### Modified Behavior
+
+- 主版本线从 4.x → 5.x；1.3.x 不再被支持（5.x 只后向支持 1.4.x）。
+
+## Risks and Mitigations
+
+| 风险                      | 缓解                                                                 |
+| ------------------------- | -------------------------------------------------------------------- |
+| 1.3.x 用户被阻塞          | 这是版本律的有意行为（每条线只后向支持上一条）；门禁会给出升级指引。 |
+| 4.1.0 与 5.0.0 并存于 npm | 接受（将错就错）；5.0.0 为正确线，后续维护走 5.x。                   |
+
+## Verification Strategy
+
+- `pnpm --filter @openspecui/core test`、`--filter @openspecui/web typecheck/test`、`format:check`、`lint:ci`。
+- `openspec validate target-openspec-cli-15-line --type change --strict`。
+- changeversion → release workflow 发布 5.0.0 成功。

--- a/openspec/changes/target-openspec-cli-15-line/specs/openspec-cli-integration/spec.md
+++ b/openspec/changes/target-openspec-cli-15-line/specs/openspec-cli-integration/spec.md
@@ -1,0 +1,42 @@
+# openspec-cli-integration Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: CLI Discovery and Version Enforcement
+
+OpenSpecUI SHALL select the OpenSpec CLI command based on availability and enforce the OpenSpecUI major-to-OpenSpec CLI minor version law for stable features. The law is a strict 1:1 mapping: one OpenSpecUI major line targets exactly one OpenSpec CLI minor line (2.x→1.2, 3.x→1.3, 4.x→1.4, 5.x→1.5). The immediately previous CLI minor line is accepted as legacy-compatible; older lines are unsupported.
+
+#### Scenario: Enforce OpenSpecUI 5.x compatibility range
+
+- **GIVEN** OpenSpecUI 5.x evaluates an OpenSpec CLI version outside `>=1.4.0 <1.6.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL block usage
+- **AND** present upgrade instructions
+
+#### Scenario: Treat 1.5 runtime as current in 5.x
+
+- **GIVEN** OpenSpecUI 5.x evaluates OpenSpec CLI `>=1.5.0 <1.6.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions without a compatibility warning
+
+#### Scenario: Accept legacy-compatible 1.4 runtime in 5.x
+
+- **GIVEN** OpenSpecUI 5.x evaluates OpenSpec CLI `>=1.4.0 <1.5.0`
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL allow core interactions
+- **AND** SHALL show that the CLI is legacy-compatible and recommend OpenSpec CLI `>=1.5.0 <1.6.0`
+
+#### Scenario: Drop support for 1.3 and older runtimes in 5.x
+
+- **GIVEN** OpenSpecUI 5.x evaluates OpenSpec CLI `1.3.x` or older
+- **WHEN** OpenSpecUI initializes
+- **THEN** the UI SHALL block usage as unsupported
+
+#### Scenario: Preserve release-line directionality
+
+- **GIVEN** OpenSpecUI release-line compatibility is evaluated
+- **WHEN** version support is declared
+- **THEN** OpenSpecUI 3.x SHALL correspond to OpenSpec CLI 1.3.x
+- **AND** OpenSpecUI 4.x SHALL correspond to OpenSpec CLI 1.4.x
+- **AND** OpenSpecUI 5.x SHALL correspond to OpenSpec CLI 1.5.x
+- **AND** each OpenSpecUI major line SHALL backward-support exactly the previous CLI minor line (no further)

--- a/packages/core/src/openspec-compat.test.ts
+++ b/packages/core/src/openspec-compat.test.ts
@@ -8,14 +8,14 @@ import {
 describe('openspec CLI compatibility law', () => {
   it('parses versions from raw CLI output', () => {
     expect(parseOpenSpecCliVersion('1.5.0')).toEqual({ major: 1, minor: 5, patch: 0 })
-    expect(parseOpenSpecCliVersion('openspec 1.3.0')).toEqual({
+    expect(parseOpenSpecCliVersion('openspec 1.4.0')).toEqual({
       major: 1,
-      minor: 3,
+      minor: 4,
       patch: 0,
     })
   })
 
-  it('classifies the 1.5 target line as the current OpenSpecUI 4.x target line', () => {
+  it('classifies the 1.5 target line as the current OpenSpecUI 5.x target line', () => {
     expect(classifyOpenSpecCliVersion('1.5.0')).toMatchObject({
       status: 'current',
       supported: true,
@@ -24,17 +24,8 @@ describe('openspec CLI compatibility law', () => {
     })
   })
 
-  it('classifies the prior 1.4 recommended line as current', () => {
+  it('classifies the prior 1.4 line as legacy-compatible but not recommended', () => {
     expect(classifyOpenSpecCliVersion('1.4.1')).toMatchObject({
-      status: 'current',
-      supported: true,
-      recommended: true,
-      blocksCoreInteractions: false,
-    })
-  })
-
-  it('classifies 1.3.x as backward-compatible but not recommended', () => {
-    expect(classifyOpenSpecCliVersion('1.3.0')).toMatchObject({
       status: 'legacy-compatible',
       supported: true,
       recommended: false,
@@ -42,7 +33,12 @@ describe('openspec CLI compatibility law', () => {
     })
   })
 
-  it('blocks versions outside the 4.x accepted range', () => {
+  it('blocks versions outside the 5.x accepted range (1.3 and below are no longer supported)', () => {
+    expect(classifyOpenSpecCliVersion('1.3.0')).toMatchObject({
+      status: 'unsupported',
+      supported: false,
+      blocksCoreInteractions: true,
+    })
     expect(classifyOpenSpecCliVersion('1.2.0')).toMatchObject({
       status: 'unsupported',
       supported: false,

--- a/packages/core/src/openspec-compat.ts
+++ b/packages/core/src/openspec-compat.ts
@@ -1,13 +1,13 @@
-export const OPENSPECUI_TARGET_MAJOR = 4
+export const OPENSPECUI_TARGET_MAJOR = 5
 export const OPENSPEC_CLI_TARGET_SERIES = '1.5'
-export const OPENSPEC_CLI_LEGACY_SERIES = '1.3'
-export const OPENSPEC_CLI_MIN_VERSION = '1.3.0'
+export const OPENSPEC_CLI_LEGACY_SERIES = '1.4'
+export const OPENSPEC_CLI_MIN_VERSION = '1.4.0'
 export const OPENSPEC_CLI_TARGET_MIN_VERSION = '1.5.0'
-export const OPENSPEC_CLI_RECOMMENDED_MIN_VERSION = '1.4.0'
+export const OPENSPEC_CLI_RECOMMENDED_MIN_VERSION = '1.5.0'
 export const OPENSPEC_CLI_NEXT_SERIES_MIN_VERSION = '1.6.0'
-export const OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.3.0 <1.6.0'
-export const OPENSPEC_CLI_RECOMMENDED_RANGE = '>=1.4.0 <1.6.0'
-export const OPENSPEC_CLI_LEGACY_RANGE = '>=1.3.0 <1.4.0'
+export const OPENSPEC_CLI_ACCEPTED_RANGE = '>=1.4.0 <1.6.0'
+export const OPENSPEC_CLI_RECOMMENDED_RANGE = '>=1.5.0 <1.6.0'
+export const OPENSPEC_CLI_LEGACY_RANGE = '>=1.4.0 <1.5.0'
 export const OPENSPEC_CLI_REFERENCE_TAG_PATTERN = 'v1.5.*'
 
 export interface OpenSpecCliVersion {
@@ -63,9 +63,10 @@ function isSeries(version: OpenSpecCliVersion, series: string): boolean {
 
 /**
  * A version is "current/recommended" when it falls inside the recommended
- * range (e.g. `>=1.4.0 <1.6.0`). This intentionally spans more than one minor
- * series so that both the previous and the target OpenSpec CLI lines are
- * treated as current without a version-law bump per release.
+ * range (e.g. `>=1.5.0 <1.6.0`). OpenSpecUI follows a 1:1 major-to-minor
+ * version law: one OpenSpecUI major line targets exactly one OpenSpec CLI
+ * minor line (2.x→1.2, 3.x→1.3, 4.x→1.4, 5.x→1.5). The previous minor line
+ * is accepted as legacy-compatible; older lines are unsupported.
  */
 function isCurrentRecommended(version: OpenSpecCliVersion): boolean {
   const min = parseOpenSpecCliVersion(OPENSPEC_CLI_RECOMMENDED_MIN_VERSION)

--- a/packages/web/src/components/cli-health-gate.test.tsx
+++ b/packages/web/src/components/cli-health-gate.test.tsx
@@ -64,14 +64,14 @@ function renderGate() {
 
 describe('CliHealthGate', () => {
   beforeEach(() => {
-    availability = { available: true, version: '1.4.1' }
+    availability = { available: true, version: '1.5.0' }
   })
 
   afterEach(() => {
     cleanup()
   })
 
-  it('does not render for current OpenSpec CLI 1.4.x', async () => {
+  it('does not render for current OpenSpec CLI 1.5.x', async () => {
     renderGate()
 
     await waitFor(() => {
@@ -80,22 +80,22 @@ describe('CliHealthGate', () => {
     })
   })
 
-  it('renders a non-blocking legacy-compatible notice for OpenSpec CLI 1.3.x', async () => {
-    availability = { available: true, version: '1.3.0' }
+  it('renders a non-blocking legacy-compatible notice for OpenSpec CLI 1.4.x', async () => {
+    availability = { available: true, version: '1.4.1' }
 
     renderGate()
 
-    expect(await screen.findByText('OpenSpec CLI 1.3.0 is legacy-compatible')).toBeInTheDocument()
+    expect(await screen.findByText('OpenSpec CLI 1.4.1 is legacy-compatible')).toBeInTheDocument()
     expect(screen.queryByText(/OpenSpec CLI .* Required/)).not.toBeInTheDocument()
   })
 
   it('blocks unsupported OpenSpec CLI versions', async () => {
-    availability = { available: true, version: '1.2.0' }
+    availability = { available: true, version: '1.3.0' }
 
     renderGate()
 
-    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).toBeInTheDocument()
-    expect(screen.getByText(/Detected OpenSpec CLI 1.2.0/)).toBeInTheDocument()
+    expect(await screen.findByText(/OpenSpec CLI >=1.4.0 <1.6.0 Required/)).toBeInTheDocument()
+    expect(screen.getByText(/Detected OpenSpec CLI 1.3.0/)).toBeInTheDocument()
   })
 
   it('offers a skip-version-check escape hatch when the CLI is available', async () => {
@@ -115,7 +115,7 @@ describe('CliHealthGate', () => {
     fireEvent.click(skip)
 
     await waitFor(() => {
-      expect(screen.queryByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/OpenSpec CLI >=1.4.0 <1.6.0 Required/)).not.toBeInTheDocument()
     })
   })
 
@@ -124,7 +124,7 @@ describe('CliHealthGate', () => {
 
     renderGate()
 
-    expect(await screen.findByText(/OpenSpec CLI >=1.3.0 <1.6.0 Required/)).toBeInTheDocument()
+    expect(await screen.findByText(/OpenSpec CLI >=1.4.0 <1.6.0 Required/)).toBeInTheDocument()
     expect(screen.queryByText(/Skip version check/)).not.toBeInTheDocument()
   })
 })

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -45,6 +45,10 @@ import { useConfigSubscription } from '@/lib/use-subscription'
 import { OFFICIAL_APP_BASE_URL } from '@openspecui/core/hosted-app'
 import { NotificationSoundSchema } from '@openspecui/core/notifications'
 import {
+  OPENSPEC_CLI_TARGET_SERIES,
+  OPENSPECUI_TARGET_MAJOR,
+} from '@openspecui/core/openspec-compat'
+import {
   DEFAULT_BELL_SOUND_ID,
   DEFAULT_NOTIFICATION_SOUND_ID,
   type SoundId,
@@ -1832,8 +1836,9 @@ export function Settings() {
                         className="w-full"
                       />
                       <p className="text-muted-foreground text-xs">
-                        OpenSpec CLI can auto-detect existing tool directories. OpenSpecUI 4.x uses
-                        OpenSpec CLI 1.4.x as the current tool line.
+                        OpenSpec CLI can auto-detect existing tool directories. OpenSpecUI{' '}
+                        {OPENSPECUI_TARGET_MAJOR}.x uses OpenSpec CLI {OPENSPEC_CLI_TARGET_SERIES}.x
+                        as the current tool line.
                       </p>
                     </label>
 


### PR DESCRIPTION
Restore the strict 1:1 major-to-minor version law. 4.1.0 mistakenly folded CLI 1.5 support into the 4.x line; 5.0.0 is the correct line.

## Changes
- **core**: `OPENSPECUI_TARGET_MAJOR=5`; accepted `>=1.4.0 <1.6.0` (1.5 current, 1.4 legacy-compatible, 1.3 and older unsupported); recommended 1.5.x.
- **tests**: `openspec-compat` + `cli-health-gate` updated for 5.x (1.5 current, 1.4 legacy, 1.3 unsupported).
- **settings**: tool-line copy now references version constants dynamically (no more stale '4.x / 1.4.x' strings).
- **spec**: `openspec-cli-integration` version-law scenarios → 5.x strict 1:1 (2.x→1.2 … 5.x→1.5; each line backward-supports only the previous CLI minor).
- **changeset**: major (5.0.0) across `openspecui` + `@openspecui/*` (fixed group).

## Note on 4.1.0
4.1.0 was published to npm as a transition artifact (it shipped Stores/CLI-1.5 features under the wrong major). Decision: leave it, do not unpublish; 5.0.0 is the correct line going forward.

## Local checks (all green)
- `pnpm format:check` / `lint:ci` ✅
- `--filter @openspecui/core --filter @openspecui/server --filter @openspecui/web typecheck` ✅
- `--filter @openspecui/core test` (337) + `--filter @openspecui/web test` (534) ✅
- `openspec validate target-openspec-cli-15-line --type change --strict` ✅