### PR TITLE
ci: skip windows gate for docs-only and website-only PRs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -152,7 +152,8 @@ jobs:
       - name: Skip for Windows-neutral scope
         if: ${{ needs.ci-scope.outputs.windows_required == 'false' }}
         shell: pwsh
-        run: Write-Output 'Skipping Windows Portability Gate: changed files have no Windows portability surface (docs-only or website-only).'
+        run: |
+          Write-Output 'Skipping Windows Portability Gate: docs-only or website-only PR has no Windows portability surface.'
 
       # GitHub runner TEMP is the 8.3 short form (RUNNER~1); where.exe, realpath, and libuv
       # fs-event reporting canonicalize to the long form, and mixing the two breaks path

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -51,6 +51,7 @@ jobs:
       run_web: ${{ steps.scope.outputs.run_web }}
       run_xterm: ${{ steps.scope.outputs.run_xterm }}
       browser_matrix: ${{ steps.scope.outputs.browser_matrix }}
+      windows_required: ${{ steps.scope.outputs.windows_required }}
     steps:
       - name: Checkout
         if: ${{ !startsWith(github.head_ref, 'chore/release/changeversion-') }}

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -140,12 +140,18 @@ jobs:
     name: Windows Portability Gate
     runs-on: windows-latest
     needs: [changeset-gate, ci-scope]
+    if: needs.ci-scope.outputs.windows_required != 'false'
     timeout-minutes: 45
     steps:
       - name: Skip for changeversion release PR
         if: ${{ startsWith(github.head_ref, 'chore/release/changeversion-') }}
         shell: pwsh
         run: Write-Output 'Skipping Windows Portability Gate for automated changeversion release PR.'
+
+      - name: Skip for Windows-neutral scope
+        if: ${{ needs.ci-scope.outputs.windows_required == 'false' }}
+        shell: pwsh
+        run: Write-Output 'Skipping Windows Portability Gate: changed files have no Windows portability surface (docs-only or website-only).'
 
       # GitHub runner TEMP is the 8.3 short form (RUNNER~1); where.exe, realpath, and libuv
       # fs-event reporting canonicalize to the long form, and mixing the two breaks path

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -36,6 +36,7 @@ if (process.env.GITHUB_OUTPUT) {
     `run_web=${scope.browser.runWeb}`,
     `run_xterm=${scope.browser.runXterm}`,
     `browser_matrix=${browserMatrixJson}`,
+    `windows_required=${scope.windowsRequired !== false}`,
   ]
   await import('node:fs').then(({ appendFileSync }) => {
     appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`)

--- a/scripts/lib/ci-scope.mjs
+++ b/scripts/lib/ci-scope.mjs
@@ -1,8 +1,10 @@
 /**
- * Orthogonal intents (created 2026-08-14 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-19 Asia/Shanghai):
  * 1. Hide Git subprocess console windows (`windowsHide`) for uniform hidden-console execution on Windows.
+ * 2. Compute `windowsRequired` so docs-only and website-only PRs skip the Windows Portability Gate.
  *
  * Original request (2026-08-14): "在Windows平台上，执行命令总是会弹出cmd窗口，这个可否统一隐藏，你先调查一下原因"
+ * Original request (2026-08-19): "门禁路径范围化（结构性减暴露）" — docs/website-only PRs burned 16-min Windows full suites.
  */
 import { execFileSync } from 'node:child_process'
 import { readdirSync, readFileSync } from 'node:fs'
@@ -33,6 +35,8 @@ const FULL_BROWSER_PATTERNS = [
   /^\.storybook\//,
 ]
 const SCRIPT_FAST_PATTERNS = [/^scripts\//, /^vitest\.root\.config\.ts$/]
+/** Private marketing site with no Windows portability surface. */
+const WINDOWS_NEUTRAL_PACKAGES = new Set(['@openspecui/website'])
 
 const IMPLICIT_PACKAGE_DEPENDENCIES = {
   '@openspecui/app': ['@openspecui/web'],
@@ -166,6 +170,7 @@ function buildFullScope({
       typecheckPackages,
     },
     reason,
+    windowsRequired: true,
   }
 }
 
@@ -312,6 +317,7 @@ export function computeCiScope({ changedFiles, rootDir, includeAllWhenUnknown = 
         typecheckPackages: [],
       },
       reason: 'Only docs/OpenSpec metadata changed; skip Fast Gate and Browser Gate execution.',
+      windowsRequired: false,
     }
   }
 
@@ -321,6 +327,11 @@ export function computeCiScope({ changedFiles, rootDir, includeAllWhenUnknown = 
   const testPackages = packages
     .filter((pkg) => affectedPackages.includes(pkg.name) && pkg.hasTestScript)
     .map((pkg) => pkg.name)
+
+  // Website-only changes have no Windows portability surface.
+  const windowsRequired = [...directPackageNames].some(
+    (name) => !WINDOWS_NEUTRAL_PACKAGES.has(name)
+  )
 
   return {
     affectedPackages,
@@ -339,6 +350,7 @@ export function computeCiScope({ changedFiles, rootDir, includeAllWhenUnknown = 
     },
     reason:
       'Route Fast Gate and Browser Gate from affected workspace packages and reverse dependencies.',
+    windowsRequired,
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a `windows_required` output to CI scope detection so docs-only and website-only PRs skip the Windows Portability Gate. The private `@openspecui/website` package (SvelteKit marketing site, Cloudflare Pages) is Windows-neutral.

**Effect**: website-only PRs go from a 16-min full Windows suite to zero. Docs-only was already skipped via `fast_mode=skip`. Any non-website package change still triggers the full Windows gate.