### PR TITLE
feat(website): copy run-it commands and pin header toggle borders

### DIFF
--- a/openspec/changes/renew-website-v9-surface/loop/intake.md
+++ b/openspec/changes/renew-website-v9-surface/loop/intake.md
@@ -13,6 +13,8 @@ Owner merged-direction decision (2026-08-19): "我希望 broadside 的整体效�
 Owner release decision (2026-08-19): "可以了，我们可以正式推进官网的开发了"
 Owner correction (2026-08-19): "app.openspecui.com 这个链接需要废除掉，这个我们已经不再使用了" — the retired browser-deployment link is removed from the header nav, footer, schema, and both locales.
 Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制命令。" — surface command lines are click-to-copy buttons sharing the site-wide copy labels.
+Original request (2026-08-19): "RUN IT 这里也需要支持点击复制" — run-it serve/export/auth command rows are click-to-copy buttons over the current dynamic values.
+Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的，所以Theme 和 Language 这里的 toggle 要固定 border 的颜色为亮色。" — the header theme/language toggle borders are pinned to a light color (terminal-foreground/30) instead of the theme-dependent border token fallback.
 -->
 
 ## User Input

--- a/packages/website/src/lib/clipboard.ts
+++ b/packages/website/src/lib/clipboard.ts
@@ -1,0 +1,22 @@
+/**
+ * Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
+ * 1. Provide one clipboard writer with an execCommand fallback for non-secure contexts.
+ *
+ * Original request (2026-08-19): "RUN IT 这里也需要支持点击复制" — shared by hero CTA, surface commands, and run-it commands.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const area = document.createElement('textarea')
+    area.value = text
+    document.body.appendChild(area)
+    area.select()
+    try {
+      document.execCommand('copy')
+    } catch {
+      /* clipboard unavailable without permissions */
+    }
+    area.remove()
+  }
+}

--- a/packages/website/src/lib/components/home/hero-section.svelte
+++ b/packages/website/src/lib/components/home/hero-section.svelte
@@ -7,6 +7,7 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
 -->
 <script lang="ts">
   import { reveal } from '$lib/actions/reveal'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import { GITHUB_URL } from '$lib/constants'
   import type { WebsiteContent } from '$lib/i18n/schema'
   import TerminalCard from './terminal-card.svelte'
@@ -21,21 +22,7 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
   let copyTimer: ReturnType<typeof setTimeout> | undefined
 
   async function copyQuickStart() {
-    const text = content.terminal.command
-    try {
-      await navigator.clipboard.writeText(text)
-    } catch {
-      const area = document.createElement('textarea')
-      area.value = text
-      document.body.appendChild(area)
-      area.select()
-      try {
-        document.execCommand('copy')
-      } catch {
-        /* clipboard unavailable without permissions */
-      }
-      area.remove()
-    }
+    await copyTextToClipboard(content.terminal.command)
     copied = true
     clearTimeout(copyTimer)
     copyTimer = setTimeout(() => {

--- a/packages/website/src/lib/components/home/run-it-section.svelte
+++ b/packages/website/src/lib/components/home/run-it-section.svelte
@@ -2,11 +2,14 @@
 Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 1. Render the inverted run-it band: runner select, App/Web flag toggle, serve/export/auth commands.
 2. Keep the runner preference persisted and every emitted command production-accurate.
+3. Own the run-it command clipboard actions with per-command copied state.
 
 Original request (2026-08-19): "只提供现有最新版本的信息" — commands mirror the published v9 CLI surface.
+Original request (2026-08-19): "RUN IT 这里也需要支持点击复制"
 -->
 <script lang="ts">
   import { reveal } from '$lib/actions/reveal'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import { RUNNER_STORAGE_KEY } from '$lib/constants'
   import type { RunnerId, WebsiteContent } from '$lib/i18n/schema'
   import { getRunnerCommandPrefix, isRunnerId } from '$lib/runner'
@@ -27,6 +30,18 @@ Original request (2026-08-19): "只提供现有最新版本的信息" — comman
   )
   const exportCommand = $derived(`${runnerCommandPrefix} openspecui@latest export -o ./dist`)
   const authCommand = 'openspecui --auth'
+
+  let copiedCommand = $state<string | null>(null)
+  let copyTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function copyRunCommand(command: string) {
+    await copyTextToClipboard(command)
+    copiedCommand = command
+    clearTimeout(copyTimer)
+    copyTimer = setTimeout(() => {
+      copiedCommand = null
+    }, 1400)
+  }
 
   onMount(() => {
     const stored = window.localStorage.getItem(RUNNER_STORAGE_KEY)
@@ -95,33 +110,63 @@ Original request (2026-08-19): "只提供现有最新版本的信息" — comman
           <span class="text-primary">{'>_'}</span>
           {content.run.serveCaption}
         </p>
-        <code
-          class="bg-terminal text-terminal-foreground block overflow-x-auto px-3 py-2.5 text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)]"
+        <button
+          type="button"
+          aria-label={`${content.copy.label} ${serveCommand}`}
+          onclick={() => copyRunCommand(serveCommand)}
+          class="bg-terminal text-terminal-foreground flex w-full items-center justify-between gap-3 overflow-x-auto px-3 py-2.5 text-left text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)] transition-[background-color] duration-150 hover:bg-[color-mix(in_oklab,var(--color-terminal)_86%,var(--color-terminal-foreground))]"
           data-run-command
         >
-          {serveCommand}
-        </code>
+          <span>$ {serveCommand}</span>
+          <span
+            class="shrink-0 border border-current px-1.5 py-0.5 text-[10px] tracking-[0.16em]"
+            class:bg-primary={copiedCommand === serveCommand}
+            class:text-primary-foreground={copiedCommand === serveCommand}
+          >
+            {copiedCommand === serveCommand ? content.copy.done : content.copy.label}
+          </span>
+        </button>
       </div>
       <div>
         <p class="font-nav mb-2 text-[11px] tracking-[0.2em] opacity-60">
           {content.run.exportCaption}
         </p>
-        <code
-          class="bg-terminal text-terminal-foreground block overflow-x-auto px-3 py-2.5 text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)]"
+        <button
+          type="button"
+          aria-label={`${content.copy.label} ${exportCommand}`}
+          onclick={() => copyRunCommand(exportCommand)}
+          class="bg-terminal text-terminal-foreground flex w-full items-center justify-between gap-3 overflow-x-auto px-3 py-2.5 text-left text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)] transition-[background-color] duration-150 hover:bg-[color-mix(in_oklab,var(--color-terminal)_86%,var(--color-terminal-foreground))]"
         >
-          {exportCommand}
-        </code>
+          <span>$ {exportCommand}</span>
+          <span
+            class="shrink-0 border border-current px-1.5 py-0.5 text-[10px] tracking-[0.16em]"
+            class:bg-primary={copiedCommand === exportCommand}
+            class:text-primary-foreground={copiedCommand === exportCommand}
+          >
+            {copiedCommand === exportCommand ? content.copy.done : content.copy.label}
+          </span>
+        </button>
         <p class="mt-2 text-[12px] leading-5 opacity-60">{content.run.exportSummary}</p>
       </div>
       <div>
         <p class="font-nav mb-2 text-[11px] tracking-[0.2em] opacity-60">
           {content.run.protectCaption}
         </p>
-        <code
-          class="bg-terminal text-terminal-foreground block overflow-x-auto px-3 py-2.5 text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)]"
+        <button
+          type="button"
+          aria-label={`${content.copy.label} ${authCommand}`}
+          onclick={() => copyRunCommand(authCommand)}
+          class="bg-terminal text-terminal-foreground flex w-full items-center justify-between gap-3 overflow-x-auto px-3 py-2.5 text-left text-sm whitespace-nowrap shadow-[6px_6px_0_0_color-mix(in_oklab,var(--background)_26%,transparent)] transition-[background-color] duration-150 hover:bg-[color-mix(in_oklab,var(--color-terminal)_86%,var(--color-terminal-foreground))]"
         >
-          $ {authCommand}
-        </code>
+          <span>$ {authCommand}</span>
+          <span
+            class="shrink-0 border border-current px-1.5 py-0.5 text-[10px] tracking-[0.16em]"
+            class:bg-primary={copiedCommand === authCommand}
+            class:text-primary-foreground={copiedCommand === authCommand}
+          >
+            {copiedCommand === authCommand ? content.copy.done : content.copy.label}
+          </span>
+        </button>
         <p class="mt-2 text-[12px] leading-5 opacity-60">{content.run.protectSummary}</p>
       </div>
       <p class="mt-2 text-[12px] leading-5 opacity-55">{content.run.compat}</p>

--- a/packages/website/src/lib/components/home/surfaces-section.svelte
+++ b/packages/website/src/lib/components/home/surfaces-section.svelte
@@ -8,6 +8,7 @@ Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制
 -->
 <script lang="ts">
   import { reveal } from '$lib/actions/reveal'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import type { WebsiteContent } from '$lib/i18n/schema'
 
   interface Props {
@@ -20,20 +21,7 @@ Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制
   let copyTimer: ReturnType<typeof setTimeout> | undefined
 
   async function copySurfaceCommand(command: string) {
-    try {
-      await navigator.clipboard.writeText(command)
-    } catch {
-      const area = document.createElement('textarea')
-      area.value = command
-      document.body.appendChild(area)
-      area.select()
-      try {
-        document.execCommand('copy')
-      } catch {
-        /* clipboard unavailable without permissions */
-      }
-      area.remove()
-    }
+    await copyTextToClipboard(command)
     copiedCommand = command
     clearTimeout(copyTimer)
     copyTimer = setTimeout(() => {

--- a/packages/website/src/lib/components/language-switcher.svelte
+++ b/packages/website/src/lib/components/language-switcher.svelte
@@ -1,3 +1,9 @@
+<!--
+Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
+1. Render the EN/中文 locale toggle as localized anchor links.
+
+Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的，所以Theme 和 Language 这里的 toggle 要固定 border 的颜色为亮色。"
+-->
 <script lang="ts">
   import { getAlternateLocale, localizePath } from '$lib/i18n/languages'
   import type { WebsiteContent, WebsiteLanguage } from '$lib/i18n/schema'
@@ -15,7 +21,7 @@
 <div class="flex items-center gap-2">
   <span class="text-terminal-foreground/72 text-xs">{content.meta.languageLabel}</span>
   <div
-    class="border-terminal-border bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
+    class="border-terminal-foreground/30 bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
     role="group"
     aria-label={content.meta.languageLabel}
   >

--- a/packages/website/src/lib/components/theme-switcher.svelte
+++ b/packages/website/src/lib/components/theme-switcher.svelte
@@ -1,3 +1,9 @@
+<!--
+Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
+1. Render the light/dark/system theme toggle persisted through the shared website theme storage.
+
+Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的，所以Theme 和 Language 这里的 toggle 要固定 border 的颜色为亮色。"
+-->
 <script lang="ts">
   import { onMount } from 'svelte'
   import type { WebsiteContent } from '$lib/i18n/schema'
@@ -32,7 +38,7 @@
 <div class="flex items-center gap-2">
   <span class="text-terminal-foreground/72 text-xs">{content.meta.themeLabel}</span>
   <div
-    class="border-terminal-border bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
+    class="border-terminal-foreground/30 bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
     role="group"
     aria-label={content.meta.themeLabel}
   >

--- a/packages/website/src/lib/pages/home-page.test.ts
+++ b/packages/website/src/lib/pages/home-page.test.ts
@@ -64,21 +64,37 @@ describe('HomePage', () => {
     expect(screen.getByRole('button', { name: 'COPY openspecui export -o ./dist' })).toBeVisible()
   })
 
+  it('run-it commands copy on click with the current dynamic value', async () => {
+    render(HomePage, { content: en })
+
+    const serve = screen.getByRole('button', { name: 'COPY npx openspecui@latest --app' })
+    await fireEvent.click(serve)
+    await waitFor(() => expect(screen.getAllByText(en.copy.done).length).toBeGreaterThanOrEqual(1))
+
+    const auth = screen.getByRole('button', { name: 'COPY openspecui --auth' })
+    await fireEvent.click(auth)
+    await waitFor(() => expect(screen.getAllByText(en.copy.done).length).toBeGreaterThanOrEqual(1))
+
+    expect(
+      screen.getByRole('button', { name: 'COPY npx openspecui@latest export -o ./dist' })
+    ).toBeVisible()
+  })
+
   it('launch controls emit explicit production CLI modes', async () => {
     render(HomePage, { content: en })
 
-    expect(screen.getByText('npx openspecui@latest --app')).toBeVisible()
-    expect(screen.getByText('npx openspecui@latest export -o ./dist')).toBeVisible()
+    expect(screen.getByText('$ npx openspecui@latest --app')).toBeVisible()
+    expect(screen.getByText('$ npx openspecui@latest export -o ./dist')).toBeVisible()
     expect(screen.getByText('$ openspecui --auth')).toBeVisible()
 
     await fireEvent.change(screen.getByLabelText('RUNNER'), { target: { value: 'pnpm' } })
 
-    expect(screen.getByText('pnpx openspecui@latest --app')).toBeVisible()
-    expect(screen.getByText('pnpx openspecui@latest export -o ./dist')).toBeVisible()
+    expect(screen.getByText('$ pnpx openspecui@latest --app')).toBeVisible()
+    expect(screen.getByText('$ pnpx openspecui@latest export -o ./dist')).toBeVisible()
 
     await fireEvent.click(screen.getByRole('button', { name: /APP MODE/ }))
 
-    expect(screen.getByText('pnpx openspecui@latest --web')).toBeVisible()
+    expect(screen.getByText('$ pnpx openspecui@latest --web')).toBeVisible()
     expect(screen.getByText(en.run.serveWebSummary)).toBeVisible()
     expect(screen.queryByText(en.run.serveAppSummary)).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

Two owner-requested refinements to the renewed website:

1. **RUN IT click-to-copy** — the SERVE / STATIC EXPORT / PROTECT IT command rows are now terminal-styled copy buttons (same pattern as THREE SURFACES). The copied value is the current dynamic command: switching the runner or the App/Web flag is reflected in what lands on the clipboard. All three rows now display a consistent `$ ` prompt prefix.
2. **Header toggle borders pinned light** — `border-terminal-border` referenced a token that does not exist anywhere, so the Theme/Language group borders silently fell back to the theme-dependent `--color-border` (black in light mode, invisible on the always-dark header). Both switchers now use `border-terminal-foreground/30`, a fixed light border in both color schemes.

Clipboard writing is extracted into a shared `copyTextToClipboard` util (Clipboard API + execCommand fallback) used by the hero CTA, surface commands, and run-it commands.

## Verification

- typecheck 0/0, tests 23/23 (new run-it copy case with dynamic values), static build, root format/lint green.
- Real Chromium with clipboard permissions: after switching runner to pnpm, clicks copy `pnpx openspecui@latest --app`, `pnpx openspecui@latest export -o ./dist`, and `openspecui --auth` verbatim; chip swaps COPY→COPIED.
- Computed style check: toggle borders are `oklab(1 0 0 / 0.3)` (light) in BOTH light and dark modes. Screenshots 11/12 in `.agents/images/2026-08-19-website-live-walkthrough/`.