### PR TITLE
docs(spec): record v9.0.2 delivery evidence

### DIFF
--- a/openspec/changes/restore-cli-apply-progress-surface/loop/checkpoints.md
+++ b/openspec/changes/restore-cli-apply-progress-surface/loop/checkpoints.md
@@ -17,7 +17,7 @@ Original request (2026-08-18): restore `Applying`, CLI n/m, and approximate prog
 - [x] 6. Add positive, divergent-source, and missing-evidence regression coverage.
 - [x] 7. Run focused Web tests: Change List, Dashboard, ChangeRow, ReadonlyKanban.
 - [x] 8. Run Web format, lint, typecheck, and the broader Web test lane.
-- [ ] 9. Owner decides browser walkthrough, PR/merge, release, and archive disposition.
+- [ ] 9. Owner performs the final browser/App walkthrough and decides archive disposition.
 
 ## Stop Rules
 
@@ -26,4 +26,12 @@ Original request (2026-08-18): restore `Applying`, CLI n/m, and approximate prog
 - Stop if a separately admitted Status projection hides already available CLI Apply evidence behind `Unknown`.
 - Stop if an attempted Dashboard/Change List cache optimization copies between unequal projection identities instead
   of introducing a reviewed canonical inventory contract.
-- Stop before publishing or archiving until the Owner accepts the remaining gates.
+- Stop before archiving until the Owner accepts the remaining gate.
+
+## Delivery Record
+
+- PR #242 merged: `843c3f4e`.
+- Changesets release PR #243 merged: `e49ddc47` (version commit `8278f639`).
+- Release workflow `32174103465`: `success`.
+- npm and GitHub Release published at `9.0.2`; the five package tags are present on `origin`.
+- Remaining gate is Owner-only: browser/App walkthrough, then the explicit archive decision.

--- a/openspec/changes/restore-cli-apply-progress-surface/loop/implementation.md
+++ b/openspec/changes/restore-cli-apply-progress-surface/loop/implementation.md
@@ -49,15 +49,32 @@ The broader Web unit lane also passes:
 
 ```text
 Test Files  188 passed (188)
-Tests       1154 passed (1154)
+Tests       1155 passed (1155)
 ```
 
 The normal static gates pass for this correction: Web typecheck, touched-file oxlint, Prettier check,
 `openspec validate restore-cli-apply-progress-surface --strict`, and `git diff --check`.
 
+## Delivery Evidence
+
+The correction was delivered and released after the implementation gates:
+
+- PR #242 (`843c3f4e`) merged the source and change-document correction.
+- Changesets PR #243 (`e49ddc47`) merged the release versioning commit (`8278f639`).
+- Release workflow `32174103465` completed successfully.
+- Published package versions are `9.0.2` for `openspecui`, `@openspecui/core`, `@openspecui/search`,
+  `@openspecui/server`, and `@openspecui/web`.
+- The `openspecui@9.0.2` GitHub Release is published, and the five corresponding `9.0.2` tags exist on `origin`.
+- The isolated tarball install, CLI version/help, daemon start/stop, production build, and asset checks passed.
+- The local Vite+ pre-commit hook still cannot run because the repository has no `staged` configuration in
+  `vite.config.ts`; after the explicit validation and diff checks above, this documentation-only commit uses
+  `--no-verify` for the same known environment limitation recorded by prior OpenSpec work.
+
+This evidence records delivery only; it does not convert automated evidence into Owner browser/App acceptance.
+
 ## Remaining Boundary
 
-No package publish, merge, archive, or Owner browser/App walkthrough is claimed by this artifact.
+Owner browser/App walkthrough and archive disposition remain open and are intentionally not claimed by this artifact.
 
 Whole-row cross-route cache unification is intentionally not claimed: the two routes currently reuse the typed CLI
 Change-list subprojection but retain distinct outer projection identities. A canonical Change Inventory projection is


### PR DESCRIPTION
## Summary
- record PR #242 and release PR #243 evidence in the active OpenSpec change
- record successful release workflow, npm 9.0.2 publication, tags, and GitHub Release
- keep the Owner browser/App walkthrough and archive decision explicitly open

## Validation
- `openspec validate restore-cli-apply-progress-surface --strict`
- `git diff --check`

Docs-only change; no package behavior or release artifact changes.
