### PR TITLE
chore: ignore local walkthrough screenshot artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ codedb.snapshot
 GOAL.md
 .zcode/
 .vitest-attachments/
+.agents/images/
 
 # Atomic staging directory used by the watched Web-to-CLI asset sync.
 packages/cli/.web-sync-*/


### PR DESCRIPTION
Owner-directed direct-to-main commit, rerouted through PR because the remote branch-protection hook declines direct pushes. Adds `.agents/images/` (local walkthrough screenshot evidence directory) to `.gitignore`.