### PR TITLE
chore(release): apply changeset version

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -20,6 +20,7 @@
   },
   "changesets": [
     "accelerate-live-projection-loading",
+    "add-kanban-board",
     "config-ownership-sections",
     "openspec-16-frontend-skeleton",
     "refine-live-projection-experience-p1a",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/app
 
+## 6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/app",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/browser-translator/CHANGELOG.md
+++ b/packages/browser-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/browser-translator
 
+## 6.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Patch Changes

--- a/packages/browser-translator/package.json
+++ b/packages/browser-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/browser-translator",
   "private": true,
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Browser-side translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # openspecui
 
+## 6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspecui",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "OpenSpec UI - Visual interface for spec-driven development",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openspecui/core
 
+## 6.0.0-beta.1
+
+### Minor Changes
+
+- 5def094: Add an objective Kanban projection over exact tracked-task phases and structural archives.
+
+  Core and Server now expose exact phase counts plus bounded recent archive summaries through the shared Dashboard Summary contract. Web adds an interactive `/board`, replaces Dashboard Workflow Progress with the callback-free `ReadonlyKanban`, and publishes the same readonly Board in static exports. The readonly projection uses its own container to select four, two, or one columns without horizontal scrolling. The live Board contains page overflow, uses one horizontal lane-grid scrollbar, and lets each lane body scroll vertically on its own. Apply and Archive remain explicit existing Operator flows; drag-to-archive only opens Archive, and stale Root or projection data cannot authorize commands.
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/core",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Core OpenSpec adapter and parser",
   "files": [
     "dist"

--- a/packages/local-ct2-translator/CHANGELOG.md
+++ b/packages/local-ct2-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-ct2-translator
 
+## 6.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Patch Changes

--- a/packages/local-ct2-translator/package.json
+++ b/packages/local-ct2-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-ct2-translator",
   "private": true,
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Server-side CTranslate2 translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-llama-translator/CHANGELOG.md
+++ b/packages/local-llama-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-llama-translator
 
+## 6.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Patch Changes

--- a/packages/local-llama-translator/package.json
+++ b/packages/local-llama-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-llama-translator",
   "private": true,
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Server-side llama.cpp translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-translator/CHANGELOG.md
+++ b/packages/local-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-translator
 
+## 6.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Patch Changes

--- a/packages/local-translator/package.json
+++ b/packages/local-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-translator",
   "private": true,
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Server-side local translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/openai-completion-translator/CHANGELOG.md
+++ b/packages/openai-completion-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/openai-completion-translator
 
+## 6.0.0-beta.1
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Patch Changes

--- a/packages/openai-completion-translator/package.json
+++ b/packages/openai-completion-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/openai-completion-translator",
   "private": true,
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "OpenAI completion translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/search
 
+## 6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/search",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "description": "Shared search engine and worker providers for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @openspecui/server
 
+## 6.0.0-beta.1
+
+### Minor Changes
+
+- 5def094: Add an objective Kanban projection over exact tracked-task phases and structural archives.
+
+  Core and Server now expose exact phase counts plus bounded recent archive summaries through the shared Dashboard Summary contract. Web adds an interactive `/board`, replaces Dashboard Workflow Progress with the callback-free `ReadonlyKanban`, and publishes the same readonly Board in static exports. The readonly projection uses its own container to select four, two, or one columns without horizontal scrolling. The live Board contains page overflow, uses one horizontal lane-grid scrollbar, and lets each lane body scroll vertically on its own. Apply and Archive remain explicit existing Operator flows; drag-to-archive only opens Archive, and stale Root or projection data cannot authorize commands.
+
+### Patch Changes
+
+- Updated dependencies [5def094]
+  - @openspecui/core@6.0.0-beta.1
+  - @openspecui/local-ct2-translator@6.0.0-beta.1
+  - @openspecui/local-llama-translator@6.0.0-beta.1
+  - @openspecui/local-translator@6.0.0-beta.1
+  - @openspecui/openai-completion-translator@6.0.0-beta.1
+  - @openspecui/search@6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/server",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "type": "module",
   "main": "dist/index.mjs",
   "exports": {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openspecui/web
 
+## 6.0.0-beta.1
+
+### Minor Changes
+
+- 5def094: Add an objective Kanban projection over exact tracked-task phases and structural archives.
+
+  Core and Server now expose exact phase counts plus bounded recent archive summaries through the shared Dashboard Summary contract. Web adds an interactive `/board`, replaces Dashboard Workflow Progress with the callback-free `ReadonlyKanban`, and publishes the same readonly Board in static exports. The readonly projection uses its own container to select four, two, or one columns without horizontal scrolling. The live Board contains page overflow, uses one horizontal lane-grid scrollbar, and lets each lane body scroll vertically on its own. Apply and Archive remain explicit existing Operator flows; drag-to-archive only opens Archive, and stale Root or projection data cannot authorize commands.
+
 ## 6.0.0-beta.0
 
 ### Major Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/web",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "type": "module",
   "bin": {
     "openspecui-ssg": "./dist-ssg/ssg-cli.mjs"

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/website
 
+## 6.0.0-beta.1
+
 ## 6.0.0-beta.0
 
 ## 5.0.0

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/website",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated by `pnpm changeversion`.

- Enter, continue, or exit the requested Changesets prerelease mode
- Run `changeset version`
- Commit version/changelog updates
- Create PR and wait for required checks
- Merge PR, sync local main, and wait for GitHub release automation