### PR TITLE
docs(spec): archive fix-windows-npm-cli-runner-shim

### DIFF
--- a/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/checkpoints.md
+++ b/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/checkpoints.md
@@ -1,0 +1,22 @@
+## 1. Research and Planning
+
+- [x] 1.1 Intake captured objectively (issue #258 + Owner request + community trace)
+- [x] 1.2 Research facts recorded (failure chain, cmd-shim formats, EINVAL probe, scripts mirror)
+- [x] 1.3 Plan reviewed and approved (Codex independent review 2026-08-28; both blockers folded in)
+
+## 2. Implementation
+
+- [x] 2.1 Implementation started from approved plan (red extraction test captured before the fix)
+- [x] 2.2 Progress synchronized with implementation artifact
+- [x] 2.3 Unexpected issues loop back to intake/research-plan (none triggered)
+
+## 3. PR and Release Gates
+
+- [x] 3.1 Changeset included for release-impacting package changes
+- [x] 3.2 CI-equivalent local checks passed (pre-existing exceptions proven on pristine main: macOS path-realpath env, board date-bomb — the latter fixed here)
+- [x] 3.3 PR checks passed (Fast / Windows Portability / Browser gates green; PR #259 merged)
+
+## 4. Merge Readiness
+
+- [x] 4.1 OpenSpec archive flow completed (this archive delivery)
+- [x] 4.2 PR merge approved (release: 9.0.3 on npm latest, remote tags, GitHub Release)

--- a/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/implementation.md
+++ b/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/implementation.md
@@ -1,0 +1,40 @@
+## Implementation State
+
+- [x] Core hardened shim extraction + validation (`packages/core/src/command-invocation.ts`)
+- [x] Core fallback runner pinning + `sniffGlobalCli` probe rewrite (`packages/core/src/config.ts`)
+- [x] Server install spec pinning (`packages/server/src/router.ts`)
+- [x] Web install display/label honesty (`packages/web/src/lib/use-cli-runner.tsx`, `packages/web/src/routes/settings.tsx`)
+- [x] Scripts mirror fix (`scripts/lib/package-manager-shim.mjs`)
+- [x] Tests: cross-platform red-then-green extraction/containment, fallback specs, sniff outcomes, Windows-gated modern fixtures (Core + scripts)
+
+Red evidence (captured before the fix): the 10 new cross-platform Core tests failed at the
+extraction boundary, and the legacy-only regex was directly shown to match the legacy shim
+source (1 match) while matching the modern cmd-shim final call (0 matches). Mutation-resistance:
+disabling only the containment rejection fails exactly the escape and symlink tests.
+
+## Decisions Taken
+
+- Entry containment root = the real shim directory, plus its real parent only when the shim
+  directory is named `.bin`; this covers the npm global-prefix layout and the local
+  `node_modules/.bin` layout exactly, and was tightened from the initially planned unconditional
+  parent after the symlink fixture proved a bare parent root over-admits.
+- The extraction regex accepts both `%~dp0<rel>` (legacy cmd-shim) and `%dp0%\<rel>` (cmd-shim
+  v4+); token validation additionally rejects NUL, drive letters, UNC prefixes, and unexpanded
+  `%` references before any filesystem call, and backslashes normalize to `/` so containment
+  stays host-testable.
+- Fallback and install specs derive from `OPENSPEC_CLI_TARGET_SERIES` (no literal `1.9` outside
+  `openspec-compat.ts`); server/web import the browser-safe subpath because the Core barrel
+  does not re-export the constant.
+- `sniffGlobalCli` keeps its public result contract; only the local probe transport changed
+  (`runBufferedCommand`), and PATH-resolution failures ("Unable to resolve ... from PATH.")
+  classify as not-found like ENOENT.
+- Settings update-target label uses `classifyOpenSpecCliVersion(latestVersion).supported` to
+  decide between the literal latest version and the `1.9.x` series label.
+
+## Divergence Notes
+
+- None. Both Codex blockers (hardened validation, scripts mirror) are folded into the plan above before implementation.
+
+## Loopback Triggers
+
+- If Windows CI reveals a standard shim layout outside the two containment roots, loop back to research-plan with the fixture evidence instead of widening containment ad hoc.

--- a/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/intake.md
+++ b/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/intake.md
@@ -1,0 +1,28 @@
+## User Input
+
+- Original request (2026-08-28, GitHub issue #258): "I tried to install OpenSpecUI and then run it from the root project folder... I'm getting the 'No available OpenSpec CLI runner.' error." Environment: Windows 11 24H2, Node 24.14.0, npm 11.9.0, OpenSpecUI 9.0.2, OpenSpec 1.9.0 (in range).
+- Original request (2026-08-28, Owner to ZCode): "看一下github上的issues 258，你先分析一下，如果确定问题，然后和codex复核一下。确定方案了就开始写测试复现并修复。"
+- Community root-cause trace (2026-08-27, e-martin): a correctly installed in-range global CLI is refused because the npm `.cmd` shim is rejected as opaque; Settings reports "Global CLI not found" while `openspec --version` works from PATH; the npx fallback resolves `@latest` (1.11.0) which the v9 gate blocks.
+
+## Objective Scope
+
+1. `packages/core/src/command-invocation.ts`: resolve standard npm `cmd-shim` v4+ Windows shims (modern `SET dp0=%~dp0` + `"%dp0%\...\bin\*.js"` final-call shape) onto `node.exe + JavaScript entry`, in addition to the legacy `%~dp0<path>.js` shape, with hardened entry validation (reject drive-letter/UNC/NUL/unexpanded-`%` tokens; entry must be an existing real file within the shim directory or its parent directory, which covers both the global-prefix layout and the local `node_modules/.bin/..` layout).
+2. Mirror the same hardened extraction in `scripts/lib/package-manager-shim.mjs` (used by the Windows installed-CLI smoke and the zero-dependency runner diagnostic) so repository release owners keep parity with Core.
+3. `packages/core/src/config.ts`: pin the five auto-fallback package-manager runner specs to `@${OPENSPEC_CLI_TARGET_SERIES}` (fail closed against out-of-range `@latest`), and route the `sniffGlobalCli` local probe through `runBufferedCommand` so a resolved `.cmd` shim executes instead of failing EINVAL on modern Node.
+4. `packages/server/src/router.ts` `installGlobalCliStream` and the matching `packages/web` install display/labels: install the target series instead of an unversioned spec, and never present an out-of-range registry `latestVersion` as the update target.
+
+## Non-Goals
+
+- Surfacing runner-resolution failure directly on the Dashboard (community suggestion 3; separate Web UX change).
+- Executing or reinterpreting any non-standard (opaque) `.cmd` shim through `cmd.exe`; the existing explicit rejection stays.
+- Changing the CLI compatibility gate or accepted range (`>=1.8.0 <1.10.0`).
+- Changing `fetchLatestVersion` (it reports the registry fact "newest on npm").
+
+## Acceptance Boundary
+
+- A cross-platform (macOS-runnable) red-then-green test extracts the JS entry from a byte-accurate modern `cmd-shim` fixture and proves today's parser misses it.
+- Hardening tests reject drive-letter, UNC, NUL, unexpanded-`%` tokens and entries escaping the shim directory/parent root, while a legitimate `node_modules/.bin/..`-style entry still resolves.
+- `buildCliRunnerCandidates` fallback specs assert `@1.9` (derived from `OPENSPEC_CLI_TARGET_SERIES`, not hardcoded).
+- `sniffGlobalCli` fixture test covers spawn-error, non-zero-exit, and success-version outcomes.
+- Windows-gated integration tests extend with a modern-shim fixture (runs in the Windows CI gate).
+- Local CI-relevant checks pass; the final browser walkthrough boundary remains Owner-owned.

--- a/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/research-plan.md
+++ b/openspec/changes/archive/2026-08-28-fix-windows-npm-cli-runner-shim/loop/research-plan.md
@@ -1,0 +1,45 @@
+## Research Findings
+
+1. Failure chain (issue #258, Windows 11 + global npm CLI 1.9.0):
+   `ConfigManager.resolveCliRunner` → `expandCliRunnerCandidates` (`config.ts:341`, `resolveShellExecutablePath` uses `where.exe` + PATHEXT preference from the issue #209 hotfix, so the candidate becomes `...\npm\openspec.cmd`) → `probeCliRunner` (`config.ts:418`) → `runBufferedCommand` → `spawnSafe` (`spawn-safe.ts:118`) → `resolveWindowsCommandInvocation` (`command-invocation.ts:160`).
+2. `resolveNodeCommandShim` (`command-invocation.ts:106-127`) extracts the JS entry only via `/%~dp0([^"\r\n]*?\.(?:c|m)?js)/gi`. That matches only the legacy npm shim shape. npm ≥7 (cmd-shim v4+; the local npm 11 bundle was read directly) emits `SET dp0=%~dp0` and a final call line referencing `"%dp0%\node_modules\<pkg>\bin\entry.js"`; the `%~dp0` literal never precedes the entry path, so extraction returns null and the resolver throws the "opaque Windows command shim" error. The same shape hits `npx.cmd`/`pnpm.cmd`/`yarn.cmd`, so every fallback candidate also fails, producing "No available OpenSpec CLI runner."
+3. `sniffGlobalCli` (`config.ts:558-595`) probes the resolved `.cmd` with `execFileAsync` (`shell` unset). Modern Node refuses to spawn `.bat`/`.cmd` without a shell (EINVAL), so the probe degrades to `hasGlobal:false` — Settings shows "Global CLI not found" while the CLI runs fine from a terminal.
+4. `BASE_PACKAGE_MANAGER_RUNNERS` (`config.ts:106-112`) uses unversioned specs. `@latest` is currently 1.11.0, outside the v9 accepted range (`openspec-compat.ts`: `OPENSPEC_CLI_TARGET_SERIES='1.9'`, `OPENSPEC_CLI_ACCEPTED_RANGE='>=1.8.0 <1.10.0'`). With shims fixed, a shim-less machine would resolve a runner the version gate then blocks.
+5. `installGlobalCliStream` (`server/src/router.ts:2196`) and the Web display (`web/src/lib/use-cli-runner.tsx:171`, `web/src/routes/settings.tsx` labels) install/present the unversioned spec, so the Settings action itself installs a version the gate rejects.
+6. A parallel implementation exists in `scripts/lib/package-manager-shim.mjs:23-35` (same legacy-only regex); it backs `scripts/lib/command-invocation.mjs`, `scripts/windows-installed-cli-smoke.sh.ts`, and `scripts/diagnose-cli-runner.mjs`. Fixing only Core would leave the Windows distribution-gate smoke and the diagnostic unable to parse modern shims.
+7. Independent review (Codex, gpt-5.6-terra xhigh, 2026-08-28): root cause 9/10 confirmed (A/B/C all verified against the workspace); plan initially 6/10 with two blockers — (a) the pre-existing extractor already permits `%~dp0..\evil.js` escapes, drive-letter absolute paths, and follows symlinks without containment, so the widened parser must add a validation layer rather than just a broader regex; legitimate `node_modules/.bin/..\..` entries must keep resolving; (b) the `scripts/` mirror must be fixed in the same delivery.
+
+## Decision & Plan (For Approval)
+
+1. `command-invocation.ts`: export a pure `extractNodeCommandShimEntryTokens(source)` that matches both `%~dp0<rel>` and `%dp0%\<rel>` entry references, plus an fs-backed `resolveNodeCommandShimEntry(commandShim, source)` that validates each token (non-empty; no NUL, drive-letter, UNC, or unexpanded `%`), resolves it against the shim directory, requires `realpathSync.native` + `statSync().isFile()`, and contains the real entry within the real shim directory or its parent directory (global-prefix and `.bin/..` layouts respectively). `resolveNodeCommandShim` consumes these; opaque non-shape shims are still rejected.
+2. `config.ts`: pin the five fallback runner specs to `@${OPENSPEC_CLI_TARGET_SERIES}` imported from `./openspec-compat.js` (no cycle: that module imports only zod); rewrite the `sniffGlobalCli` local probe on `runBufferedCommand` while keeping its result contract (`hasGlobal`/`version`/`latestVersion`/`hasUpdate`/`error`) unchanged.
+3. `server/src/router.ts` `installGlobalCliStream` + `web` display/labels: install and present `@${OPENSPEC_CLI_TARGET_SERIES}`; when the registry `latestVersion` is outside the accepted range (via `classifyOpenSpecCliVersion(...).supported`), Settings presents the target series instead of the out-of-range version as the update target.
+4. `scripts/lib/package-manager-shim.mjs`: mirror the hardened extraction (same tokens + same validation semantics).
+5. Tests: cross-platform pure-extraction and fs-containment tests (macOS-runnable red first), fallback-spec assertions, `sniffGlobalCli` outcome tests, and Windows-gated integration fixtures for the modern shim in both Core and scripts.
+
+## Capability Impact
+
+### New or Expanded Behavior
+
+- Standard modern npm Windows shims (global prefix and `node_modules/.bin`) now resolve to `node.exe + entry.js` and execute without `cmd.exe`.
+- Hardened entry validation closes the pre-existing escape/absolute-path/symlink weaknesses for both shim generations.
+
+### Modified Behavior
+
+- Auto-fallback runners and the Settings global install action now target the supported CLI series instead of `@latest`.
+- The Settings update label never names an out-of-range version as the update target.
+- `sniffGlobalCli` executes the resolved runner through the same spawn-safe boundary as production CLI execution.
+
+## Risks and Mitigations
+
+- Over-strict containment could reject exotic but legitimate installs: containment allows the shim directory and its parent (both standard layouts); anything else fails closed to the existing explicit opaque rejection, which is diagnosable via the runner diagnostic.
+- Pinning fallbacks goes stale when the release line moves: the spec derives from `OPENSPEC_CLI_TARGET_SERIES`, the same constant that drives the compatibility gate, so lines move together.
+- Mirrored logic in `scripts/` can drift: both sides gain byte-equivalent fixtures; drift risk is accepted because scripts must stay zero-dependency (documented residual).
+
+## Verification Strategy
+
+- Red evidence: new macOS-runnable extraction test fails against the current parser at the named fixed point (modern-shim fixture → no entry).
+- Focused lanes: `pnpm --filter @openspecui/core test -- src/command-invocation.test.ts src/config.test.ts`, `node scripts/...` script tests via `pnpm test:root`, server/web focused tests for the touched files.
+- Full local gates before PR: `pnpm format:check`, `pnpm lint:ci`, `pnpm typecheck`, `pnpm test:ci`, `pnpm test:browser:ci` (or the documented scoped subset with justification).
+- Windows CI gate covers the win32-gated integration fixtures and the real installed-CLI smoke.
+- Codex review of the final diff before merge; Owner browser walkthrough remains the acceptance boundary.


### PR DESCRIPTION
Archives the OpenSpec change delivered by #259 and released as 9.0.3. All checkpoints complete: CI gates green, PR merged, release verified (npm latest 9.0.3, remote tags, GitHub Release). Docs-only.