### PR TITLE
fix(core): resolve Windows CLI runner ENOENT via cross-spawn (#209)

### DIFF
--- a/.changeset/cuddly-ligers-cheer.md
+++ b/.changeset/cuddly-ligers-cheer.md
@@ -1,0 +1,15 @@
+---
+'@openspecui/core': patch
+'@openspecui/server': patch
+'@openspecui/web': patch
+'openspecui': patch
+---
+
+Fix Windows CLI runner resolution failing with ENOENT on npm-global extension-less shims.
+
+On Windows, `where openspec` returns the npm-global extension-less Unix shim first, but Node
+`spawn({ shell: false })` cannot execute it, so every CLI probe failed with `ENOENT` and
+OpenSpecUI could not start (#209). Replace `node:child_process` `spawn` with `cross-spawn`, which
+resolves `PATHEXT` (`openspec.cmd`) while keeping `shell:false` and the existing security model.
+Also prefer the `PATHEXT`-matching entry in `where` output so the resolved path is the real
+executable. Fixes #209.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -201,6 +201,7 @@
   },
   "dependencies": {
     "@parcel/watcher": "^2.5.1",
+    "cross-spawn": "^7.0.6",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-gfm": "^3.1.0",
     "mdast-util-to-string": "^4.0.0",
@@ -210,6 +211,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.3",
     "@vitest/coverage-v8": "^4.1.0",

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_CONFIG,
   OpenSpecUIConfigSchema,
   buildCliRunnerCandidates,
+  pickWindowsExecutablePath,
 } from './config.js'
 import * as reactiveFs from './reactive-fs/index.js'
 import { clearCache } from './reactive-fs/index.js'
@@ -708,6 +709,29 @@ describe('ConfigManager', () => {
         process.env.PATH = previousPath
         process.env.SHELL = previousShell
       }
+    })
+
+    it('pickWindowsExecutablePath prefers a PATHEXT-matching entry over the extension-less shim', () => {
+      // Reproduces the issue #209 `where openspec` shape: extension-less shim first, then .cmd.
+      const lines = [
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\openspec',
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\openspec.cmd',
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\openspec.ps1',
+      ]
+      const pathExt = '.COM;.EXE;.BAT;.CMD;.VBS;.JS;.WS;.MSC'
+      expect(pickWindowsExecutablePath(lines, pathExt)).toBe(
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\openspec.cmd'
+      )
+    })
+
+    it('pickWindowsExecutablePath falls back to the first line when no PATHEXT match exists', () => {
+      const lines = ['C:\\bin\\openspec', 'C:\\bin\\openspec.sh']
+      expect(pickWindowsExecutablePath(lines, '.COM;.EXE;.CMD')).toBe('C:\\bin\\openspec')
+    })
+
+    it('pickWindowsExecutablePath returns null for empty where output', () => {
+      expect(pickWindowsExecutablePath([], '.COM;.EXE;.CMD')).toBeNull()
+      expect(pickWindowsExecutablePath(['', '  '], '.COM;.EXE;.CMD')).toBeNull()
     })
 
     it('does not let an invalidated in-flight runner replace its newer owner', async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,13 +1,17 @@
 /**
- * Orthogonal intents (updated 2026-07-20 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-07-30 Asia/Shanghai):
  * 1. Define and persist project-scoped OpenSpecUI settings.
  * 2. Resolve, diagnose, cache, and explicitly invalidate the OpenSpec CLI runner.
  * 3. Prevent retired in-flight runner resolutions from reclaiming cache ownership.
  * 4. Preserve reactive config reads and serialized config writes.
+ * 5. Resolve Windows `where` candidates by PATHEXT so the executable shim is preferred over the
+ *    extension-less script (issue #209 hotfix).
  *
  * Original request (2026-07-14): "openspec 1.6.0 已经放出，我们需要开始进行适配。"
  * Independent review correction (2026-07-20): Global CLI installation must retire cached and
  * in-flight runner authority.
+ * Hotfix (2026-07-30, issue #209): `where openspec` returns the extension-less npm shim first;
+ *   `spawn({shell:false})` cannot execute it. Prefer the PATHEXT-matching entry (e.g. `.cmd`).
  *
  * Compromise: configuration schemas and runtime management remain in one historical physical file;
  * splitting that public surface is outside the bounded 6.13 correction.
@@ -247,6 +251,33 @@ function quotePosixShellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+/**
+ * Pick the most executable path from Windows `where` output.
+ *
+ * npm global installs emit three siblings: the extension-less Unix shim (returned first and
+ * usable only by Git Bash/WSL), `<cmd>.cmd`, and `<cmd>.ps1`. Node `spawn({shell:false})` cannot
+ * execute the extension-less shim, so prefer the first entry that matches `PATHEXT`. Only fall
+ * back to the raw first line when no entry carries an executable extension.
+ */
+export function pickWindowsExecutablePath(
+  lines: readonly string[],
+  pathExt: string | undefined
+): string | null {
+  const trimmed = lines.map((line) => line.trim()).filter((line) => line.length > 0)
+  if (trimmed.length === 0) return null
+
+  const extensions = (pathExt ?? '.COM;.EXE;.BAT;.CMD;.VBS;.JS;.WS;.MSC')
+    .split(';')
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0)
+
+  const byExtension = trimmed.find((line) => {
+    const lower = line.toLowerCase()
+    return extensions.some((ext) => lower.endsWith(ext))
+  })
+  return byExtension ?? trimmed[0]
+}
+
 async function resolveShellExecutablePath(
   command: string,
   cwd: string,
@@ -264,11 +295,8 @@ async function resolveShellExecutablePath(
         encoding: 'utf8',
         timeout: 5_000,
       })
-      const resolved = stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .find((line) => line.length > 0)
-      return resolved || null
+      const resolved = pickWindowsExecutablePath(stdout.split(/\r?\n/), env.PATHEXT)
+      return resolved
     }
 
     const shell = env.SHELL || process.env.SHELL || '/bin/sh'

--- a/packages/core/src/spawn-safe.ts
+++ b/packages/core/src/spawn-safe.ts
@@ -1,4 +1,19 @@
-import { spawn, type ChildProcess, type SpawnOptionsWithoutStdio } from 'child_process'
+/**
+ * Orthogonal intents (updated 2026-07-30 Asia/Shanghai):
+ * 1. Spawn non-shell child processes without converting synchronous failures into thrown control flow.
+ * 2. Buffer stdout/stderr and preserve exit, timeout, and spawn-error evidence.
+ * 3. Retire cancelled buffered children through bounded SIGTERM-to-SIGKILL escalation.
+ * 4. Resolve commands cross-platform via cross-spawn so Windows npm-global extension-less shims
+ *    (`openspec` without `.cmd`) don't fail with ENOENT under `shell:false`.
+ *
+ * Original request (2026-07-29): "继续打磨 app 模式，我们需要将它适配对接 opentray。"
+ * Hotfix (2026-07-30, issue #209): Windows `spawn({shell:false})` cannot execute the npm-global
+ *   extension-less shim returned first by `where openspec`. `cross-spawn` resolves PATHEXT
+ *   (`openspec.cmd`) while keeping `shell:false`, so the security model in cli-executor.ts is
+ *   unchanged.
+ */
+import type { ChildProcess, SpawnOptionsWithoutStdio } from 'child_process'
+import crossSpawn from 'cross-spawn'
 
 export interface SpawnErrorInfo {
   code?: string
@@ -50,7 +65,7 @@ export function spawnSafe(
   try {
     return {
       ok: true,
-      child: spawn(command, [...args], options),
+      child: crossSpawn(command, [...args], options),
     }
   } catch (err) {
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.1
         version: 2.5.1
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       mdast-util-from-markdown:
         specifier: ^2.0.2
         version: 2.0.2
@@ -249,6 +252,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
@@ -368,7 +374,7 @@ importers:
         version: 0.20.0
       '@tanstack/ai-openai':
         specifier: ^0.9.4
-        version: 0.9.4(@tanstack/ai-client@0.11.2)(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@3.25.76)
+        version: 0.9.4(@tanstack/ai-client@0.11.2)(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -6001,6 +6007,12 @@ packages:
     resolution:
       {
         integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==,
+      }
+
+  '@types/cross-spawn@6.0.6':
+    resolution:
+      {
+        integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==,
       }
 
   '@types/debug@4.1.12':
@@ -15360,14 +15372,14 @@ snapshots:
       '@tanstack/ai': 0.20.0
       '@tanstack/devtools-event-client': 0.4.3
 
-  '@tanstack/ai-openai@0.9.4(@tanstack/ai-client@0.11.2)(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@3.25.76)':
+  '@tanstack/ai-openai@0.9.4(@tanstack/ai-client@0.11.2)(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@4.4.3)':
     dependencies:
       '@tanstack/ai': 0.20.0
       '@tanstack/ai-client': 0.11.2
       '@tanstack/ai-utils': 0.2.0
-      '@tanstack/openai-base': 0.3.3(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@3.25.76)
-      openai: 6.38.0(ws@8.19.0)(zod@3.25.76)
-      zod: 3.25.76
+      '@tanstack/openai-base': 0.3.3(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@4.4.3)
+      openai: 6.38.0(ws@8.19.0)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
@@ -15383,11 +15395,11 @@ snapshots:
 
   '@tanstack/history@1.139.0': {}
 
-  '@tanstack/openai-base@0.3.3(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@3.25.76)':
+  '@tanstack/openai-base@0.3.3(@tanstack/ai@0.20.0)(ws@8.19.0)(zod@4.4.3)':
     dependencies:
       '@tanstack/ai': 0.20.0
       '@tanstack/ai-utils': 0.2.0
-      openai: 6.38.0(ws@8.19.0)(zod@3.25.76)
+      openai: 6.38.0(ws@8.19.0)(zod@4.4.3)
     transitivePeerDependencies:
       - ws
       - zod
@@ -15521,6 +15533,10 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/cookie@0.6.0': {}
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 22.19.1
 
   '@types/debug@4.1.12':
     dependencies:
@@ -17834,10 +17850,10 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.38.0(ws@8.19.0)(zod@3.25.76):
+  openai@6.38.0(ws@8.19.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.19.0
-      zod: 3.25.76
+      zod: 4.4.3
 
   ora@8.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #209 — Windows users hit `Kernel warmup failed: No available OpenSpec CLI runner` because `spawn({ shell: false })` cannot execute the npm-global extension-less shim.

## Root cause

On Windows, `npm i -g @fission-ai/openspec` emits three siblings in the global bin:

```
C:\...\npm\openspec       ← extension-less Unix shim (Git Bash/WSL only)
C:\...\npm\openspec.cmd   ← executable on Windows
C:\...\npm\openspec.ps1
```

`where openspec` returns the **extension-less shim first**. Node `spawn({ shell: false })` cannot execute it (it neither appends `PATHEXT` nor interprets the shim), so every CLI probe failed with `ENOENT` and OpenSpecUI could not start. The real `openspec.cmd` on the second line was never selected.

This is **not** a permissions issue (#209 asked about elevated rights — not required).

## Fix

1. **`spawn-safe.ts`** — replace `node:child_process` `spawn` with `cross-spawn`. cross-spawn resolves `PATHEXT` (`openspec.cmd`) even when handed an absolute extension-less path, while keeping `shell:false`. The security model documented in `cli-executor.ts` (shell-injection avoidance via `shell:false`) is **unchanged**.

2. **`config.ts`** — add `pickWindowsExecutablePath` to prefer the `PATHEXT`-matching entry in `where` output over the blind first line, so the resolved path is the real executable.

## Verification (local)

- `pnpm --filter @openspecui/core typecheck` ✅
- `pnpm --filter @openspecui/core test` — **490/490 passed** ✅ (includes 3 new `pickWindowsExecutablePath` tests covering the #209 `where` shape)
- `pnpm --filter @openspecui/core build` ✅ — dist correctly emits `import crossSpawn from "cross-spawn"` as an external dependency; cli bundles it via existing `noExternal:[/.*/]`
- format + lint on changed files ✅

## Notes

- `shell:false` is deliberately preserved across the whole codebase (4 spawn entry points) for shell-injection safety. cross-spawn fixes Windows resolution **without** relaxing that boundary.
- Branch is based on the `@openspecui/core@6.0.0` tag (695bdef) as a clean hotfix baseline.
- Changeset is `patch` → ships `6.0.1`.

## Checklist

- [x] Local CI-equivalent checks pass (typecheck, test, build, format, lint)
- [x] Includes a `.changeset/*.md` file (patch)
- [x] Every changed TS file retains an accurate timestamped orthogonal-intent header