### PR TITLE
feat(website): copy surface commands on click

### DIFF
--- a/openspec/changes/renew-website-v9-surface/loop/intake.md
+++ b/openspec/changes/renew-website-v9-surface/loop/intake.md
@@ -12,6 +12,7 @@ Owner IA decision (2026-08-19): "单页叙事，我觉得可以用是Scroll-Anim
 Owner merged-direction decision (2026-08-19): "我希望 broadside 的整体效果，还喜欢 BootLog 的那个终端打字的效果，把 BootLog 的这个效果卡片合并到 broadside 中，放在 WHAT'S INSIDE 前面。特别是在桌面模式下，首屏右侧有空间的话，那么我觉得可以吧这个终端打字放在首屏右侧，如果空间不够再放在下面一栏。"
 Owner release decision (2026-08-19): "可以了，我们可以正式推进官网的开发了"
 Owner correction (2026-08-19): "app.openspecui.com 这个链接需要废除掉，这个我们已经不再使用了" — the retired browser-deployment link is removed from the header nav, footer, schema, and both locales.
+Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制命令。" — surface command lines are click-to-copy buttons sharing the site-wide copy labels.
 -->
 
 ## User Input

--- a/packages/website/src/lib/components/home/hero-section.svelte
+++ b/packages/website/src/lib/components/home/hero-section.svelte
@@ -84,7 +84,7 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
             'shadow-xs hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-md active:translate-x-px active:translate-y-px active:shadow-none',
           ].join(' ')}
         >
-          <span>{copied ? content.hero.copiedCta : content.hero.copyCta}</span>
+          <span>{copied ? content.copy.done : content.copy.label}</span>
           <span>{content.terminal.command}</span>
         </button>
         <a

--- a/packages/website/src/lib/components/home/surfaces-section.svelte
+++ b/packages/website/src/lib/components/home/surfaces-section.svelte
@@ -1,8 +1,10 @@
 <!--
 Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 1. Render the three usage surfaces as outlined-numeral cards with their production commands.
+2. Own the surface command clipboard action with a per-command copied state.
 
 Original request (2026-08-19): "只提供现有最新版本的信息" — surfaces describe the v9 CLI surface only.
+Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制命令。"
 -->
 <script lang="ts">
   import { reveal } from '$lib/actions/reveal'
@@ -13,6 +15,31 @@ Original request (2026-08-19): "只提供现有最新版本的信息" — surfac
   }
 
   let { content }: Props = $props()
+
+  let copiedCommand = $state<string | null>(null)
+  let copyTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function copySurfaceCommand(command: string) {
+    try {
+      await navigator.clipboard.writeText(command)
+    } catch {
+      const area = document.createElement('textarea')
+      area.value = command
+      document.body.appendChild(area)
+      area.select()
+      try {
+        document.execCommand('copy')
+      } catch {
+        /* clipboard unavailable without permissions */
+      }
+      area.remove()
+    }
+    copiedCommand = command
+    clearTimeout(copyTimer)
+    copyTimer = setTimeout(() => {
+      copiedCommand = null
+    }, 1400)
+  }
 </script>
 
 <section id="surfaces" class="mx-auto w-full max-w-[90rem] px-4 pb-16 sm:px-6 lg:px-8">
@@ -29,11 +56,21 @@ Original request (2026-08-19): "只提供现有最新版本的信息" — surfac
         <div class="surface-numeral font-nav" aria-hidden="true">{`0${index + 1}`}</div>
         <h3 class="font-nav text-[19px]">{item.title}</h3>
         <p class="text-muted-foreground mb-2 text-pretty text-[13.5px] leading-6">{item.body}</p>
-        <code
-          class="bg-terminal text-terminal-foreground mt-auto block overflow-x-auto px-3 py-2 text-sm whitespace-nowrap"
+        <button
+          type="button"
+          aria-label={`${content.copy.label} ${item.command}`}
+          onclick={() => copySurfaceCommand(item.command)}
+          class="bg-terminal text-terminal-foreground mt-auto flex w-full items-center justify-between gap-3 overflow-x-auto px-3 py-2 text-left text-sm whitespace-nowrap transition-[background-color] duration-150 hover:bg-[color-mix(in_oklab,var(--color-terminal)_86%,var(--color-terminal-foreground))]"
         >
-          $ {item.command}
-        </code>
+          <span>$ {item.command}</span>
+          <span
+            class="shrink-0 border border-current px-1.5 py-0.5 text-[10px] tracking-[0.16em]"
+            class:bg-primary={copiedCommand === item.command}
+            class:text-primary-foreground={copiedCommand === item.command}
+          >
+            {copiedCommand === item.command ? content.copy.done : content.copy.label}
+          </span>
+        </button>
       </article>
     {/each}
   </div>

--- a/packages/website/src/lib/i18n/locales/en.ts
+++ b/packages/website/src/lib/i18n/locales/en.ts
@@ -28,6 +28,10 @@ export const en = {
     hooks: 'Hooks',
     github: 'GitHub',
   },
+  copy: {
+    label: 'COPY',
+    done: 'COPIED',
+  },
   hero: {
     eyebrow: 'OPENSPECUI 9 — VISUAL PROJECTION OF OPENSPEC',
     titleLead: 'Operate OpenSpec through a UI that stays ',
@@ -35,8 +39,6 @@ export const en = {
     summary:
       'OpenSpecUI 9 gives OpenSpec projects a reactive dashboard, an objective change workflow, a config workbench, real terminals, and static export — without hiding the OpenSpec CLI underneath.',
     badges: ['NATIVE APP', 'LIVE WEB', 'STATIC EXPORT'],
-    copyCta: 'COPY',
-    copiedCta: 'COPIED',
     githubCta: 'GITHUB ↗',
   },
   terminal: {

--- a/packages/website/src/lib/i18n/locales/zh.ts
+++ b/packages/website/src/lib/i18n/locales/zh.ts
@@ -28,6 +28,10 @@ export const zh = {
     hooks: 'Hooks',
     github: 'GitHub',
   },
+  copy: {
+    label: '复制',
+    done: '已复制',
+  },
   hero: {
     eyebrow: 'OPENSPECUI 9 — OPENSPEC 的可视化投影',
     titleLead: '操作 OpenSpec，让 UI 始终',
@@ -35,8 +39,6 @@ export const zh = {
     summary:
       'OpenSpecUI 9 为 OpenSpec 项目提供响应式仪表盘、客观的变更工作流、配置工作台、真实终端与静态导出——同时不隐藏底层的 OpenSpec CLI。',
     badges: ['原生 App', '实时 Web', '静态导出'],
-    copyCta: '复制',
-    copiedCta: '已复制',
     githubCta: 'GITHUB ↗',
   },
   terminal: {

--- a/packages/website/src/lib/i18n/schema.ts
+++ b/packages/website/src/lib/i18n/schema.ts
@@ -41,6 +41,11 @@ export interface WebsiteContent {
     hooks: string
     github: string
   }
+  /** Shared clipboard action labels used by the hero CTA and surface command buttons. */
+  copy: {
+    label: string
+    done: string
+  }
   hero: {
     eyebrow: string
     /** Rendered as large lead type; the accent fragment renders in the primary color. */
@@ -48,8 +53,6 @@ export interface WebsiteContent {
     titleAccent: string
     summary: string
     badges: [string, string, string]
-    copyCta: string
-    copiedCta: string
     githubCta: string
   }
   terminal: {

--- a/packages/website/src/lib/pages/home-page.test.ts
+++ b/packages/website/src/lib/pages/home-page.test.ts
@@ -50,6 +50,20 @@ describe('HomePage', () => {
     expect(screen.getByText(en.terminal.outputs[3])).toBeVisible()
   })
 
+  it('surface commands copy on click with per-command feedback', async () => {
+    render(HomePage, { content: en })
+
+    const start = screen.getByRole('button', { name: 'COPY openspecui start' })
+    await fireEvent.click(start)
+
+    await waitFor(() => expect(screen.getByText(en.copy.done)).toBeVisible())
+    expect(screen.getAllByText(en.copy.label).length).toBeGreaterThanOrEqual(1)
+
+    // The other surface commands keep their idle labels.
+    expect(screen.getByRole('button', { name: 'COPY openspecui --web' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'COPY openspecui export -o ./dist' })).toBeVisible()
+  })
+
   it('launch controls emit explicit production CLI modes', async () => {
     render(HomePage, { content: en })
 


### PR DESCRIPTION
## Summary

The THREE SURFACES command lines are now click-to-copy buttons, per owner request:

- Each surface card's `$ command` line is a full-width terminal-styled button; clicking copies the exact command (no `$ ` prefix) with a `COPY → COPIED` chip on the inline-end that resets after 1.4s.
- Copy labels move from hero-only fields to a shared top-level `copy: { label, done }` schema entry so the hero CTA and surface buttons use one source (EN: COPY/COPIED, ZH: 复制/已复制).
- Hover affordance on the terminal block; aria-label `COPY <command>` per button.

## Verification

- typecheck 0/0, tests 22/22 (new per-command feedback case), static build, root format/lint all green.
- Real-Chromium check with clipboard permissions: `openspecui start` / `openspecui export -o ./dist` / `openspecui --web` land verbatim in the clipboard, chip resets to COPY, ZH shows 已复制. Screenshot: `.agents/images/2026-08-19-website-live-walkthrough/10-en-surfaces-copied.png`