### PR TITLE
fix(website): relax display leading and iconize header switchers

### DIFF
--- a/openspec/changes/renew-website-v9-surface/loop/intake.md
+++ b/openspec/changes/renew-website-v9-surface/loop/intake.md
@@ -18,6 +18,9 @@ Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的
 Original request (2026-08-19): "我发现移动端的窄屏模式下，这些可复制的命令行过长，导致存在溢出问题" — copyable command buttons delegate horizontal scrolling to the command text; the copy chip stays pinned and neither the button nor the page overflows.
 Owner follow-up (2026-08-19): "我这边看问题还是存在" — the internal horizontal scroll still read as clipped overflow on a phone; commands now wrap (`wrap-anywhere`) so the full text is always visible at any width.
 Owner refinement (2026-08-19): "最好把开头的 `$` 这个作为一个独立的头部，而不是 inline 到 command 里面。然后 command 的换行，不要 break-all，要基于空格去换行" — the `$` prompt is a separate shrink-0 primary-colored column; command text wraps at spaces (`wrap-break-word`).
+Original request (2026-08-19): "这个 COPY 和 COPIED 改成图标吧，这样会比较稳定" — fixed-size icon chips; state moves to the aria-label.
+Original request (2026-08-19): hero and hooks hero titles read uncomfortably — display headings move to `leading: 1.2`; home hero tracking relaxes to -0.02em and the SectionCard hero tone drops negative tracking, because tight leading and sans-style negative tracking collide on monospace ascenders/descenders.
+Original request (2026-08-19): "GitHub是一个外链，应该要加上↗。Theme 和 Language 这两个文字我建议也改成图标" — the GitHub nav link gains the external ↗ marker; theme/language switcher labels become SunMoon/Languages icons (textual names stay on the group aria-labels).
 -->
 
 ## User Input

--- a/packages/website/src/lib/components/home/hero-section.svelte
+++ b/packages/website/src/lib/components/home/hero-section.svelte
@@ -43,7 +43,7 @@ Original request (2026-08-19): "特别是在桌面模式下，首屏右侧有空
         {content.hero.eyebrow}
       </p>
       <h1
-        class="mt-4 text-[clamp(2.4rem,5vw,4.4rem)] leading-[0.99] font-bold tracking-[-0.035em] text-balance"
+        class="mt-4 text-[clamp(2.4rem,5vw,4.4rem)] leading-[1.2] font-bold tracking-[-0.02em] text-balance"
         use:reveal={{ delay: 60, rise: 14 }}
       >
         {content.hero.titleLead}<em class="text-primary not-italic">{content.hero.titleAccent}</em>

--- a/packages/website/src/lib/components/language-switcher.svelte
+++ b/packages/website/src/lib/components/language-switcher.svelte
@@ -3,10 +3,12 @@ Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 1. Render the EN/中文 locale toggle as localized anchor links.
 
 Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的，所以Theme 和 Language 这里的 toggle 要固定 border 的颜色为亮色。"
+Original request (2026-08-19): "Theme 和 Language 这两个文字我建议也改成图标" — a Languages icon replaces the visible label; the textual name stays on the group aria-label.
 -->
 <script lang="ts">
   import { getAlternateLocale, localizePath } from '$lib/i18n/languages'
   import type { WebsiteContent, WebsiteLanguage } from '$lib/i18n/schema'
+  import Languages from 'lucide-svelte/icons/languages'
 
   interface Props {
     content: WebsiteContent
@@ -19,7 +21,7 @@ Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的
 </script>
 
 <div class="flex items-center gap-2">
-  <span class="text-terminal-foreground/72 text-xs">{content.meta.languageLabel}</span>
+  <Languages class="text-terminal-foreground/72 h-3.5 w-3.5" aria-hidden="true" />
   <div
     class="border-terminal-foreground/30 bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
     role="group"

--- a/packages/website/src/lib/components/section-card.svelte
+++ b/packages/website/src/lib/components/section-card.svelte
@@ -25,7 +25,7 @@
 
   const titleClassName = $derived(
     tone === 'hero'
-      ? 'font-nav max-w-[24ch] text-balance text-[clamp(1.58rem,2.55vw,2.7rem)] tracking-tight leading-[0.96] sm:max-w-[22ch] lg:max-w-[24ch]'
+      ? 'font-nav max-w-[24ch] text-balance text-[clamp(1.58rem,2.55vw,2.7rem)] tracking-normal leading-[1.2] sm:max-w-[22ch] lg:max-w-[24ch]'
       : 'font-nav text-balance text-[1.05rem] tracking-tight leading-tight sm:text-[1.22rem]'
   )
 

--- a/packages/website/src/lib/components/site-header.svelte
+++ b/packages/website/src/lib/components/site-header.svelte
@@ -66,7 +66,7 @@
           rel="noreferrer"
           class="text-terminal-foreground/70 px-2.5 py-1 transition-colors hover:text-terminal-foreground"
         >
-          {content.nav.github}
+          {content.nav.github} ↗
         </a>
       </nav>
     </div>

--- a/packages/website/src/lib/components/theme-switcher.svelte
+++ b/packages/website/src/lib/components/theme-switcher.svelte
@@ -3,10 +3,12 @@ Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
 1. Render the light/dark/system theme toggle persisted through the shared website theme storage.
 
 Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的，所以Theme 和 Language 这里的 toggle 要固定 border 的颜色为亮色。"
+Original request (2026-08-19): "Theme 和 Language 这两个文字我建议也改成图标" — a SunMoon icon replaces the visible label; the textual name stays on the group aria-label.
 -->
 <script lang="ts">
   import { onMount } from 'svelte'
   import type { WebsiteContent } from '$lib/i18n/schema'
+  import SunMoon from 'lucide-svelte/icons/sun-moon'
   import {
     applyWebsiteTheme,
     getWebsiteStoredTheme,
@@ -36,7 +38,7 @@ Original request (2026-08-19): "因为顶部栏这里背景始终都是暗色的
 </script>
 
 <div class="flex items-center gap-2">
-  <span class="text-terminal-foreground/72 text-xs">{content.meta.themeLabel}</span>
+  <SunMoon class="text-terminal-foreground/72 h-3.5 w-3.5" aria-hidden="true" />
   <div
     class="border-terminal-foreground/30 bg-terminal-muted inline-flex w-fit max-w-full items-center self-start overflow-hidden border shadow-none"
     role="group"


### PR DESCRIPTION
## Summary

Two owner-reported readability/affordance fixes:

1. **Display typography** — the home hero H1 and the Hooks page hero title read uncomfortably at large sizes. Root cause was not only `leading` 0.96–0.99 (ascender/descender collision on JetBrains Mono / Share Tech Mono) but also sans-style negative tracking applied to monospace, which has its own side bearings. Both hero titles move to `line-height: 1.2`; home hero tracking relaxes from -0.035em to -0.02em and the SectionCard hero tone drops negative tracking entirely.
2. **Header affordances** — the GitHub nav link gains the external `↗` marker; the Theme/Language switcher text labels become lucide `SunMoon` / `Languages` icons (14px, matching the old text color), with the textual names preserved on the group `aria-label`s so accessibility is unchanged.

## Verification

- typecheck 0/0, tests 23/23, static build, root format/lint green.
- Real Chromium computed styles: hero H1 line-height is exactly 1.2× font-size with -0.02em tracking; hooks H1 1.2 with normal tracking; GitHub shows "GitHub ↗"; both switcher groups render icons with aria-labels intact. Screenshots 21–23 in `.agents/images/2026-08-19-website-live-walkthrough/`.