### PR TITLE
chore(release): apply changeset version

### DIFF
--- a/.changeset/fresh-lions-dance.md
+++ b/.changeset/fresh-lions-dance.md
@@ -1,9 +1,0 @@
----
-'openspecui': patch
-'@openspecui/core': patch
-'@openspecui/server': patch
-'@openspecui/web': patch
-'@openspecui/search': patch
----
-
-Preserve typed CLI contract-error evidence when static Schema export fails.

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/app
 
+## 9.0.1
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/app",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/browser-translator/CHANGELOG.md
+++ b/packages/browser-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/browser-translator
 
+## 9.0.1
+
+### Patch Changes
+
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/browser-translator/package.json
+++ b/packages/browser-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/browser-translator",
   "private": true,
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Browser-side translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openspecui
 
+## 9.0.1
+
+### Patch Changes
+
+- dc854a8: Preserve typed CLI contract-error evidence when static Schema export fails.
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspecui",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "OpenSpec UI - Visual interface for spec-driven development",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openspecui/core
 
+## 9.0.1
+
+### Patch Changes
+
+- dc854a8: Preserve typed CLI contract-error evidence when static Schema export fails.
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/core",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Core OpenSpec adapter and parser",
   "files": [
     "dist"

--- a/packages/local-ct2-translator/CHANGELOG.md
+++ b/packages/local-ct2-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-ct2-translator
 
+## 9.0.1
+
+### Patch Changes
+
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/local-ct2-translator/package.json
+++ b/packages/local-ct2-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-ct2-translator",
   "private": true,
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Server-side CTranslate2 translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-llama-translator/CHANGELOG.md
+++ b/packages/local-llama-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-llama-translator
 
+## 9.0.1
+
+### Patch Changes
+
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/local-llama-translator/package.json
+++ b/packages/local-llama-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-llama-translator",
   "private": true,
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Server-side llama.cpp translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-translator/CHANGELOG.md
+++ b/packages/local-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-translator
 
+## 9.0.1
+
+### Patch Changes
+
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/local-translator/package.json
+++ b/packages/local-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-translator",
   "private": true,
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Server-side local translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/openai-completion-translator/CHANGELOG.md
+++ b/packages/openai-completion-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/openai-completion-translator
 
+## 9.0.1
+
+### Patch Changes
+
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+
 ## 9.0.0
 
 ### Patch Changes

--- a/packages/openai-completion-translator/package.json
+++ b/packages/openai-completion-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/openai-completion-translator",
   "private": true,
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "OpenAI completion translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openspecui/search
 
+## 9.0.1
+
+### Patch Changes
+
+- dc854a8: Preserve typed CLI contract-error evidence when static Schema export fails.
+
 ## 9.0.0
 
 ## 7.0.2

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/search",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Shared search engine and worker providers for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @openspecui/server
 
+## 9.0.1
+
+### Patch Changes
+
+- dc854a8: Preserve typed CLI contract-error evidence when static Schema export fails.
+- Updated dependencies [dc854a8]
+  - @openspecui/core@9.0.1
+  - @openspecui/search@9.0.1
+  - @openspecui/local-ct2-translator@9.0.1
+  - @openspecui/local-llama-translator@9.0.1
+  - @openspecui/local-translator@9.0.1
+  - @openspecui/openai-completion-translator@9.0.1
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/server",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "type": "module",
   "main": "dist/index.mjs",
   "exports": {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openspecui/web
 
+## 9.0.1
+
+### Patch Changes
+
+- dc854a8: Preserve typed CLI contract-error evidence when static Schema export fails.
+
 ## 9.0.0
 
 ### Major Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/web",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "type": "module",
   "bin": {
     "openspecui-ssg": "./dist-ssg/ssg-cli.mjs"

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/website
 
+## 9.0.1
+
 ## 9.0.0
 
 ## 7.0.2

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/website",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Automated by `pnpm changeversion`.

- Enter, continue, or exit the requested Changesets prerelease mode
- Run `changeset version`
- Commit version/changelog updates
- Create PR and wait for required checks
- Merge PR, sync local main, and wait for GitHub release automation