### PR TITLE
fix(website): retire the app.openspecui.com link

### DIFF
--- a/openspec/changes/renew-website-v9-surface/loop/intake.md
+++ b/openspec/changes/renew-website-v9-surface/loop/intake.md
@@ -11,6 +11,7 @@ Owner visual decision (2026-08-19): "保持纯文字终端风" — no product sc
 Owner IA decision (2026-08-19): "单页叙事，我觉得可以用是Scroll-Animation 来实现相关的 features 展示，但是注意动效要克制。还有，翻译功能不要提，因为我可能会做大重构。"
 Owner merged-direction decision (2026-08-19): "我希望 broadside 的整体效果，还喜欢 BootLog 的那个终端打字的效果，把 BootLog 的这个效果卡片合并到 broadside 中，放在 WHAT'S INSIDE 前面。特别是在桌面模式下，首屏右侧有空间的话，那么我觉得可以吧这个终端打字放在首屏右侧，如果空间不够再放在下面一栏。"
 Owner release decision (2026-08-19): "可以了，我们可以正式推进官网的开发了"
+Owner correction (2026-08-19): "app.openspecui.com 这个链接需要废除掉，这个我们已经不再使用了" — the retired browser-deployment link is removed from the header nav, footer, schema, and both locales.
 -->
 
 ## User Input

--- a/openspec/changes/renew-website-v9-surface/loop/research-plan.md
+++ b/openspec/changes/renew-website-v9-surface/loop/research-plan.md
@@ -31,7 +31,7 @@
 | Features      | 8 numbered full-width rows: OPSX change workflow, Dashboard, Config workbench, Agent delivery, Terminals, Git view, Search, Reactive kernel — sticky index rail with scroll-spy ≥1000px       |
 | Surfaces      | Three cards: Native App (`openspecui start`), Direct Web (`openspecui --web`), Static export (`openspecui export -o ./dist`)                                                                  |
 | Run it        | Inverted band: runner select (npm/pnpm/bun, persisted), App/Web flag toggle with summary swap, SERVE / STATIC EXPORT / PROTECT IT (`--auth`) command rows, compatibility footnote             |
-| Footer        | Ghost word `OPENSPECUI` + links row (app.openspecui.com / openspec.dev / GitHub) + copyright                                                                                                  |
+| Footer        | Ghost word `OPENSPECUI` + links row (openspec.dev / GitHub) + copyright; the retired `app.openspecui.com` link was removed by owner correction                                                |
 | Omitted       | Translation platform (owner expects major rework), PWA (retired), hooks page content (unchanged and still accurate)                                                                           |
 
 ## Implementation map

--- a/packages/website/src/lib/components/site-footer.svelte
+++ b/packages/website/src/lib/components/site-footer.svelte
@@ -5,7 +5,7 @@ Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 Original request (2026-08-19): Broadside Log direction — the ghost word closes the single-page narrative.
 -->
 <script lang="ts">
-  import { APP_URL, GITHUB_URL, OPENSPEC_URL } from '$lib/constants'
+  import { GITHUB_URL, OPENSPEC_URL } from '$lib/constants'
   import type { WebsiteContent } from '$lib/i18n/schema'
 
   interface Props {
@@ -22,9 +22,6 @@ Original request (2026-08-19): Broadside Log direction — the ghost word closes
     class="text-muted-foreground mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 text-[12.5px]"
   >
     <div class="flex flex-wrap items-center gap-x-5 gap-y-2">
-      <a href={APP_URL} target="_blank" rel="noreferrer" class="hover:text-primary transition-colors">
-        {content.links.appTitle} ↗
-      </a>
       <a
         href={OPENSPEC_URL}
         target="_blank"

--- a/packages/website/src/lib/components/site-header.svelte
+++ b/packages/website/src/lib/components/site-header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { APP_URL, GITHUB_URL } from '$lib/constants'
+  import { GITHUB_URL } from '$lib/constants'
   import type { WebsiteContent, WebsiteLanguage } from '$lib/i18n/schema'
   import type { Snippet } from 'svelte'
 
@@ -59,14 +59,6 @@
           ].join(' ')}
         >
           {content.nav.hooks}
-        </a>
-        <a
-          href={APP_URL}
-          target="_blank"
-          rel="noreferrer"
-          class="text-terminal-foreground/70 px-2.5 py-1 transition-colors hover:text-terminal-foreground"
-        >
-          {content.nav.app}
         </a>
         <a
           href={GITHUB_URL}

--- a/packages/website/src/lib/constants.ts
+++ b/packages/website/src/lib/constants.ts
@@ -1,4 +1,3 @@
-export const APP_URL = 'https://app.openspecui.com'
 export const OPENSPEC_URL = 'https://openspec.dev'
 export const GITHUB_URL = 'https://github.com/jixoai/openspecui'
 export const RUNNER_STORAGE_KEY = 'openspecui-website:runner'

--- a/packages/website/src/lib/i18n/locales/en.ts
+++ b/packages/website/src/lib/i18n/locales/en.ts
@@ -26,7 +26,6 @@ export const en = {
   nav: {
     home: 'Home',
     hooks: 'Hooks',
-    app: 'Browser App',
     github: 'GitHub',
   },
   hero: {
@@ -140,8 +139,6 @@ export const en = {
     compat: 'OpenSpecUI 9 supports OpenSpec CLI 1.8.x and 1.9.x (1.9 recommended) · Node ≥ 20.19',
   },
   links: {
-    appTitle: 'app.openspecui.com',
-    appBody: 'Optional browser deployment of the App shell.',
     openspecTitle: 'openspec.dev',
     openspecBody: 'The official OpenSpec project and workflow reference.',
     githubTitle: 'GitHub',

--- a/packages/website/src/lib/i18n/locales/zh.ts
+++ b/packages/website/src/lib/i18n/locales/zh.ts
@@ -26,7 +26,6 @@ export const zh = {
   nav: {
     home: '首页',
     hooks: 'Hooks',
-    app: '浏览器 App',
     github: 'GitHub',
   },
   hero: {
@@ -136,8 +135,6 @@ export const zh = {
     compat: 'OpenSpecUI 9 支持 OpenSpec CLI 1.8.x 与 1.9.x（推荐 1.9）· Node ≥ 20.19',
   },
   links: {
-    appTitle: 'app.openspecui.com',
-    appBody: 'App 外壳的可选浏览器部署。',
     openspecTitle: 'openspec.dev',
     openspecBody: 'OpenSpec 官方项目与工作流参考。',
     githubTitle: 'GitHub',

--- a/packages/website/src/lib/i18n/schema.ts
+++ b/packages/website/src/lib/i18n/schema.ts
@@ -39,7 +39,6 @@ export interface WebsiteContent {
   nav: {
     home: string
     hooks: string
-    app: string
     github: string
   }
   hero: {
@@ -96,8 +95,6 @@ export interface WebsiteContent {
     compat: string
   }
   links: {
-    appTitle: string
-    appBody: string
     openspecTitle: string
     openspecBody: string
     githubTitle: string

--- a/packages/website/src/lib/pages/home-page.test.ts
+++ b/packages/website/src/lib/pages/home-page.test.ts
@@ -34,6 +34,7 @@ describe('HomePage', () => {
 
     expect(screen.queryByText(/PWA/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/translation/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/app\.openspecui\.com/)).not.toBeInTheDocument()
   })
 
   it('settles the terminal typing story with full command and outputs', async () => {


### PR DESCRIPTION
## Summary

Removes every reference to the retired `app.openspecui.com` browser deployment from the website, per owner decision:

- Header nav drops the "Browser App" entry (Home / Hooks / GitHub remain).
- Footer links row keeps `openspec.dev` + GitHub only.
- `APP_URL` constant, `nav.app`, and `links.appTitle/appBody` schema/locale fields are deleted (no backward compatibility), with a test guard asserting the domain never reappears on the rendered home page.

Follow-up to #245 within the active `renew-website-v9-surface` OpenSpec change (owner correction recorded in intake/research-plan).

## Verification

- `typecheck` 0/0, `test` 21/21, static `build`, root `format:check` + `lint:ci` all green.
- Rendered `/en/` verified: no `app.openspecui.com`, no "Browser App" nav label, GitHub nav present.

**Note:** product-level docs (repo `README.md`, `packages/app` README) still describe `app.openspecui.com` as an optional deployment; that cleanup is intentionally left for a separate docs pass.