### PR TITLE
fix(release): support beta publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,10 @@
+# Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+# 1. Build required native artifacts before package publication.
+# 2. Publish and recover one objective workspace release.
+# 3. Push release tags without pushing a stale branch ref.
+# 4. Synchronize GitHub release notes only after real release work.
+# Original request (2026-07-28): "我想先发布一个beta版本"
+
 name: Release
 
 on:
@@ -126,14 +133,17 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Publish packages
+        id: publish
         env:
           NPM_CONFIG_PROVENANCE: 'true'
         run: pnpm release:packages
 
       - name: Push release tags
-        run: git push --follow-tags
+        if: steps.publish.outputs.release_created == 'true'
+        run: git push origin --tags
 
       - name: Sync GitHub Release notes
+        if: steps.publish.outputs.release_created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: pnpm release:github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Owner presentation direction (2026-07-28): "backend a 会重新打开一个浏�
 Owner acceptance feedback (2026-07-28): "基本全部通过。列表骨架之间需要 gap 或分割线；Static 导出后的 /context 页面没数据。"
 Owner-reported defect (2026-07-28): "pnpm openspecui export -o ./tmp --open 导出的数据好像逃逸到 html 去了。"
 Original request (2026-07-28): "把残留的工作先完成"
+Original request (2026-07-28): "我想先发布一个beta版本"
 Review correction (2026-07-20): Terminal cwd evidence must cross the production Server owner instead of injecting a hand-authored downstream callback.
 Review correction (2026-07-20): Settings tool delivery must preserve upstream physical artifact scope, render-time subscription provenance, and CLI-runner cache retirement.
 -->
@@ -115,11 +116,13 @@ MUST READ: CLAUDE.md
 - After required PR checks pass, auto-merge to `main`.
 - After merge to `main`, ask manager whether to release.
 - If manager confirms release:
-  1. run `pnpm changeversion`
+  1. run `pnpm changeversion` for stable or `pnpm changeversion --pre <channel>` for an explicitly requested prerelease
   2. wait for the changeversion PR checks to pass
   3. auto-merge the changeversion PR
   4. wait for GitHub Actions `release.yml` on `main` to publish packages and push tags
   5. notify manager only after the GitHub release automation succeeds
+
+- Prerelease delivery law (2026-07-28): A requested beta release enters or continues explicit Changesets prerelease mode and derives npm dist-tag plus GitHub prerelease state from the generated SemVer version; caller-authored parallel channel flags are forbidden. `6.0.0-beta.0` publishes under `beta` and cannot move `latest`. Registry publication and package-tag delivery are independent facts: a rerun must recover missing tags after packages already exist, while a true registry-and-tag no-op must not rewrite an old GitHub Release. Release automation pushes tag refs only, never its potentially stale checked-out `main`. Completion requires the exact-head workflow, npm channel state, remote tags, and GitHub prerelease as separate evidence.
 
 ## OpenSpec 1.6 Adaptation Baseline
 

--- a/i18n.zh.md
+++ b/i18n.zh.md
@@ -4,7 +4,7 @@ Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
 2. Preserve canonical terms for root-operation lifetime, stream settlement, PTY transport, mutation identity, and real-owner recurrence evidence.
 3. Preserve Config ownership and file-presence terminology across product and implementation discussions.
 4. Preserve Search isolation and Git repository binding/rebinding terminology.
-5. Preserve the owner/Agent boundary for final browser acceptance, canonical interaction-timing provenance, live-projection performance terminology, real-time visual lifecycle terminology, hosted presentation terminology, static Context publication terminology, and static document embedding terminology.
+5. Preserve the owner/Agent boundary for final browser acceptance, canonical interaction-timing provenance, live-projection performance terminology, real-time visual lifecycle terminology, hosted presentation terminology, static publication terminology, and prerelease delivery terminology.
 
 Original request (2026-07-15): "我只知道openspec开始在做类似monorepo这种多包的概念，但具体的技术细节我并不清楚，所以我还需要你对我展开教程"
 Original request (2026-07-15): "我们可以在 cli 上新增一个 --auth 或者 --password。"
@@ -44,6 +44,7 @@ Owner walkthrough feedback (2026-07-27): iframe 权限、认证终态、会话�
 Owner acceptance request (2026-07-28): "我需要非常具体的验收工具和验收流程"
 Owner acceptance feedback (2026-07-28): "列表骨架之间需要 gap 或分割线；Static 导出后的 /context 页面没数据。"
 Owner-reported defect (2026-07-28): "导出的数据好像逃逸到 html 去了。"
+Original request (2026-07-28): "我想先发布一个beta版本"
 -->
 
 # OpenSpecUI Chinese terminology
@@ -183,6 +184,9 @@ Owner-reported defect (2026-07-28): "导出的数据好像逃逸到 html 去了�
 | planning root                       | 规划根                   | The single writable OpenSpec root selected by the CLI for the current operation.                                                                                                                                                                                                                                                           |
 | project workspace                   | 项目工作台               | The WebUI surface for one launch project and its resolved planning context.                                                                                                                                                                                                                                                                |
 | runtime environment                 | OpenSpec 运行环境        | One backend execution environment sharing a CLI installation, process environment, OpenSpec data scope, and Store registry.                                                                                                                                                                                                                |
+| prerelease channel                  | 预发布通道               | The explicit Changesets and npm channel derived from a SemVer prerelease identifier, such as `beta` in `6.0.0-beta.0`; it never aliases or advances stable `latest`.                                                                                                                                                                       |
+| tag-only release delivery           | 仅标签发布交付           | Release automation pushes package tag refs without pushing its checked-out branch, so a concurrent `main` advance cannot reject already-built release delivery.                                                                                                                                                                            |
+| release recovery                    | 发布恢复                 | An idempotent rerun that treats registry version presence and package-tag presence as separate facts, publishing only missing versions while recreating and delivering missing tags before GitHub Release synchronization.                                                                                                                 |
 | Store Manager                       | Store 管理器             | The App-native surface that administers Stores through one selected OpenSpec runtime environment.                                                                                                                                                                                                                                          |
 | envUri                              | 环境 URI                 | Backend-issued opaque URI identifying one backend-host and OpenSpec-data-home combination; it is an identity, not an API locator.                                                                                                                                                                                                          |
 | authentication-required             | 需要认证                 | A reachable protected backend state: the App received authentication rejection (for example 401/403) and therefore must not label the backend offline, current, or successful.                                                                                                                                                             |

--- a/openspec/changes/support-beta-release-channel/.openspec.yaml
+++ b/openspec/changes/support-beta-release-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-07-28

--- a/openspec/changes/support-beta-release-channel/loop/checkpoints.md
+++ b/openspec/changes/support-beta-release-channel/loop/checkpoints.md
@@ -1,0 +1,47 @@
+<!--
+Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+1. Track verifiable beta release implementation checkpoints.
+2. Separate infrastructure PR, version PR, registry publication, and archive gates.
+3. Keep stable-channel preservation explicit.
+
+Original request (2026-07-28): "我想先发布一个beta版本"
+-->
+
+## 1. Research and Planning
+
+- [x] 1.1 Capture the beta-first request and non-goals objectively.
+- [x] 1.2 Audit version generation, package publication, tag push, and GitHub Release owners.
+- [x] 1.3 Record the current failed-run evidence and retry-safe execution plan.
+
+## 2. Prerelease Contract
+
+- [ ] 2.1 Add explicit `--pre <channel>` entry/continuation and `--exit-pre` planning.
+- [ ] 2.2 Derive npm dist-tag and GitHub prerelease state from validated SemVer versions.
+- [ ] 2.3 Reject conflicting prerelease state instead of silently changing channel.
+
+## 3. Retry-safe Publication
+
+- [ ] 3.1 Publish only registry-missing package versions with their derived channel.
+- [ ] 3.2 Treat missing package tags as remaining release work after registry success.
+- [ ] 3.3 Emit an objective workflow output and skip tag/release steps for a true no-op.
+- [ ] 3.4 Push tag refs only so a concurrent `main` merge cannot reject delivery.
+
+## 4. Infrastructure PR Gates
+
+- [ ] 4.1 Add focused unit/mutation-resistant evidence for release-channel and prerelease planning.
+- [ ] 4.2 Update repository architecture law and canonical Chinese vocabulary.
+- [ ] 4.3 Pass CI-equivalent local checks and OpenSpec strict validation.
+- [ ] 4.4 Merge the infrastructure PR after required checks pass; no package changeset is required for CI-only behavior.
+
+## 5. Beta Version and Release
+
+- [ ] 5.1 Run `pnpm changeversion --pre beta` from clean synchronized `main`.
+- [ ] 5.2 Confirm the version PR contains `6.0.0-beta.0`, prerelease state, changelogs, and consumed changesets.
+- [ ] 5.3 Merge the version PR only after required checks pass and wait for the exact-head Release workflow.
+- [ ] 5.4 Verify public packages at `6.0.0-beta.0` under `beta` while `latest` remains `5.0.0`.
+- [ ] 5.5 Verify remote package tags and the `openspecui@6.0.0-beta.0` GitHub prerelease.
+
+## 6. Closure
+
+- [ ] 6.1 Synchronize final workflow, registry, tag, and release evidence into implementation notes.
+- [ ] 6.2 Archive this Change through the official OpenSpec flow and merge the archive PR.

--- a/openspec/changes/support-beta-release-channel/loop/checkpoints.md
+++ b/openspec/changes/support-beta-release-channel/loop/checkpoints.md
@@ -15,22 +15,22 @@ Original request (2026-07-28): "我想先发布一个beta版本"
 
 ## 2. Prerelease Contract
 
-- [ ] 2.1 Add explicit `--pre <channel>` entry/continuation and `--exit-pre` planning.
-- [ ] 2.2 Derive npm dist-tag and GitHub prerelease state from validated SemVer versions.
-- [ ] 2.3 Reject conflicting prerelease state instead of silently changing channel.
+- [x] 2.1 Add explicit `--pre <channel>` entry/continuation and `--exit-pre` planning.
+- [x] 2.2 Derive npm dist-tag and GitHub prerelease state from validated SemVer versions.
+- [x] 2.3 Reject conflicting prerelease state instead of silently changing channel.
 
 ## 3. Retry-safe Publication
 
-- [ ] 3.1 Publish only registry-missing package versions with their derived channel.
-- [ ] 3.2 Treat missing package tags as remaining release work after registry success.
-- [ ] 3.3 Emit an objective workflow output and skip tag/release steps for a true no-op.
-- [ ] 3.4 Push tag refs only so a concurrent `main` merge cannot reject delivery.
+- [x] 3.1 Publish only registry-missing package versions with their derived channel.
+- [x] 3.2 Treat missing package tags as remaining release work after registry success.
+- [x] 3.3 Emit an objective workflow output and skip tag/release steps for a true no-op.
+- [x] 3.4 Push tag refs only so a concurrent `main` merge cannot reject delivery.
 
 ## 4. Infrastructure PR Gates
 
-- [ ] 4.1 Add focused unit/mutation-resistant evidence for release-channel and prerelease planning.
-- [ ] 4.2 Update repository architecture law and canonical Chinese vocabulary.
-- [ ] 4.3 Pass CI-equivalent local checks and OpenSpec strict validation.
+- [x] 4.1 Add focused unit/mutation-resistant evidence for release-channel and prerelease planning.
+- [x] 4.2 Update repository architecture law and canonical Chinese vocabulary.
+- [x] 4.3 Pass CI-equivalent local checks and OpenSpec strict validation.
 - [ ] 4.4 Merge the infrastructure PR after required checks pass; no package changeset is required for CI-only behavior.
 
 ## 5. Beta Version and Release

--- a/openspec/changes/support-beta-release-channel/loop/implementation.md
+++ b/openspec/changes/support-beta-release-channel/loop/implementation.md
@@ -9,13 +9,13 @@ Original request (2026-07-28): "我想先发布一个beta版本"
 
 ## Implementation State
 
-Status: approved for implementation. No registry state has changed.
+Status: infrastructure implementation and full local gates complete; PR delivery remains pending. No registry state has changed.
 
 ```text
-release-channel projection   pending
-changeversion prerelease     pending
-retry-safe publication       pending
-workflow tag-only delivery   pending
+release-channel projection   implemented
+changeversion prerelease     implemented
+retry-safe publication       implemented
+workflow tag-only delivery   implemented
 real beta publication        pending
 ```
 
@@ -27,6 +27,60 @@ real beta publication        pending
 - Git pushes from release automation carry tag refs only.
 - `release_created` is emitted only after package publication or tag recovery; a registry-and-tag-complete run skips downstream release mutation.
 - Release scripts and their focused tests now have an explicit TypeScript lane instead of transpile-only evidence.
+
+## Focused Evidence
+
+Green fixed point:
+
+```text
+pnpm exec vitest run <six release files>
+6 files / 33 tests passed
+
+pnpm typecheck:scripts
+passed
+
+bun ./scripts/publish-packages.ts
+[publish] registry versions and release tags are already complete
+```
+
+Mutation resistance:
+
+```text
+Mutation: prerelease distTag returned latest instead of the SemVer channel
+Result: beta and rc channel assertions failed
+
+Mutation: release work ignored missing tags after registry publication
+Result: expected required=true, received false
+```
+
+Both exact transitions were restored and the focused suite returned green.
+
+CI-equivalent local evidence:
+
+```text
+pnpm format:check
+passed
+
+pnpm lint:ci
+passed with 0 warnings and 0 errors
+
+pnpm typecheck
+release scripts and all 15 workspace package lanes passed
+
+pnpm test:ci
+all root and workspace suites passed
+
+pnpm test:browser:ci
+Web and xterm component/browser fixtures passed
+
+pnpm install --frozen-lockfile
+passed
+
+openspec validate support-beta-release-channel --strict
+19/19 passed
+```
+
+The release script's real registry probe remained a safe no-op against the stable `5.0.0` state.
 
 ## Divergence Notes
 

--- a/openspec/changes/support-beta-release-channel/loop/implementation.md
+++ b/openspec/changes/support-beta-release-channel/loop/implementation.md
@@ -1,0 +1,40 @@
+<!--
+Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+1. Track implementation state against the approved beta release plan.
+2. Record owner and recovery decisions as code lands.
+3. Preserve divergences and loopback triggers without rewriting history.
+
+Original request (2026-07-28): "我想先发布一个beta版本"
+-->
+
+## Implementation State
+
+Status: approved for implementation. No registry state has changed.
+
+```text
+release-channel projection   pending
+changeversion prerelease     pending
+retry-safe publication       pending
+workflow tag-only delivery   pending
+real beta publication        pending
+```
+
+## Decisions Taken
+
+- SemVer package versions are the only authority for npm dist-tag and GitHub prerelease state.
+- `.changeset/pre.json` is the only persisted prerelease-mode authority.
+- The publish owner decides whether registry or tag work remains; the workflow consumes one objective output.
+- Git pushes from release automation carry tag refs only.
+- `release_created` is emitted only after package publication or tag recovery; a registry-and-tag-complete run skips downstream release mutation.
+- Release scripts and their focused tests now have an explicit TypeScript lane instead of transpile-only evidence.
+
+## Divergence Notes
+
+None.
+
+## Loopback Triggers
+
+- Changesets cannot produce `6.0.0-beta.0` from the current major ledger.
+- npm requires a channel mapping that cannot be derived from the generated SemVer version.
+- A retry after registry success cannot reconstruct missing tags from repository state.
+- Required CI or real registry verification exposes a broader release contract defect.

--- a/openspec/changes/support-beta-release-channel/loop/intake.md
+++ b/openspec/changes/support-beta-release-channel/loop/intake.md
@@ -1,0 +1,35 @@
+<!--
+Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+1. Preserve the owner's request to release OpenSpecUI 6 through a beta channel first.
+2. Bound beta versioning, registry tagging, GitHub release presentation, and retry-safe tag delivery.
+3. Keep stable latest publication and unrelated product work outside this Change.
+
+Original request (2026-07-28): "我想先发布一个beta版本"
+-->
+
+## User Input
+
+> 我想先发布一个beta版本
+
+## Objective Scope
+
+- Generate the first OpenSpecUI 6 prerelease as `6.0.0-beta.0` from the accepted OpenSpec CLI 1.6 changesets.
+- Publish every public changed workspace package under the npm `beta` dist-tag while preserving `latest=5.0.0`.
+- Create package tags and an `openspecui@6.0.0-beta.0` GitHub prerelease without pushing a stale `main` ref.
+- Make a rerun recover tags and release metadata after packages were published but tag delivery was interrupted.
+
+## Non-Goals
+
+- Do not publish stable `6.0.0` or move the npm `latest` dist-tag.
+- Do not merge the independent Kanban PR or add product behavior.
+- Do not redesign the complete release TUI or migration policy.
+- Do not claim completion from a dry run alone.
+
+## Acceptance Boundary
+
+- `pnpm changeversion --pre beta` produces a reviewed version PR for `6.0.0-beta.0`.
+- Stable versions publish with `latest`; prerelease versions publish with their explicit prerelease channel.
+- A no-op workflow does not rewrite an old GitHub Release, while a tag-recovery run can finish after registry publication.
+- Release tag delivery pushes tags only and remains valid when `main` advances during the build.
+- Required CI passes before merge.
+- npm shows `beta=6.0.0-beta.0` and `latest=5.0.0`; the corresponding Git tag and GitHub prerelease exist.

--- a/openspec/changes/support-beta-release-channel/loop/research-plan.md
+++ b/openspec/changes/support-beta-release-channel/loop/research-plan.md
@@ -1,0 +1,111 @@
+<!--
+Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+1. Record current prerelease and release-workflow facts.
+2. Define the procedural beta publication and recovery topology.
+3. Separate mandatory registry evidence from optional product work.
+4. Bound failure modes before implementation.
+
+Original request (2026-07-28): "我想先发布一个beta版本"
+-->
+
+## Research Findings
+
+Current facts on `main@ef36400`:
+
+- Public OpenSpecUI packages and npm `latest` are `5.0.0`; no 6.x package or beta tag exists.
+- Existing major changesets resolve the fixed OpenSpecUI family to 6.x and name OpenSpec CLI 1.6 as its target.
+- `scripts/changeversion-auto.ts` runs only `changeset version`; it cannot enter, continue, or exit prerelease mode explicitly.
+- `scripts/publish-packages.ts` hard-codes `npm publish --tag latest`, so a prerelease version would incorrectly move the stable channel.
+- `scripts/create-github-release.ts` creates an ordinary GitHub Release and does not project SemVer prerelease state.
+- `.github/workflows/release.yml` always runs tag/release steps and uses `git push --follow-tags`.
+- Release runs `30273200732` and `30341874768` built successfully, found no unpublished package, then failed because the long-running checkout tried to push its stale `main` branch. No registry version changed.
+
+Current release topology:
+
+```text
+package.json change
+       |
+       v
+build all native targets
+       |
+       v
+publish unpublished packages --tag latest
+       |
+       v
+push current main + tags  ---- race with a later main merge
+       |
+       v
+rewrite current GitHub Release even after a registry no-op
+```
+
+## Decision & Plan (For Approval)
+
+Adopt an explicit prerelease channel and a retry-safe release decision:
+
+```text
+pnpm changeversion --pre beta
+       |
+       +-- no pre.json ------> changeset pre enter beta
+       +-- beta pre.json ----> continue same channel
+       +-- other channel ----> fail closed
+       |
+       v
+changeset version -> 6.0.0-beta.0 version PR
+       |
+       v
+release plan = unpublished package OR missing release tag
+       |
+       +-- false -----------> stop; no old Release rewrite
+       |
+       v
+npm publish --tag beta
+       |
+       v
+changeset tag -> git push origin --tags
+       |
+       v
+GitHub Release --prerelease
+```
+
+Implementation order:
+
+1. Add a checked prerelease-mode planner for `--pre <channel>` and `--exit-pre`.
+2. Add one shared SemVer release-channel projection used by npm and GitHub release owners.
+3. Make publication idempotent across registry-published/tag-missing recovery.
+4. Gate tag and GitHub Release steps on an objective release-created output; push tags only.
+5. Merge the infrastructure PR before generating the beta version PR.
+6. Run the automated beta changeversion and verify registry/tag/release truth.
+
+## Capability Impact
+
+### New or Expanded Behavior
+
+- Operators can explicitly enter or continue a named prerelease channel.
+- Prerelease package versions publish under their SemVer channel instead of `latest`.
+- GitHub represents prerelease versions as prereleases.
+- A rerun can restore missing tags after package publication.
+
+### Modified Behavior
+
+- Stable versions continue to publish under `latest`.
+- Registry no-op runs no longer push refs or rewrite release notes.
+- Tag delivery no longer pushes the workflow checkout's branch.
+
+## Risks and Mitigations
+
+- **Accidental stable publication:** derive the npm tag from each validated package version; never accept a caller-authored tag beside it.
+- **Mixed prerelease channels:** reject a requested channel that differs from `.changeset/pre.json`.
+- **Partial publication:** query each package/version independently and publish only missing versions; missing tags still keep the release plan active.
+- **Moving `latest`:** assert npm `latest=5.0.0` after beta publication.
+- **Concurrent main merges:** push only `refs/tags`, never the checked-out branch.
+- **False completion:** require registry, Git tag, GitHub prerelease, and workflow success as separate terminal evidence.
+
+## Verification Strategy
+
+- Unit-test stable/beta/rc channel projection and invalid prerelease identifiers.
+- Unit-test prerelease mode entry, continuation, conflict, and exit planning.
+- Unit-test release-needed decisions for unpublished packages and missing tags.
+- Run focused release-helper tests, root typecheck, lint, format, and `git diff --check`.
+- Let required PR CI independently validate the infrastructure change.
+- Execute `pnpm changeversion --pre beta` only after that PR merges.
+- Verify `npm view`, remote Git tags, GitHub Release metadata, and a clean synchronized `main`.

--- a/openspec/changes/support-beta-release-channel/specs/build-pipeline/spec.md
+++ b/openspec/changes/support-beta-release-channel/specs/build-pipeline/spec.md
@@ -1,0 +1,65 @@
+<!--
+Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+1. Specify channel-correct prerelease publication.
+2. Specify retry-safe registry and tag delivery.
+3. Specify terminal release evidence.
+
+Original request (2026-07-28): "我想先发布一个beta版本"
+-->
+
+## ADDED Requirements
+
+### Requirement: Channel-correct retry-safe package release
+
+The release pipeline SHALL derive package registry and GitHub release channels from the generated SemVer version, SHALL preserve registry and tag delivery as separate facts, and SHALL never push its checked-out branch while delivering release tags.
+
+#### Scenario: Publish a beta without moving stable latest
+
+- **GIVEN** Changesets generates `6.0.0-beta.0`
+- **WHEN** the release pipeline publishes the changed public packages
+- **THEN** each package SHALL publish under the npm `beta` dist-tag
+- **AND** npm `latest` SHALL remain unchanged
+- **AND** the GitHub Release SHALL be marked as a prerelease and not latest
+
+#### Scenario: Recover tags after registry publication
+
+- **GIVEN** every target package version already exists in the registry
+- **AND** one or more corresponding package tags are absent
+- **WHEN** the exact version workflow is retried
+- **THEN** the pipeline SHALL recreate and push the missing tags
+- **AND** SHALL synchronize the corresponding GitHub Release
+- **AND** SHALL NOT republish existing package versions
+
+#### Scenario: Ignore a fully delivered no-op
+
+- **GIVEN** every target package version exists in the registry
+- **AND** every corresponding package tag exists
+- **WHEN** a package-manifest-triggered workflow runs
+- **THEN** the pipeline SHALL report no release work
+- **AND** SHALL NOT push refs or rewrite an existing GitHub Release
+
+#### Scenario: Main advances during release work
+
+- **GIVEN** release work started from commit A
+- **AND** the remote `main` branch advances to commit B during the build
+- **WHEN** the pipeline delivers tags created from commit A
+- **THEN** it SHALL push tag refs only
+- **AND** SHALL NOT submit A as an update to `main`
+
+### Requirement: Explicit prerelease mode transition
+
+The version automation SHALL require explicit operator intent to enter, continue, or exit Changesets prerelease mode and SHALL reject a channel that conflicts with persisted prerelease state.
+
+#### Scenario: Enter the first beta channel
+
+- **GIVEN** no Changesets prerelease state exists
+- **WHEN** the operator runs `pnpm changeversion --pre beta`
+- **THEN** the automation SHALL enter the `beta` prerelease mode before versioning
+- **AND** SHALL generate the version PR through the existing protected delivery flow
+
+#### Scenario: Reject an implicit or conflicting continuation
+
+- **GIVEN** the persisted Changesets prerelease channel is `beta`
+- **WHEN** the operator omits prerelease intent or requests `rc`
+- **THEN** the automation SHALL fail before versioning
+- **AND** SHALL preserve the existing `beta` state

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "build:deps": "pnpm --filter @openspecui/core build && pnpm --filter @openspecui/search build && pnpm --filter @openspecui/ai-provider build && pnpm --filter @openspecui/browser-translator build && pnpm --filter ctranslate2 build && pnpm --filter @openspecui/local-ct2-translator build && pnpm --filter @openspecui/local-llama-translator build && pnpm --filter @openspecui/local-translator build && pnpm --filter @openspecui/openai-completion-translator build",
     "build:packages": "pnpm --filter @openspecui/server build && pnpm --filter @openspecui/web build",
     "build:cli": "pnpm --filter openspecui run build:copy-web && pnpm --filter openspecui exec tsdown",
-    "typecheck": "pnpm -r --parallel run typecheck",
-    "tc": "pnpm -r --parallel run typecheck",
+    "typecheck": "pnpm run typecheck:scripts && pnpm -r --parallel run typecheck",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.release-scripts.json",
+    "tc": "pnpm run typecheck",
     "preview": "pnpm --filter openspecui dev",
     "lint": "oxlint packages scripts --ignore-path .gitignore",
     "lint:ci": "oxlint packages scripts --ignore-path .gitignore",
@@ -67,6 +68,7 @@
     "@opentui/core": "^0.1.79",
     "@opentui/react": "^0.1.79",
     "@types/node": "^22.10.0",
+    "@types/yargs": "^17.0.35",
     "@xterm/headless": "6.0.0",
     "oxlint": "^1.15.0",
     "prettier": "^3.4.2",
@@ -75,7 +77,9 @@
     "react": "^19.2.0",
     "shadcn": "^3.8.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.0",
+    "yargs": "^18.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.1
+      '@types/yargs':
+        specifier: ^17.0.35
+        version: 17.0.35
       '@xterm/headless':
         specifier: 6.0.0
         version: 6.0.0
@@ -49,6 +52,12 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@22.19.1)(@vitest/browser-playwright@4.1.0)(jsdom@25.0.1)(msw@2.12.8(@types/node@22.19.1)(typescript@5.9.3))(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.2))
+      yargs:
+        specifier: ^18.0.0
+        version: 18.0.0
 
   packages/ai-provider:
     dependencies:

--- a/scripts/changeversion-auto.ts
+++ b/scripts/changeversion-auto.ts
@@ -1,7 +1,24 @@
 #!/usr/bin/env bun
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Generate and deliver a protected changeset version PR.
+ * 2. Enter, continue, or exit an explicit Changesets prerelease channel.
+ * 3. Wait for the exact merged-head release workflow before reporting completion.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
 import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 
 import { loadGhPrMergeability, waitForPrMergeability } from './lib/changeversion/pr-mergeability'
+import {
+  planPrereleaseMode,
+  readChangesetsPrereleaseState,
+} from './lib/changeversion/prerelease-mode'
 import {
   type InheritRunResult,
   waitForWorkflowRunToAppear,
@@ -15,6 +32,7 @@ const PR_TITLE = 'chore(release): apply changeset version'
 const PR_BODY = [
   'Automated by `pnpm changeversion`.',
   '',
+  '- Enter, continue, or exit the requested Changesets prerelease mode',
   '- Run `changeset version`',
   '- Commit version/changelog updates',
   '- Create PR and wait for required checks',
@@ -34,6 +52,11 @@ type CaptureRunResult = {
   status: number
   stdout: string
   stderr: string
+}
+
+type ChangeversionOptions = {
+  exitPre: boolean
+  preTag: null | string
 }
 
 function commandFor(bin: 'pnpm' | 'git' | 'gh'): string {
@@ -209,7 +232,7 @@ function findOpenPrByHeadBranch(branch: string): { number: number; url: string }
   return parsed[0] ?? null
 }
 
-function closePrAndDeleteBranch(prNumber: number, branch: string, reason: string): void {
+function closePrAndDeleteBranch(prNumber: number, reason: string): void {
   runInheritAllowFailure(commandFor('gh'), [
     'pr',
     'close',
@@ -297,7 +320,7 @@ function waitForReleaseWorkflow(headCommit: string): void {
   }
 }
 
-function main(): void {
+function main(options: ChangeversionOptions): void {
   ensureOnMainBranch()
   ensureMainIsSyncedWithRemote()
   ensureGhAuthAvailable()
@@ -318,6 +341,14 @@ function main(): void {
       stashRef = createStash(stashMessage)
     }
 
+    const prereleaseAction = planPrereleaseMode({
+      exitPre: options.exitPre,
+      preTag: options.preTag,
+      state: readChangesetsPrereleaseState(process.cwd()),
+    })
+    if (prereleaseAction) {
+      runInheritOrThrow(commandFor('pnpm'), ['exec', 'changeset', ...prereleaseAction.args])
+    }
     runInheritOrThrow(commandFor('pnpm'), ['exec', 'changeset', 'version'])
 
     const changedFiles = runCapture(commandFor('git'), ['diff', '--name-only'])
@@ -371,7 +402,7 @@ function main(): void {
           const reason = checks.timedOut
             ? 'Closed automatically: CI checks timed out in changeversion automation.'
             : 'Closed automatically: CI checks failed in changeversion automation.'
-          closePrAndDeleteBranch(prNumber, releaseBranch, reason)
+          closePrAndDeleteBranch(prNumber, reason)
           throw new Error(
             checks.timedOut
               ? 'PR checks timed out; PR was auto-closed.'
@@ -414,7 +445,6 @@ function main(): void {
     if (!prMerged && prNumber !== null && releaseBranch !== null) {
       closePrAndDeleteBranch(
         prNumber,
-        releaseBranch,
         'Closed automatically due to changeversion automation failure.'
       )
     } else if (!prMerged && releaseBranch !== null) {
@@ -422,7 +452,6 @@ function main(): void {
       if (existingPr) {
         closePrAndDeleteBranch(
           existingPr.number,
-          releaseBranch,
           'Closed automatically due to changeversion automation failure.'
         )
       } else {
@@ -446,8 +475,27 @@ function main(): void {
   if (stashError) throw stashError
 }
 
+const argv = yargs(hideBin(process.argv))
+  .scriptName('changeversion')
+  .option('pre', {
+    description: 'Enter or continue a named Changesets prerelease channel.',
+    type: 'string',
+  })
+  .option('exit-pre', {
+    default: false,
+    description: 'Exit the current Changesets prerelease channel before versioning.',
+    type: 'boolean',
+  })
+  .conflicts('pre', 'exit-pre')
+  .strict()
+  .help()
+  .parseSync()
+
 try {
-  main()
+  main({
+    exitPre: argv['exit-pre'],
+    preTag: argv.pre ?? null,
+  })
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error)
   console.error(`[changeversion] ${message}`)

--- a/scripts/create-github-release.ts
+++ b/scripts/create-github-release.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env bun
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Materialize the current CLI package tag as a GitHub Release.
+ * 2. Preserve changelog-derived notes across create and update.
+ * 3. Mark prerelease versions without making them latest.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
 import { spawnSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -7,6 +16,7 @@ import { join } from 'node:path'
 import {
   extractChangelogSection,
   formatGithubReleaseNotes,
+  getGithubReleaseChannelFlags,
   getGithubReleaseTag,
   getGithubReleaseTitle,
 } from './lib/release/github-release'
@@ -90,6 +100,7 @@ function main(): void {
   const { name, version } = readCliManifest(rootDir)
   const tag = getGithubReleaseTag(name, version)
   const title = getGithubReleaseTitle(name, version)
+  const channelFlags = getGithubReleaseChannelFlags(version)
   const changelogSection = extractChangelogSection(readCliChangelog(rootDir), version)
   const notes = formatGithubReleaseNotes({
     packageName: name,
@@ -113,14 +124,24 @@ function main(): void {
       console.log(`[release] updating GitHub release ${tag}`)
       runOrThrow(
         commandFor('gh'),
-        ['release', 'edit', tag, '--title', title, '--notes-file', notesPath],
+        ['release', 'edit', tag, '--title', title, '--notes-file', notesPath, ...channelFlags],
         rootDir
       )
     } else {
       console.log(`[release] creating GitHub release ${tag}`)
       runOrThrow(
         commandFor('gh'),
-        ['release', 'create', tag, '--verify-tag', '--title', title, '--notes-file', notesPath],
+        [
+          'release',
+          'create',
+          tag,
+          '--verify-tag',
+          '--title',
+          title,
+          '--notes-file',
+          notesPath,
+          ...channelFlags,
+        ],
         rootDir
       )
     }

--- a/scripts/lib/changeversion/prerelease-mode.test.ts
+++ b/scripts/lib/changeversion/prerelease-mode.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Prove explicit prerelease entry and continuation.
+ * 2. Prove explicit exit and interrupted-exit continuation.
+ * 3. Prove ambiguous, unsafe, or conflicting modes fail closed.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { planPrereleaseMode } from './prerelease-mode'
+
+describe('changeversion prerelease mode', () => {
+  it('enters beta when no prerelease state exists', () => {
+    expect(planPrereleaseMode({ exitPre: false, preTag: 'beta', state: null })).toEqual({
+      args: ['pre', 'enter', 'beta'],
+      kind: 'enter',
+    })
+  })
+
+  it('continues the same beta channel without re-entering it', () => {
+    expect(
+      planPrereleaseMode({
+        exitPre: false,
+        preTag: 'beta',
+        state: { mode: 'pre', tag: 'beta' },
+      })
+    ).toBeNull()
+  })
+
+  it('plans prerelease exit and tolerates an already-persisted exit', () => {
+    expect(
+      planPrereleaseMode({
+        exitPre: true,
+        preTag: null,
+        state: { mode: 'pre', tag: 'beta' },
+      })
+    ).toEqual({ args: ['pre', 'exit'], kind: 'exit' })
+    expect(
+      planPrereleaseMode({
+        exitPre: true,
+        preTag: null,
+        state: { mode: 'exit', tag: 'beta' },
+      })
+    ).toBeNull()
+  })
+
+  it.each([
+    { exitPre: false, preTag: 'rc', state: { mode: 'pre' as const, tag: 'beta' } },
+    { exitPre: false, preTag: null, state: { mode: 'pre' as const, tag: 'beta' } },
+    { exitPre: false, preTag: 'latest', state: null },
+    { exitPre: true, preTag: 'beta', state: null },
+  ])('rejects ambiguous or conflicting input %#', (input) => {
+    expect(() => planPrereleaseMode(input)).toThrow()
+  })
+})

--- a/scripts/lib/changeversion/prerelease-mode.ts
+++ b/scripts/lib/changeversion/prerelease-mode.ts
@@ -1,0 +1,92 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Read the persisted Changesets prerelease mode as typed runtime evidence.
+ * 2. Plan explicit prerelease entry, continuation, and exit commands.
+ * 3. Reject ambiguous or conflicting channel changes.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PRERELEASE_TAG_PATTERN = /^[a-z][a-z0-9-]*$/
+
+export type ChangesetsPrereleaseState = {
+  mode: 'exit' | 'pre'
+  tag: string
+}
+
+export type PrereleaseModeAction =
+  | { args: ['pre', 'enter', string]; kind: 'enter' }
+  | { args: ['pre', 'exit']; kind: 'exit' }
+
+type PrereleaseModeInput = {
+  exitPre: boolean
+  preTag: null | string
+  state: ChangesetsPrereleaseState | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validatePrereleaseTag(tag: string): string {
+  if (!PRERELEASE_TAG_PATTERN.test(tag) || tag === 'latest') {
+    throw new Error(`Invalid prerelease channel '${tag}'. Use a lowercase npm tag such as 'beta'.`)
+  }
+  return tag
+}
+
+export function readChangesetsPrereleaseState(rootDir: string): ChangesetsPrereleaseState | null {
+  const path = join(rootDir, '.changeset', 'pre.json')
+  if (!existsSync(path)) return null
+
+  const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+  if (
+    !isRecord(parsed) ||
+    (parsed.mode !== 'pre' && parsed.mode !== 'exit') ||
+    typeof parsed.tag !== 'string'
+  ) {
+    throw new Error(`Invalid Changesets prerelease state at ${path}`)
+  }
+
+  return { mode: parsed.mode, tag: validatePrereleaseTag(parsed.tag) }
+}
+
+export function planPrereleaseMode(input: PrereleaseModeInput): PrereleaseModeAction | null {
+  if (input.preTag !== null && input.exitPre) {
+    throw new Error('Use either --pre <channel> or --exit-pre, not both.')
+  }
+
+  if (input.preTag !== null) {
+    const requestedTag = validatePrereleaseTag(input.preTag)
+    if (!input.state) {
+      return { args: ['pre', 'enter', requestedTag], kind: 'enter' }
+    }
+    if (input.state.mode !== 'pre') {
+      throw new Error(`Cannot enter '${requestedTag}' while Changesets prerelease exit is pending.`)
+    }
+    if (input.state.tag !== requestedTag) {
+      throw new Error(
+        `Changesets prerelease channel '${input.state.tag}' is active; refusing '${requestedTag}'.`
+      )
+    }
+    return null
+  }
+
+  if (input.exitPre) {
+    if (!input.state) {
+      throw new Error('Cannot exit prerelease mode because no Changesets prerelease state exists.')
+    }
+    if (input.state.mode === 'exit') return null
+    return { args: ['pre', 'exit'], kind: 'exit' }
+  }
+
+  if (input.state) {
+    throw new Error(
+      `Changesets prerelease channel '${input.state.tag}' is active. Pass '--pre ${input.state.tag}' to continue or '--exit-pre' to finish it.`
+    )
+  }
+  return null
+}

--- a/scripts/lib/publish-packages/release-work.test.ts
+++ b/scripts/lib/publish-packages/release-work.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Prove registry-missing versions require publication.
+ * 2. Prove registry-complete but tag-missing versions require recovery.
+ * 3. Prove a fully delivered version is a true no-op.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { createPackageReleaseWork } from './release-work'
+
+describe('package release work', () => {
+  it('keeps registry publication and tag recovery as separate facts', () => {
+    const plan = createPackageReleaseWork([
+      { package: 'core', tagExists: false, versionPublished: false },
+      { package: 'web', tagExists: false, versionPublished: true },
+      { package: 'cli', tagExists: true, versionPublished: true },
+    ])
+
+    expect(plan).toEqual({
+      missingTags: ['core', 'web'],
+      packagesToPublish: ['core'],
+      required: true,
+    })
+  })
+
+  it('requires tag recovery after registry publication has already completed', () => {
+    expect(
+      createPackageReleaseWork([
+        { package: 'openspecui', tagExists: false, versionPublished: true },
+      ])
+    ).toMatchObject({ packagesToPublish: [], required: true })
+  })
+
+  it('reports a true no-op only when registry and tag delivery are complete', () => {
+    expect(
+      createPackageReleaseWork([{ package: 'openspecui', tagExists: true, versionPublished: true }])
+    ).toEqual({ missingTags: [], packagesToPublish: [], required: false })
+  })
+})

--- a/scripts/lib/publish-packages/release-work.ts
+++ b/scripts/lib/publish-packages/release-work.ts
@@ -1,0 +1,34 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Separate registry publication work from tag recovery work.
+ * 2. Preserve package facts in an idempotent release plan.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+export type PackageReleaseFact<TPackage> = {
+  package: TPackage
+  tagExists: boolean
+  versionPublished: boolean
+}
+
+export type PackageReleaseWork<TPackage> = {
+  missingTags: TPackage[]
+  packagesToPublish: TPackage[]
+  required: boolean
+}
+
+export function createPackageReleaseWork<TPackage>(
+  facts: readonly PackageReleaseFact<TPackage>[]
+): PackageReleaseWork<TPackage> {
+  const packagesToPublish = facts
+    .filter((fact) => !fact.versionPublished)
+    .map((fact) => fact.package)
+  const missingTags = facts.filter((fact) => !fact.tagExists).map((fact) => fact.package)
+
+  return {
+    missingTags,
+    packagesToPublish,
+    required: packagesToPublish.length > 0 || missingTags.length > 0,
+  }
+}

--- a/scripts/lib/publish-packages/repository.ts
+++ b/scripts/lib/publish-packages/repository.ts
@@ -1,3 +1,12 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Materialize publication-safe package directories.
+ * 2. Normalize workspace dependencies and repository metadata.
+ * 3. Keep release-script typechecking exact across Node filesystem overloads.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
 import { spawnSync } from 'node:child_process'
 import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -48,12 +57,13 @@ type WorkspacePackageInfo = {
 
 function readWorkspacePackages(rootDir: string): Map<string, WorkspacePackageInfo> {
   const packagesDir = join(rootDir, 'packages')
-  let entries: ReturnType<typeof readdirSync>
-  try {
-    entries = readdirSync(packagesDir, { withFileTypes: true })
-  } catch {
-    return new Map()
-  }
+  const entries = (() => {
+    try {
+      return readdirSync(packagesDir, { encoding: 'utf8', withFileTypes: true })
+    } catch {
+      return []
+    }
+  })()
 
   const packages = new Map<string, WorkspacePackageInfo>()
   for (const entry of entries) {
@@ -109,7 +119,7 @@ function normalizeManifestDependencies(
   }
 }
 
-function currentRepositoryUrl(repository: RepositoryValue): string | null {
+function currentRepositoryUrl(repository: RepositoryValue | undefined): string | null {
   if (!repository) return null
   if (typeof repository === 'string') {
     const value = repository.trim()

--- a/scripts/lib/release/channel.test.ts
+++ b/scripts/lib/release/channel.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Prove stable and prerelease channel derivation.
+ * 2. Prove unsafe or malformed versions fail closed.
+ * 3. Prove canonical package tag construction.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { getPackageReleaseTag, resolveReleaseChannel } from './channel'
+
+describe('release channel', () => {
+  it('keeps stable versions on latest', () => {
+    expect(resolveReleaseChannel('6.0.0')).toEqual({ distTag: 'latest', prerelease: false })
+  })
+
+  it.each([
+    ['6.0.0-beta.0', 'beta'],
+    ['6.0.0-rc.2+build.7', 'rc'],
+  ])('routes %s through the %s prerelease channel', (version, distTag) => {
+    expect(resolveReleaseChannel(version)).toEqual({ distTag, prerelease: true })
+  })
+
+  it.each(['6.0', '6.0.0-01', '6.0.0-latest.0', '6.0.0-0.beta'])(
+    'rejects an unsafe release version %s',
+    (version) => {
+      expect(() => resolveReleaseChannel(version)).toThrow()
+    }
+  )
+
+  it('builds the Changesets package tag from validated version truth', () => {
+    expect(getPackageReleaseTag('openspecui', '6.0.0-beta.0')).toBe('openspecui@6.0.0-beta.0')
+  })
+})

--- a/scripts/lib/release/channel.ts
+++ b/scripts/lib/release/channel.ts
@@ -1,0 +1,56 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Validate package SemVer before release routing.
+ * 2. Derive npm and GitHub prerelease channels from one version fact.
+ * 3. Build the canonical Changesets package tag.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+const NPM_PRERELEASE_CHANNEL_PATTERN = /^[a-z][a-z0-9-]*$/
+
+export type ReleaseChannel = {
+  distTag: string
+  prerelease: boolean
+}
+
+function parsePrereleaseIdentifiers(version: string): string[] | null {
+  const match = SEMVER_PATTERN.exec(version)
+  if (!match) {
+    throw new Error(`Invalid SemVer release version: ${version}`)
+  }
+
+  const prerelease = match[4]
+  if (!prerelease) return null
+
+  const identifiers = prerelease.split('.')
+  for (const identifier of identifiers) {
+    if (/^\d+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0')) {
+      throw new Error(`Invalid numeric prerelease identifier in version: ${version}`)
+    }
+  }
+  return identifiers
+}
+
+export function resolveReleaseChannel(version: string): ReleaseChannel {
+  const identifiers = parsePrereleaseIdentifiers(version)
+  if (!identifiers) {
+    return { distTag: 'latest', prerelease: false }
+  }
+
+  const channel = identifiers[0]!
+  if (!NPM_PRERELEASE_CHANNEL_PATTERN.test(channel) || channel === 'latest') {
+    throw new Error(
+      `Prerelease version '${version}' does not start with a safe npm channel identifier.`
+    )
+  }
+
+  return { distTag: channel, prerelease: true }
+}
+
+export function getPackageReleaseTag(packageName: string, version: string): string {
+  resolveReleaseChannel(version)
+  return `${packageName}@${version}`
+}

--- a/scripts/lib/release/github-release.test.ts
+++ b/scripts/lib/release/github-release.test.ts
@@ -1,8 +1,18 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Prove changelog extraction and fallback notes.
+ * 2. Prove canonical release tag and title identity.
+ * 3. Prove prerelease GitHub flags follow version truth.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
 import { describe, expect, it } from 'vitest'
 
 import {
   extractChangelogSection,
   formatGithubReleaseNotes,
+  getGithubReleaseChannelFlags,
   getGithubReleaseTag,
   getGithubReleaseTitle,
 } from './github-release'
@@ -58,5 +68,10 @@ describe('github release helpers', () => {
   it('builds the canonical release tag and title', () => {
     expect(getGithubReleaseTag('openspecui', '3.11.0')).toBe('openspecui@3.11.0')
     expect(getGithubReleaseTitle('openspecui', '3.11.0')).toBe('openspecui 3.11.0')
+  })
+
+  it('marks only SemVer prereleases as GitHub prereleases', () => {
+    expect(getGithubReleaseChannelFlags('6.0.0-beta.0')).toEqual(['--prerelease', '--latest=false'])
+    expect(getGithubReleaseChannelFlags('6.0.0')).toEqual([])
   })
 })

--- a/scripts/lib/release/github-release.ts
+++ b/scripts/lib/release/github-release.ts
@@ -1,3 +1,14 @@
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Extract one package changelog section.
+ * 2. Build canonical GitHub release identity and notes.
+ * 3. Project SemVer prerelease state into GitHub CLI flags.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
+import { resolveReleaseChannel } from './channel'
+
 export function extractChangelogSection(changelog: string, version: string): string | null {
   const lines = changelog.split('\n')
   const header = `## ${version}`
@@ -36,4 +47,8 @@ export function getGithubReleaseTag(packageName: string, version: string): strin
 
 export function getGithubReleaseTitle(packageName: string, version: string): string {
   return `${packageName} ${version}`
+}
+
+export function getGithubReleaseChannelFlags(version: string): string[] {
+  return resolveReleaseChannel(version).prerelease ? ['--prerelease', '--latest=false'] : []
 }

--- a/scripts/publish-packages.ts
+++ b/scripts/publish-packages.ts
@@ -1,15 +1,27 @@
 #!/usr/bin/env bun
+/**
+ * Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+ * 1. Publish only registry-missing public workspace versions in dependency order.
+ * 2. Recover missing Changesets tags independently from registry publication.
+ * 3. Emit an objective workflow release/no-op decision.
+ *
+ * Original request (2026-07-28): "我想先发布一个beta版本"
+ */
+
 import { spawnSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
 import { verifyNapiPublishArtifacts } from './lib/publish-packages/napi-artifacts'
+import { createPackageReleaseWork } from './lib/publish-packages/release-work'
 import { preparePublishDirectory, resolveRepositoryUrl } from './lib/publish-packages/repository'
 import {
   orderPackagesForPublish,
   readPublishablePackages,
   type PublishablePackage,
 } from './lib/publish-packages/workspace'
+import { getPackageReleaseTag, resolveReleaseChannel } from './lib/release/channel'
 
 type CaptureResult = {
   status: number
@@ -17,7 +29,7 @@ type CaptureResult = {
   stdout: string
 }
 
-function commandFor(bin: 'npm' | 'pnpm'): string {
+function commandFor(bin: 'git' | 'npm' | 'pnpm'): string {
   if (process.platform === 'win32') {
     return `${bin}.cmd`
   }
@@ -70,7 +82,6 @@ function isVersionPublished(rootDir: string, pkg: PublishablePackage): boolean {
 }
 
 function publishPackage(
-  rootDir: string,
   pkg: PublishablePackage,
   dryRun: boolean,
   repositoryUrl: string | null
@@ -78,7 +89,8 @@ function publishPackage(
   const publishTarget = pkg.publishDirectory ? resolve(pkg.dir, pkg.publishDirectory) : pkg.dir
   verifyNapiPublishArtifacts(publishTarget)
   const prepared = preparePublishDirectory(publishTarget, repositoryUrl)
-  const args = ['publish', '--provenance', '--tag', 'latest', '--access', pkg.access]
+  const { distTag } = resolveReleaseChannel(pkg.version)
+  const args = ['publish', '--provenance', '--tag', distTag, '--access', pkg.access]
   if (dryRun) args.push('--dry-run')
   console.log(`[publish] ${pkg.name}@${pkg.version}`)
 
@@ -94,33 +106,66 @@ function createChangesetTags(rootDir: string): void {
   runInherit(commandFor('pnpm'), ['exec', 'changeset', 'tag'], rootDir)
 }
 
+function localTagExists(rootDir: string, pkg: PublishablePackage): boolean {
+  const tag = getPackageReleaseTag(pkg.name, pkg.version)
+  const result = runCapture(
+    commandFor('git'),
+    ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}`],
+    rootDir
+  )
+  return result.status === 0
+}
+
+function writeReleaseCreatedOutput(created: boolean): void {
+  const outputPath = process.env.GITHUB_OUTPUT?.trim()
+  if (!outputPath) return
+  appendFileSync(outputPath, `release_created=${created ? 'true' : 'false'}\n`, 'utf8')
+}
+
 function main(): void {
   const rootDir = process.cwd()
   const dryRun = process.env.PUBLISH_PACKAGES_DRY_RUN === '1'
   const publishablePackages = orderPackagesForPublish(readPublishablePackages(rootDir))
   const repositoryUrl = resolveRepositoryUrl(rootDir)
-  const unpublishedPackages = publishablePackages.filter((pkg) => !isVersionPublished(rootDir, pkg))
+  const releaseWork = createPackageReleaseWork(
+    publishablePackages.map((pkg) => ({
+      package: pkg,
+      tagExists: localTagExists(rootDir, pkg),
+      versionPublished: isVersionPublished(rootDir, pkg),
+    }))
+  )
 
-  if (unpublishedPackages.length === 0) {
-    console.log('[publish] no unpublished workspace packages found')
+  if (!releaseWork.required) {
+    console.log('[publish] registry versions and release tags are already complete')
+    writeReleaseCreatedOutput(false)
     return
   }
 
-  console.log('[publish] unpublished packages:')
-  for (const pkg of unpublishedPackages) {
-    console.log(`- ${pkg.name}@${pkg.version}`)
+  if (releaseWork.packagesToPublish.length > 0) {
+    console.log('[publish] unpublished packages:')
+    for (const pkg of releaseWork.packagesToPublish) {
+      console.log(`- ${pkg.name}@${pkg.version}`)
+    }
   }
 
-  for (const pkg of unpublishedPackages) {
-    publishPackage(rootDir, pkg, dryRun, repositoryUrl)
+  for (const pkg of releaseWork.packagesToPublish) {
+    publishPackage(pkg, dryRun, repositoryUrl)
   }
 
   if (dryRun) {
     console.log('[publish] dry run enabled, skipping changeset tag creation')
+    writeReleaseCreatedOutput(false)
     return
   }
 
-  createChangesetTags(rootDir)
+  if (releaseWork.missingTags.length > 0) {
+    console.log('[publish] missing release tags:')
+    for (const pkg of releaseWork.missingTags) {
+      console.log(`- ${getPackageReleaseTag(pkg.name, pkg.version)}`)
+    }
+    createChangesetTags(rootDir)
+  }
+  writeReleaseCreatedOutput(true)
 }
 
 try {

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -1,0 +1,20 @@
+{
+  // Orthogonal intents (updated 2026-07-28 Asia/Shanghai):
+  // 1. Typecheck release entrypoints and their transitive owners.
+  // 2. Typecheck focused release tests instead of relying on transpilation.
+  // Original request (2026-07-28): "我想先发布一个beta版本"
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": [
+    "scripts/changeversion-auto.ts",
+    "scripts/create-github-release.ts",
+    "scripts/publish-packages.ts",
+    "scripts/lib/changeversion/**/*.ts",
+    "scripts/lib/publish-packages/**/*.ts",
+    "scripts/lib/release/channel*.ts",
+    "scripts/lib/release/github-release*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add explicit Changesets prerelease entry, continuation, and exit planning
- derive npm dist-tags and GitHub prerelease state from validated SemVer
- make registry publication and package tag recovery independently retryable
- skip true no-op release mutations and push tag refs only
- add a checked TypeScript lane and focused mutation-resistant release tests

## Validation

- pnpm format:check
- pnpm lint:ci
- pnpm typecheck
- pnpm test:ci
- pnpm test:browser:ci
- pnpm install --frozen-lockfile
- openspec validate support-beta-release-channel --strict
- focused release helpers: 11 files / 50 tests

The local Vite+ pre-commit hook cannot run because the repository has no staged config. Both commits used --no-verify only after the independent gates above passed.

## Changeset

Not required: this PR changes private release infrastructure and repository guidance only. The following version PR will consume the existing OpenSpec 6 changesets.