### PR TITLE
feat(website): swap copy labels for fixed-size icon chips

### DIFF
--- a/packages/website/src/lib/components/home/command-copy-button.svelte
+++ b/packages/website/src/lib/components/home/command-copy-button.svelte
@@ -1,14 +1,17 @@
 <!--
 Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 1. Provide the single click-to-copy terminal command button used by surfaces and run-it rows.
-2. Own the copied feedback lifecycle (chip swap + 1.4s reset) and reset it when the command changes.
+2. Own the copied feedback lifecycle (icon chip swap + 1.4s reset) and reset it when the command changes.
 
 Owner correction (2026-08-19): "是不是很多地方你都是复制粘贴不做组件化的" — extracted from four pasted copies.
 Original request (2026-08-19): "THREE SURFACES 这里需要能支持点击复制命令。" / "RUN IT 这里也需要支持点击复制"
 Owner layout refinement (2026-08-19): "最好把开头的 `$` 这个作为一个独立的头部…要基于空格去换行"
+Owner icon decision (2026-08-19): "这个 COPY 和 COPIED 改成图标吧，这样会比较稳定" — fixed-size icon chip; state moves to the aria-label.
 -->
 <script lang="ts">
   import { copyTextToClipboard } from '$lib/clipboard'
+  import Check from 'lucide-svelte/icons/check'
+  import Copy from 'lucide-svelte/icons/copy'
 
   interface Props {
     command: string
@@ -48,7 +51,7 @@ Owner layout refinement (2026-08-19): "最好把开头的 `$` 这个作为一个
 
 <button
   type="button"
-  aria-label={`${copyLabel} ${command}`}
+  aria-label={`${copied ? copiedLabel : copyLabel} ${command}`}
   onclick={copyCommand}
   data-run-command={dataRunCommand}
   class="bg-terminal text-terminal-foreground flex w-full items-start justify-between gap-2 px-3 py-2.5 text-left text-sm transition-[background-color] duration-150 hover:bg-[color-mix(in_oklab,var(--color-terminal)_86%,var(--color-terminal-foreground))] {className}"
@@ -56,10 +59,14 @@ Owner layout refinement (2026-08-19): "最好把开头的 `$` 这个作为一个
   <span class="text-primary shrink-0" aria-hidden="true">$</span>
   <span class="block min-w-0 flex-1 wrap-break-word">{command}</span>
   <span
-    class="shrink-0 border border-current px-1.5 py-0.5 text-[10px] tracking-[0.16em] transition-colors duration-150"
+    class="border-current inline-flex h-5 w-5 shrink-0 items-center justify-center border transition-colors duration-150"
     class:bg-primary={copied}
     class:text-primary-foreground={copied}
   >
-    {copied ? copiedLabel : copyLabel}
+    {#if copied}
+      <Check class="h-3 w-3" aria-hidden="true" />
+    {:else}
+      <Copy class="h-3 w-3" aria-hidden="true" />
+    {/if}
   </span>
 </button>

--- a/packages/website/src/lib/components/home/hero-section.svelte
+++ b/packages/website/src/lib/components/home/hero-section.svelte
@@ -11,6 +11,8 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
   import PressButton from '$lib/components/press-button.svelte'
   import { GITHUB_URL } from '$lib/constants'
   import type { WebsiteContent } from '$lib/i18n/schema'
+  import Check from 'lucide-svelte/icons/check'
+  import Copy from 'lucide-svelte/icons/copy'
   import TerminalCard from './terminal-card.svelte'
 
   interface Props {
@@ -61,8 +63,16 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
         {/each}
       </div>
       <div class="mt-8 flex flex-wrap gap-3" use:reveal={{ delay: 200 }}>
-        <PressButton variant={copied ? 'copied' : 'primary'} onclick={copyQuickStart}>
-          <span>{copied ? content.copy.done : content.copy.label}</span>
+        <PressButton
+          variant={copied ? 'copied' : 'primary'}
+          onclick={copyQuickStart}
+          ariaLabel={`${copied ? content.copy.done : content.copy.label} ${content.terminal.command}`}
+        >
+          {#if copied}
+            <Check class="h-4 w-4" aria-hidden="true" />
+          {:else}
+            <Copy class="h-4 w-4" aria-hidden="true" />
+          {/if}
           <span>{content.terminal.command}</span>
         </PressButton>
         <PressButton variant="outline" href={GITHUB_URL}>{content.hero.githubCta}</PressButton>

--- a/packages/website/src/lib/components/press-button.svelte
+++ b/packages/website/src/lib/components/press-button.svelte
@@ -12,6 +12,7 @@ Owner correction (2026-08-19): "应该组件化就组件化，哪怕是我们官
     href?: string
     onclick?: () => void
     type?: 'button' | 'submit'
+    ariaLabel?: string
     children: Snippet
   }
 
@@ -20,6 +21,7 @@ Owner correction (2026-08-19): "应该组件化就组件化，哪怕是我们官
     href,
     onclick,
     type = 'button',
+    ariaLabel,
     children,
   }: Props = $props()
 
@@ -34,7 +36,9 @@ Owner correction (2026-08-19): "应该组件化就组件化，哪怕是我们官
 </script>
 
 {#if href}
-  <a {href} target="_blank" rel="noreferrer" class={classes}>{@render children()}</a>
+  <a {href} target="_blank" rel="noreferrer" aria-label={ariaLabel} class={classes}>
+    {@render children()}
+  </a>
 {:else}
-  <button {type} {onclick} class={classes}>{@render children()}</button>
+  <button {type} {onclick} aria-label={ariaLabel} class={classes}>{@render children()}</button>
 {/if}

--- a/packages/website/src/lib/pages/home-page.test.ts
+++ b/packages/website/src/lib/pages/home-page.test.ts
@@ -56,10 +56,12 @@ describe('HomePage', () => {
     const start = screen.getByRole('button', { name: 'COPY openspecui start' })
     await fireEvent.click(start)
 
-    await waitFor(() => expect(screen.getByText(en.copy.done)).toBeVisible())
-    expect(screen.getAllByText(en.copy.label).length).toBeGreaterThanOrEqual(1)
+    // The copied state moves to the icon chip and the accessible name.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'COPIED openspecui start' })).toBeVisible()
+    )
 
-    // The other surface commands keep their idle labels.
+    // The other surface commands keep their idle state.
     expect(screen.getByRole('button', { name: 'COPY openspecui --web' })).toBeVisible()
     expect(screen.getByRole('button', { name: 'COPY openspecui export -o ./dist' })).toBeVisible()
   })
@@ -69,11 +71,17 @@ describe('HomePage', () => {
 
     const serve = screen.getByRole('button', { name: 'COPY npx openspecui@latest --app' })
     await fireEvent.click(serve)
-    await waitFor(() => expect(screen.getAllByText(en.copy.done).length).toBeGreaterThanOrEqual(1))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'COPIED npx openspecui@latest --app' })
+      ).toBeVisible()
+    )
 
     const auth = screen.getByRole('button', { name: 'COPY openspecui --auth' })
     await fireEvent.click(auth)
-    await waitFor(() => expect(screen.getAllByText(en.copy.done).length).toBeGreaterThanOrEqual(1))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'COPIED openspecui --auth' })).toBeVisible()
+    )
 
     expect(
       screen.getByRole('button', { name: 'COPY npx openspecui@latest export -o ./dist' })


### PR DESCRIPTION
## Summary

Per owner request, the COPY/COPIED text labels become fixed-size icon chips:

- All command copy buttons (THREE SURFACES + RUN IT, via the shared `command-copy-button`) swap the text chip for a 20×20 bordered icon chip — lucide `copy` idle, `check` on copied with primary fill. Chip geometry is identical across languages and states, so nothing shifts when feedback appears.
- The hero quick-start CTA gets the same treatment (`copy`/`check` icon + command text) via `PressButton`, which now forwards an `aria-label`.
- Copied state moves to the accessible name (`COPY <cmd>` → `COPIED <cmd>`, 复制 → 已复制), keeping screen-reader feedback after the visible text left the DOM; locale `copy.label/done` strings now serve aria-labels only.

## Verification

- typecheck 0/0, tests 23/23 (copy cases now assert the accessible-name swap), static build, root format/lint green.
- Real Chromium at 390px: hero and surface copies land verbatim on the clipboard; chip measures exactly 20×20 before and after the state change (zero layout shift). Screenshot 20 in `.agents/images/2026-08-19-website-live-walkthrough/`.