### PR TITLE
feat(web): Change Evidence list-detail workspace

### DIFF
--- a/.changeset/change-evidence-list-detail.md
+++ b/.changeset/change-evidence-list-detail.md
@@ -1,0 +1,21 @@
+---
+'@openspecui/app': minor
+'@openspecui/browser-translator': minor
+'@openspecui/core': minor
+'@openspecui/local-ct2-translator': minor
+'@openspecui/local-llama-translator': minor
+'@openspecui/local-translator': minor
+'@openspecui/openai-completion-translator': minor
+'@openspecui/search': minor
+'@openspecui/server': minor
+'@openspecui/web': minor
+'@openspecui/website': minor
+'openspecui': minor
+---
+
+
+Present the Change Detail Evidence tab as a container-responsive list-detail workspace:
+evidence rows in the decision-plane layer order with fact-derived status chips, a detail
+pane that owns the tab's reading surface, and a crowded drill with a back affordance that
+keeps settled evidence mounted — replacing the stacked full-width accordions. Evidence
+semantics, CLI provenance, and typed degradation are unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ openspec/.openspecui.json
 .wrangler/
 
 *HANDOFF.md
+
+# vitest browser-mode snapshot artifacts
+__screenshots__/

--- a/openspec/changes/redesign-change-evidence-list-detail/.openspec.yaml
+++ b/openspec/changes/redesign-change-evidence-list-detail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: opsx-collab-pr-loop
+created: 2026-08-28

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
@@ -10,11 +10,26 @@ Original request (2026-08-28): "这种结构替代手风琴会更好"
 
 ```text
 R0 change authored              DONE   intake / research-plan / opsx-ui-views delta
-R1 implementation               PENDING  single web slice (see research-plan slice table)
-R2 Codex review                 PENDING
+R1 implementation               DONE   integrator-verified: change-view/diff/archived-validation/panel
+                                       tests 42/42 (+2 added round-2), web unit full 1181/1181, Chromium
+                                       browser 5/5, typecheck + lint + format green. Slice owner: one
+                                       implementation subagent; integrator re-ran focused suites.
+R2 Codex review                 ROUND1 DONE (6.5/10) -> fixes applied; ROUND2 PENDING
 R3 rebuild walkthrough assets   PENDING  rebuild web bundle + copy-web + restart 3100/3101
 R4 Owner re-walkthrough        PENDING  acceptance boundary
 ```
+
+## Round-1 review disposition (herdr `evidence-reviewer`, 2026-08-28, 6.5/10)
+
+- Major 1 fixed: crowded drill now hands focus to the back affordance and returns it to the
+  originating row; keyboard test asserts `document.activeElement` both ways.
+- Major 2 fixed: this file now records the real gate evidence (was left PENDING during review).
+- Minor: no-refetch assertion added (drill + back + re-enter leaves the settled diff fetch count
+  unchanged); ResizeObserver-absent fallback documented as an invariant (no-RO engines also lack
+  @container, so the crowded base matches the rendered single column).
+- Minor (accepted, no change): chip fact-type duplication across sections is cosmetic; the
+  .gitignore `__screenshots__/` entry covers this change's browser-test artifacts (justified in
+  the PR body).
 
 ## Evidence recording rule
 

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
@@ -1,0 +1,22 @@
+<!--
+Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+1. Track the single implementation slice and its evidence.
+2. Keep the walkthrough re-verification handoff explicit.
+
+Original request (2026-08-28): "这种结构替代手风琴会更好"
+-->
+
+# Implementation state
+
+```text
+R0 change authored              DONE   intake / research-plan / opsx-ui-views delta
+R1 implementation               PENDING  single web slice (see research-plan slice table)
+R2 Codex review                 PENDING
+R3 rebuild walkthrough assets   PENDING  rebuild web bundle + copy-web + restart 3100/3101
+R4 Owner re-walkthrough        PENDING  acceptance boundary
+```
+
+## Evidence recording rule
+
+Gate turns DONE only with the touched files, the focused test commands actually run, and any
+deviation. The integrator re-runs focused tests locally before recording.

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
@@ -26,8 +26,11 @@ R1 implementation               DONE   touched files: web/components/evidence-wo
                                        `npx tsc --noEmit` plus the four check lanes through
                                        `pnpm --filter @openspecui/web typecheck`, `pnpm lint:ci`,
                                        `pnpm format:check`,
-                                       `npx vitest run` (web full unit, 1181/1181).
-                                       Deviation: none. Slice owner: one implementation subagent;
+                                       `npx vitest run --project unit` (web full unit, 189 files /
+                                       1178 tests). Deviation: the first full-unit run in the
+                                       isolated verification worktree flaked on two untouched files
+                                       under machine load; both passed in isolation and the rerun was
+                                       fully green. Slice owner: one implementation subagent;
                                        integrator re-ran every focused suite.
 R2 Codex review                 ROUND1 6.5/10 -> fixes; ROUND2 7.0/10 -> fixes; ROUND3 7.5/10 ->
                                        fixes (spacious focus capture via focus events, live no-refetch

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
@@ -10,14 +10,38 @@ Original request (2026-08-28): "这种结构替代手风琴会更好"
 
 ```text
 R0 change authored              DONE   intake / research-plan / opsx-ui-views delta
-R1 implementation               DONE   integrator-verified: change-view/diff/archived-validation/panel
-                                       tests 42/42 (+2 added round-2), web unit full 1181/1181, Chromium
-                                       browser 5/5, typecheck + lint + format green. Slice owner: one
-                                       implementation subagent; integrator re-ran focused suites.
-R2 Codex review                 ROUND1 DONE (6.5/10) -> fixes applied; ROUND2 PENDING
+R1 implementation               DONE   touched files: web/components/evidence-workspace.tsx (new),
+                                       web/components/change-diff-evidence.{tsx,test.tsx},
+                                       web/components/archived-validation-evidence.{tsx,test.tsx},
+                                       web/components/change-evidence-panel.{tsx,test.tsx},
+                                       web/components/change-evidence-surface.browser.test.tsx,
+                                       web/routes/change-view.{tsx,test.tsx}, .gitignore.
+                                       Focused commands (run in this branch):
+                                       `cd packages/web && npx vitest run src/routes/change-view.test.tsx`
+                                       (20/20), the three component suites (24/24),
+                                       `npx vitest run --config vitest.browser.config.ts
+                                       src/components/change-evidence-surface.browser.test.tsx` (5/5),
+                                       `pnpm --filter @openspecui/web typecheck`, `pnpm lint:ci`,
+                                       `pnpm format:check`, plus web full unit (1181/1181).
+                                       Deviation: none. Slice owner: one implementation subagent;
+                                       integrator re-ran every focused suite.
+R2 Codex review                 ROUND1 DONE (6.5/10) -> fixes; ROUND2 DONE (7.0/10) -> fixes; ROUND3
+                                       PENDING
 R3 rebuild walkthrough assets   PENDING  rebuild web bundle + copy-web + restart 3100/3101
 R4 Owner re-walkthrough        PENDING  acceptance boundary
 ```
+
+## Round-2 review disposition (herdr `evidence-reviewer`, 2026-08-28, 7.0/10)
+
+- No-refetch test rewritten as a live 1.11 session (ready Root Context with cli 1.11.0 and a
+  resolving diff fetch): waits for exactly one settled call before drilling, then asserts the
+  count stays one across back and re-entry — no longer a vacuous 0==0.
+- Spacious-transition focus: growing from crowded while drilled unmounts the back affordance;
+  focus now migrates to the selected row when it was on the back button.
+- implementation.md now carries the full touched-file list and the exact focused commands.
+- Rejected with reason: synthesizing Enter/Space activation would require user-event solely to
+  reproduce a native `<button type="button">` platform guarantee jsdom does not implement; the
+  rows are native controls and the keyboard path is covered by focus/tab tests.
 
 ## Round-1 review disposition (herdr `evidence-reviewer`, 2026-08-28, 6.5/10)
 

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/implementation.md
@@ -16,20 +16,36 @@ R1 implementation               DONE   touched files: web/components/evidence-wo
                                        web/components/change-evidence-panel.{tsx,test.tsx},
                                        web/components/change-evidence-surface.browser.test.tsx,
                                        web/routes/change-view.{tsx,test.tsx}, .gitignore.
-                                       Focused commands (run in this branch):
+                                       Focused commands (run in this branch, updated through round 3):
                                        `cd packages/web && npx vitest run src/routes/change-view.test.tsx`
-                                       (20/20), the three component suites (24/24),
+                                       (21/21), `npx vitest run src/components/change-diff-evidence.test.tsx
+                                       src/components/archived-validation-evidence.test.tsx
+                                       src/components/change-evidence-panel.test.tsx` (24/24),
                                        `npx vitest run --config vitest.browser.config.ts
                                        src/components/change-evidence-surface.browser.test.tsx` (5/5),
+                                       `npx tsc --noEmit` plus the four check lanes through
                                        `pnpm --filter @openspecui/web typecheck`, `pnpm lint:ci`,
-                                       `pnpm format:check`, plus web full unit (1181/1181).
+                                       `pnpm format:check`,
+                                       `npx vitest run` (web full unit, 1181/1181).
                                        Deviation: none. Slice owner: one implementation subagent;
                                        integrator re-ran every focused suite.
-R2 Codex review                 ROUND1 DONE (6.5/10) -> fixes; ROUND2 DONE (7.0/10) -> fixes; ROUND3
-                                       PENDING
+R2 Codex review                 ROUND1 6.5/10 -> fixes; ROUND2 7.0/10 -> fixes; ROUND3 7.5/10 ->
+                                       fixes (spacious focus capture via focus events, live no-refetch
+                                       test, full command evidence; Enter/Space rejection accepted);
+                                       ROUND4 PENDING
 R3 rebuild walkthrough assets   PENDING  rebuild web bundle + copy-web + restart 3100/3101
 R4 Owner re-walkthrough        PENDING  acceptance boundary
 ```
+
+## Round-3 review disposition (herdr `evidence-reviewer`, 2026-08-28, 7.5/10)
+
+- Spacious focus migration fixed for real: the round-2 check inspected `document.activeElement`
+  after the back affordance had already unmounted (ref null, focus on body), so it never fired;
+  focus ownership is now captured by focus events on the back button and the migration targets
+  the selected row when the topology grows while drilled. Locked by a resize-transition test
+  (stubbed ResizeObserver, 320 -> 1200, asserting the selected row receives focus).
+- Command-level evidence in this file now lists every focused command verbatim.
+- Enter/Space synthesis rejection accepted by the reviewer (native button platform semantics).
 
 ## Round-2 review disposition (herdr `evidence-reviewer`, 2026-08-28, 7.0/10)
 

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/intake.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/intake.md
@@ -1,0 +1,44 @@
+<!--
+Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+1. Preserve the Owner walkthrough feedback and the list-detail redesign direction.
+2. State the delivery boundary: Change Detail Evidence tab only.
+
+Original request (2026-08-28, walkthrough feedback): "就是界面需要打磨一下，比如 requirement diff 和 archived validation，这两个手风琴，在 Evidence 页面是 full-w。其实整个 Evidence 页面的结构就应该重新设计一下，使用移动端的 list-detail 思维来设计这个页面会更好一些：分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
+-->
+
+# Change Evidence list-detail redesign intake
+
+## User Input
+
+> 走查基本没问题。界面打磨：requirement diff 和 archived validation 两个手风琴在 Evidence 页面是 full-width。
+> 整个 Evidence 页面的结构应该重新设计：使用移动端的 list-detail 思维——分成两栏，左侧 list，右侧详情，替代手风琴。
+
+## Objective Scope
+
+Replace the stacked full-width accordion composition of the Change Detail Evidence tab with a
+container-responsive list-detail workspace:
+
+```text
+wide container                    crowded container (mobile-first base)
++----------+------------------+   +------------------------+
+| evidence | selected detail  |   | evidence list          |
+| list     | (scroll owner)   |   | tap item ->            |
+| (order = decision-plane law)|   |   detail + back        |
++----------+------------------+   +------------------------+
+```
+
+List order preserves the established evidence layering (summary/paths -> requirement diffs ->
+archived validation -> CLI/raw payload). No evidence semantics, fetching, or authority change —
+this is a presentation-structure change only.
+
+## Non-Goals
+
+- Do not change what evidence exists, how it is fetched, or its CLI-owned provenance.
+- Do not touch the Detail Header, Folder/Content tabs, or the decision plane.
+- Do not introduce viewport breakpoints (container queries own the topology).
+- Do not persist sub-selection in routes or browser storage.
+
+## Acceptance Boundary
+
+- Owner re-walkthrough on the rebuilt walkthrough servers (3100/3101) accepts the new structure;
+  automated component tests are preparation evidence only.

--- a/openspec/changes/redesign-change-evidence-list-detail/loop/research-plan.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/loop/research-plan.md
@@ -1,0 +1,62 @@
+<!--
+Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+1. Record the current Evidence composition and the constraints that carry over.
+2. Define the list-detail topology and its container-responsive behavior.
+3. Assign one production owner and red/green evidence to the single implementation slice.
+
+Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
+-->
+
+# Change Evidence list-detail redesign plan
+
+## Current state (verified)
+
+```text
+packages/web/src/routes/change-view.tsx:115-122
+  Evidence tab = stacked panels:
+    <ChangeEvidencePanel/>      summary, paths, artifacts, references (full-w sections)
+    <ChangeDiffEvidence/>       requirement diffs (own Accordion, full-w)
+    <ArchivedValidationEvidence/> archived validation (own Accordion, full-w)
+```
+
+Constraints that carry over unchanged (AGENTS.md laws):
+
+- Evidence layering order: readable paths/facts -> artifact outputs/references -> requirement
+  diffs -> archived validation -> CLI result -> raw payload.
+- The tab owns primary vertical scrolling; no page-level horizontal overflow; paths wrap.
+- Container queries, never viewport breakpoints, choose the project-surface topology.
+- Failures stay on the direct plane; unavailable evidence is typed-unavailable, never fabricated.
+- Keyboard reachability for every list item; no hover-only information.
+
+## Design
+
+1. New `EvidenceWorkspace` owner inside the Evidence tab:
+   - evidence item list: one row per evidence section, in the law's layer order, each with a
+     compact status chip derived only from already-available facts (e.g., MODIFIED delta count
+     for diffs; pass/fail/unavailable for archived validation); no fabricated counts.
+   - detail pane: renders the selected section's existing content components.
+2. Container-responsive topology via `@container` on the workspace:
+   - spacious: two columns `auto 1fr` (list ~clamp 220-260px; detail takes the rest); both panes
+     scroll independently, detail remains the tab's primary reading surface.
+   - crowded: single column; the list is the entry surface; selecting an item reveals the detail
+     with a back affordance; returning restores the list without refetch.
+3. Sub-selection is presentational local state (default: first item); the routed unit remains the
+   Evidence tab. No route/storage persistence.
+4. Existing content components become structure-agnostic: `ChangeDiffEvidence` and
+   `ArchivedValidationEvidence` drop their own Accordion wrappers and expose content sections the
+   workspace mounts; their fetching/provenance/degradation logic is untouched.
+5. `ChangeEvidencePanel` splits presentation-wise into list-addressable sections (summary/paths
+   first, CLI/raw payload last) without changing its data contract.
+
+## Slice
+
+| Owner                                                                                                                                                                                                 | Red case                                                                                                                                                                      | Green case and focused gate                                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/web/src/components/evidence-workspace.tsx` (new) + `change-view.tsx` Evidence composition + de-accordioned `change-diff-evidence.tsx` / `archived-validation-evidence.tsx` + affected tests | Evidence still renders stacked full-width accordions; list rows are not keyboard reachable; crowded container shows two cramped columns; a11y tree loses the section headings | Wide container: list + detail, detail scrolls independently; crowded container: list -> detail -> back; layer order preserved; de-accordioned sections keep provenance and typed-unavailable behavior. Run `change-view.test.tsx`, `change-diff-evidence.test.tsx`, `archived-validation-evidence.test.tsx` (rewritten to the new structure). |
+
+## Risks
+
+- Existing tests drive Accordion triggers; they must be rewritten against the workspace
+  (structure-only assertions; keep provenance assertions intact).
+- The mobile back-navigation must not unmount fetching state (keep components mounted or accept
+  refetch; prefer keep-mounted with hidden pane).

--- a/openspec/changes/redesign-change-evidence-list-detail/specs/opsx-ui-views/spec.md
+++ b/openspec/changes/redesign-change-evidence-list-detail/specs/opsx-ui-views/spec.md
@@ -1,0 +1,41 @@
+<!--
+Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+1. Define the Change Detail Evidence list-detail workspace topology.
+
+Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
+-->
+
+## ADDED Requirements
+
+### Requirement: Change Evidence List-Detail Workspace
+
+The Change Detail Evidence tab SHALL present its evidence sections through a
+container-responsive list-detail workspace instead of stacked full-width accordions. The evidence
+list SHALL preserve the established layering order (summary/paths, requirement diffs, archived
+validation, CLI/raw payload), every list row SHALL be keyboard reachable, and row status chips
+SHALL derive only from available evidence facts. The detail pane SHALL render the selected
+section's content and remain the tab's primary reading surface. Sub-selection SHALL be
+presentational runtime state of the Evidence tab and SHALL NOT persist in routes or browser
+storage.
+
+#### Scenario: Spacious container shows list and detail together
+
+- **GIVEN** the Evidence tab renders in a container wide enough for two panes
+- **WHEN** an evidence row is selected
+- **THEN** the list and the selected section's detail SHALL be visible side by side
+- **AND** each pane SHALL scroll independently without page-level horizontal overflow
+
+#### Scenario: Crowded container drills from list to detail
+
+- **GIVEN** the Evidence tab renders in a crowded container
+- **WHEN** an evidence row is activated
+- **THEN** the detail SHALL replace the list as the visible surface with a back affordance
+- **AND** returning to the list SHALL NOT lose already-settled evidence state
+
+#### Scenario: Evidence semantics are unchanged by the structure
+
+- **GIVEN** any admitted session and any evidence section
+- **WHEN** the workspace renders that section
+- **THEN** its content, CLI-owned provenance, failure presentation, and typed-unavailable
+  degradation SHALL match the pre-workspace behavior
+- **AND** no evidence count or status SHALL be fabricated for list chips

--- a/packages/web/src/components/archived-validation-evidence.test.tsx
+++ b/packages/web/src/components/archived-validation-evidence.test.tsx
@@ -5,9 +5,12 @@
  * 3. Identify the evidence as unavailable in static snapshots instead of fabricating it.
  * 4. Lock the OpenSpec 1.11 Purpose-placeholder WARNING rendering: the exact upstream message
  *    stays visible on the `overview` path without truncation or rewriting.
+ * 5. Lock the workspace row-chip facts: pass/fail derive only from the typed report, degradation
+ *    reports `unavailable`, and an unexecuted session reports no chip.
  *
  * Original request (2026-08-15): "v9的适配需要同时适配 1.8和1.9。"
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import { isStaticMode } from '@/lib/static-mode'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -112,7 +115,7 @@ describe('ArchivedValidationEvidence', () => {
     validateMock.mockResolvedValue(archivedReport())
     render(<ArchivedValidationEvidence />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
+    // The de-accordioned section presents its content directly in the detail pane.
     expect(screen.getByText(/never repairs or archives/)).toBeVisible()
     expect(screen.queryByRole('button', { name: /repair/i })).not.toBeInTheDocument()
 
@@ -139,7 +142,6 @@ describe('ArchivedValidationEvidence', () => {
     )
     render(<ArchivedValidationEvidence />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     expect(await screen.findByText('CLI failure evidence')).toBeVisible()
@@ -152,7 +154,6 @@ describe('ArchivedValidationEvidence', () => {
     render(<ArchivedValidationEvidence />)
 
     expect(screen.getByText('Unavailable in static snapshot')).toBeVisible()
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     expect(screen.getByText(/not captured in this static snapshot/)).toBeVisible()
     expect(validateMock).not.toHaveBeenCalled()
   })
@@ -172,7 +173,6 @@ describe('ArchivedValidationEvidence', () => {
     )
 
     render(<ArchivedValidationEvidence />)
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     await waitFor(() => expect(validateMock).toHaveBeenCalled())
@@ -193,7 +193,6 @@ describe('ArchivedValidationEvidence', () => {
     )
 
     render(<ArchivedValidationEvidence />)
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     await waitFor(() => expect(screen.getByText('CLI failure evidence')).toBeVisible())
@@ -206,7 +205,6 @@ describe('ArchivedValidationEvidence', () => {
     validateMock.mockResolvedValue(archivedReport({ payload, exitCode: 1 }))
 
     render(<ArchivedValidationEvidence />)
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     await waitFor(() => expect(document.body.textContent).toContain('1 passed · 1 failed'))
@@ -222,7 +220,6 @@ describe('ArchivedValidationEvidence', () => {
     render(<ArchivedValidationEvidence />)
 
     expect(screen.getByText('Unavailable on this CLI line')).toBeVisible()
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     expect(screen.getByText(/requires an admitted OpenSpec CLI line/)).toBeVisible()
     expect(screen.getByText(/detected 1\.9\.0/)).toBeVisible()
     expect(
@@ -235,7 +232,6 @@ describe('ArchivedValidationEvidence', () => {
     validateMock.mockRejectedValue(new Error('planning root unresolved'))
     render(<ArchivedValidationEvidence />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     expect(await screen.findByText(/planning root unresolved/)).toBeVisible()
@@ -279,7 +275,6 @@ describe('ArchivedValidationEvidence', () => {
     )
 
     render(<ArchivedValidationEvidence />)
-    fireEvent.click(screen.getByRole('button', { name: /Archived validation/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
 
     // The complete upstream message renders as one untruncated, unrewritten evidence line.
@@ -291,5 +286,54 @@ describe('ArchivedValidationEvidence', () => {
     )
     expect(line).toBeVisible()
     expect(document.body.textContent).toContain(purposePlaceholderWarning)
+  })
+
+  it('reports pass/fail row chips only from the typed report and none before a run', async () => {
+    const onChip = vi.fn()
+    validateMock.mockResolvedValue(archivedReport())
+    render(<ArchivedValidationEvidence onChip={onChip} />)
+
+    // Before any run there is no fact to project — no fabricated chip.
+    expect(onChip).toHaveBeenLastCalledWith(null)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
+    await waitFor(() =>
+      expect(onChip).toHaveBeenLastCalledWith({ label: 'fail', tone: 'negative' })
+    )
+
+    // An all-pass report projects `pass`.
+    const passingChip = vi.fn()
+    validateMock.mockResolvedValueOnce(
+      archivedReport({
+        data: {
+          items: [],
+          summary: { totals: { items: 0, passed: 0, failed: 0 }, byType: {} },
+          version: '1.0',
+          root: { path: '/repo', source: 'nearest' },
+        },
+      })
+    )
+    cleanup()
+    render(<ArchivedValidationEvidence onChip={passingChip} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Validate archived tasks' }))
+    await waitFor(() =>
+      expect(passingChip).toHaveBeenLastCalledWith({ label: 'pass', tone: 'positive' })
+    )
+  })
+
+  it('reports an unavailable row chip on static and retired CLI sessions', () => {
+    const staticChip = vi.fn()
+    vi.mocked(isStaticMode).mockReturnValueOnce(true)
+    const { unmount } = render(<ArchivedValidationEvidence onChip={staticChip} />)
+    expect(staticChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
+    unmount()
+
+    const retiredChip = vi.fn()
+    rootActionStateMock.state = {
+      ...rootActionStateMock.state,
+      context: { cli: { available: true, version: '1.9.0' } },
+    }
+    render(<ArchivedValidationEvidence onChip={retiredChip} />)
+    expect(retiredChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
   })
 })

--- a/packages/web/src/components/archived-validation-evidence.tsx
+++ b/packages/web/src/components/archived-validation-evidence.tsx
@@ -6,11 +6,14 @@
  * 4. Derive the capability from the detected admitted CLI; both admitted v11 lines (1.10 and
  *    1.11) declare it, so the unavailable branch names the accepted range, not one series.
  * 5. Validate report payloads with the Core contract schema, never shallow shape guards.
+ * 6. Mount directly inside the Evidence workspace detail pane: the Accordion shell is gone, the
+ *    section header keeps the title and summary facts, and `onChip` reports only derived facts
+ *    (pass/fail from the typed report, typed unavailable) for the workspace rows.
  *
  * Original request (2026-08-15): "v9的适配需要同时适配 1.8和1.9。"
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
-import { EvidenceDisclosure } from '@/components/information-disclosure'
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
@@ -26,7 +29,7 @@ import {
   parseOpenSpecCliVersion,
 } from '@openspecui/core/openspec-compat'
 import { AlertTriangle, CheckCircle2, Loader2, RefreshCw } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 
 type ArchivedValidationReport = CliValidateReport
 
@@ -54,6 +57,16 @@ function parseValidationReport(value: unknown): ParsedArchivedValidationReport {
       (issue) => `${issue.path.length > 0 ? issue.path.join('.') : '<root>'}: ${issue.message}`
     ),
   }
+}
+
+/**
+ * Row-chip fact derived only from settled evidence. `positive`/`negative` come exclusively
+ * from the typed report totals or failure evidence; `unavailable` names a typed degradation.
+ * An unexecuted session reports no chip (`null`) — no fabricated verdict.
+ */
+export interface ArchivedValidationEvidenceChip {
+  label: string
+  tone: 'positive' | 'negative' | 'unavailable'
 }
 
 function IssueList({ issues }: { issues: ArchivedValidationReport['items'][number]['issues'] }) {
@@ -90,13 +103,46 @@ function RunButton({ pending, label, onRun }: { pending: boolean; label: string;
   )
 }
 
-/** On-demand, read-only archived-task validation evidence for the Change Evidence tab. */
-export function ArchivedValidationEvidence() {
+/**
+ * Structure-agnostic section frame for the Evidence workspace detail pane. The heading and
+ * summary line preserve the facts the former Accordion trigger carried; the content is
+ * presented directly — the workspace, not a disclosure, owns reveal behavior.
+ */
+function ArchivedValidationSection({
+  summary,
+  children,
+}: {
+  summary: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section
+      data-evidence-section="archived-validation"
+      aria-label="Archived validation"
+      className="min-w-0"
+    >
+      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
+        <h3 className="min-w-0 text-xs font-semibold">Archived validation</h3>
+        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
+      </header>
+      <div className="min-w-0 pt-3">{children}</div>
+    </section>
+  )
+}
+
+/** On-demand, read-only archived-task validation evidence for the Change Evidence workspace. */
+export function ArchivedValidationEvidence({
+  onChip,
+}: {
+  /** Receives the currently derived row-chip fact; `null` means "no fact, no chip". */
+  onChip?: (chip: ArchivedValidationEvidenceChip | null) => void
+} = {}) {
   const [report, setReport] = useState<CliCommandResult<unknown> | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
   const rootAction = useRootActionState()
   const cli = rootAction.context?.cli
+  const staticMode = isStaticMode()
   // `validate --archived` exists on OpenSpec 1.9+ and both admitted v11 lines (1.10 and 1.11)
   // declare it. An available-but-out-of-range session (e.g. a bypassed 1.9 CLI) must see the
   // capability as unavailable here, never a button that spawns a failing command.
@@ -104,13 +150,32 @@ export function ArchivedValidationEvidence() {
     cli?.available ? parseOpenSpecCliVersion(cli.version) : null
   )
 
-  if (isStaticMode()) {
+  // Row-chip fact for the workspace list — derived from the same settled states the section
+  // renders. Before a run there is no verdict to project, so no chip is fabricated.
+  const chip = useMemo<ArchivedValidationEvidenceChip | null>(() => {
+    if (staticMode) return { label: 'unavailable', tone: 'unavailable' }
+    if (cli?.available === true && !capabilities.archivedValidation) {
+      return { label: 'unavailable', tone: 'unavailable' }
+    }
+    if (!report && !error) return null
+    const parsed = report ? parseValidationReport(report.data) : { report: null, schemaIssues: [] }
+    if (error || !parsed.report) return { label: 'fail', tone: 'negative' }
+    return parsed.report.summary.totals.failed > 0
+      ? { label: 'fail', tone: 'negative' }
+      : { label: 'pass', tone: 'positive' }
+  }, [capabilities.archivedValidation, cli?.available, error, report, staticMode])
+
+  useEffect(() => {
+    onChip?.(chip)
+  }, [chip, onChip])
+
+  if (staticMode) {
     return (
-      <EvidenceDisclosure title="Archived validation" summary="Unavailable in static snapshot">
+      <ArchivedValidationSection summary="Unavailable in static snapshot">
         <p className="text-muted-foreground">
           Archived-task validation is live CLI evidence and is not captured in this static snapshot.
         </p>
-      </EvidenceDisclosure>
+      </ArchivedValidationSection>
     )
   }
 
@@ -119,13 +184,13 @@ export function ArchivedValidationEvidence() {
   if (cli?.available === true && !capabilities.archivedValidation) {
     const detected = cli.version ? ` (detected ${cli.version.trim()})` : ''
     return (
-      <EvidenceDisclosure title="Archived validation" summary="Unavailable on this CLI line">
+      <ArchivedValidationSection summary="Unavailable on this CLI line">
         <p className="text-muted-foreground">
           Archived-task validation requires an admitted OpenSpec CLI line (
           {OPENSPEC_CLI_ACCEPTED_RANGE}){detected}. This session&apos;s CLI does not declare the
           capability, so no command is offered.
         </p>
-      </EvidenceDisclosure>
+      </ArchivedValidationSection>
     )
   }
 
@@ -161,7 +226,7 @@ export function ArchivedValidationEvidence() {
 
   if (!report && !error) {
     return (
-      <EvidenceDisclosure title="Archived validation" summary="OpenSpec archived-task validation">
+      <ArchivedValidationSection summary="OpenSpec archived-task validation">
         <div className="space-y-2">
           <p className="text-muted-foreground">
             Run the official CLI&apos;s archived-task validation and keep its typed report as
@@ -169,7 +234,7 @@ export function ArchivedValidationEvidence() {
           </p>
           <RunButton pending={pending} label="Validate archived tasks" onRun={() => void run()} />
         </div>
-      </EvidenceDisclosure>
+      </ArchivedValidationSection>
     )
   }
 
@@ -181,7 +246,7 @@ export function ArchivedValidationEvidence() {
   if (error || !validationReport) {
     const schemaDiagnostic = parsed.schemaIssues.length > 0 ? parsed.schemaIssues.join('; ') : null
     return (
-      <EvidenceDisclosure title="Archived validation" summary="CLI failure evidence">
+      <ArchivedValidationSection summary="CLI failure evidence">
         <div className="space-y-2">
           <div className="text-destructive flex items-start gap-2 break-words" role="alert">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
@@ -195,15 +260,14 @@ export function ArchivedValidationEvidence() {
           </div>
           <RunButton pending={pending} label="Rerun" onRun={() => void run()} />
         </div>
-      </EvidenceDisclosure>
+      </ArchivedValidationSection>
     )
   }
 
   const validation = validationReport
   const failed = validation.summary.totals.failed
   return (
-    <EvidenceDisclosure
-      title="Archived validation"
+    <ArchivedValidationSection
       summary={`${validation.summary.totals.passed} passed · ${failed} failed`}
     >
       <div className="space-y-3">
@@ -237,6 +301,6 @@ export function ArchivedValidationEvidence() {
         </div>
         <RunButton pending={pending} label="Rerun" onRun={() => void run()} />
       </div>
-    </EvidenceDisclosure>
+    </ArchivedValidationSection>
   )
 }

--- a/packages/web/src/components/change-diff-evidence.test.tsx
+++ b/packages/web/src/components/change-diff-evidence.test.tsx
@@ -1,17 +1,20 @@
 /**
- * Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
  * 1. Lock the 1.11-session rendering: MODIFIED diff body, line roles, exact upstream warning,
- *    and CLI provenance are visible in the direct evidence layer.
+ *    and CLI provenance are directly visible in the Evidence workspace detail pane.
  * 2. Lock the near-miss contract: a delta carrying both warning and diff renders both.
  * 3. Prove 1.10 and static sessions never issue the diff transport call and degrade without
  *    fabricated evidence.
  * 4. Prove absent diff fields, command failure, and transport failure render typed evidence
  *    instead of a crash or an invented diff.
+ * 5. Lock the workspace row-chip facts: counts come only from CLI MODIFIED deltas, degradation
+ *    reports `unavailable`, and undetected/pending sessions report no chip.
  *
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import { isStaticMode } from '@/lib/static-mode'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ChangeDiffEvidence } from './change-diff-evidence'
 
@@ -40,7 +43,7 @@ const rootActionStateMock = vi.hoisted(() => ({
     evidence: [] as string[],
     context: {
       cli: { available: true, version: '1.11.0' },
-    },
+    } as { cli: { available: boolean; version: string } } | null,
     observedAt: 1,
   },
 }))
@@ -82,12 +85,15 @@ function setSessionVersion(version: string) {
 }
 
 /**
- * jsdom keeps collapsed Accordion panels out of the visibility tree, so panel assertions
- * open the disclosure through its trigger — the same pattern the archived-validation
- * evidence tests use.
+ * The de-accordioned section must present its diff body directly — visible without any
+ * disclosure interaction (the old Accordion kept it collapsed in jsdom's visibility tree).
  */
-function openDisclosure() {
-  fireEvent.click(screen.getByRole('button', { name: /Requirement diffs/ }))
+async function waitForVisibleDiffBody(container: HTMLElement) {
+  await waitFor(() => {
+    const body = container.querySelector<HTMLElement>('[data-diff-body]')
+    expect(body).not.toBeNull()
+    if (body) expect(body).toBeVisible()
+  })
 }
 
 describe('ChangeDiffEvidence', () => {
@@ -113,8 +119,11 @@ describe('ChangeDiffEvidence', () => {
     const { container } = render(<ChangeDiffEvidence changeId="add-search" />)
 
     await waitFor(() => expect(diffEvidenceQuery).toHaveBeenCalledWith({ id: 'add-search' }))
-    await waitFor(() => expect(container.querySelector('[data-diff-body]')).not.toBeNull())
-    openDisclosure()
+
+    // The de-accordioned section presents its content directly in the detail pane.
+    const section = container.querySelector('[data-evidence-section="requirement-diffs"]')
+    expect(section).not.toBeNull()
+    await waitForVisibleDiffBody(container)
 
     // Unified diff body: every line role is present and colored through its data attribute.
     const roles = Array.from(container.querySelectorAll('[data-diff-line]')).map((line) =>
@@ -147,8 +156,7 @@ describe('ChangeDiffEvidence', () => {
     diffEvidenceQuery.mockResolvedValue(executedEvidence())
     const { container } = render(<ChangeDiffEvidence changeId="add-search" />)
 
-    await waitFor(() => expect(container.querySelector('[data-diff-body]')).not.toBeNull())
-    openDisclosure()
+    await waitForVisibleDiffBody(container)
     expect(container.querySelector('[data-diff-warning]')).not.toBeNull()
     expect(container.querySelector('[data-diff-warning]')?.textContent).toBe(NEAR_MISS_WARNING)
     expect(container.querySelector('[data-diff-line="remove"]')).not.toBeNull()
@@ -157,7 +165,6 @@ describe('ChangeDiffEvidence', () => {
   it('never issues the transport call on an admitted 1.10 session and degrades', () => {
     setSessionVersion('1.10.0')
     render(<ChangeDiffEvidence changeId="add-search" />)
-    openDisclosure()
 
     expect(diffEvidenceQuery).toHaveBeenCalledTimes(0)
     expect(screen.getByText('Unavailable on this CLI line')).toBeVisible()
@@ -169,7 +176,6 @@ describe('ChangeDiffEvidence', () => {
   it('never issues the transport call in a static snapshot', () => {
     vi.mocked(isStaticMode).mockReturnValue(true)
     render(<ChangeDiffEvidence changeId="add-search" />)
-    openDisclosure()
 
     expect(diffEvidenceQuery).toHaveBeenCalledTimes(0)
     expect(screen.getByText('Unavailable in static snapshot')).toBeVisible()
@@ -188,8 +194,7 @@ describe('ChangeDiffEvidence', () => {
     )
     const { container } = render(<ChangeDiffEvidence changeId="add-search" />)
 
-    await waitFor(() => expect(screen.getByText(/CLI provided no diff fields/)).toBeInTheDocument())
-    openDisclosure()
+    await waitFor(() => expect(screen.getByText(/CLI provided no diff fields/)).toBeVisible())
     expect(container.querySelector('[data-diff-body]')).toBeNull()
     expect(container.querySelector('[data-diff-warning]')).toBeNull()
     expect(screen.getByText('openspec show add-search --json --diff')).toBeVisible()
@@ -204,10 +209,6 @@ describe('ChangeDiffEvidence', () => {
     })
     render(<ChangeDiffEvidence changeId="missing-change" />)
 
-    // The fetch settles into a fresh disclosure; wait for its trigger summary, then open it.
-    const settled = await screen.findByRole('button', { name: /CLI evidence unavailable/ })
-    fireEvent.click(settled)
-
     await waitFor(() =>
       expect(screen.getByText(/FS-001: No active change found with that name/)).toBeVisible()
     )
@@ -217,10 +218,49 @@ describe('ChangeDiffEvidence', () => {
   it('surfaces a transport failure as direct alert evidence', async () => {
     diffEvidenceQuery.mockRejectedValue(new Error('planning root unresolved'))
     render(<ChangeDiffEvidence changeId="add-search" />)
-    openDisclosure()
 
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent('planning root unresolved')
     )
+  })
+
+  it('reports the CLI MODIFIED-delta count as the only executed row-chip fact', async () => {
+    const onChip = vi.fn()
+    diffEvidenceQuery.mockResolvedValue(executedEvidence())
+    const { container } = render(<ChangeDiffEvidence changeId="add-search" onChip={onChip} />)
+
+    await waitForVisibleDiffBody(container)
+    expect(onChip).toHaveBeenLastCalledWith({ label: '1 MODIFIED', tone: 'neutral' })
+  })
+
+  it('reports unavailable chips for static and below-1.11 sessions and none while undetected', () => {
+    const staticChip = vi.fn()
+    vi.mocked(isStaticMode).mockReturnValue(true)
+    const { unmount } = render(<ChangeDiffEvidence changeId="add-search" onChip={staticChip} />)
+    expect(staticChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
+    unmount()
+
+    const legacyChip = vi.fn()
+    setSessionVersion('1.10.0')
+    render(<ChangeDiffEvidence changeId="add-search" onChip={legacyChip} />)
+    expect(legacyChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
+  })
+
+  it('reports an error chip for a transport failure and none while the CLI is undetected', async () => {
+    const onChip = vi.fn()
+    rootActionStateMock.state = {
+      ...rootActionStateMock.state,
+      context: null,
+    }
+    const { rerender } = render(<ChangeDiffEvidence changeId="add-search" onChip={onChip} />)
+    expect(onChip).toHaveBeenLastCalledWith(null)
+
+    diffEvidenceQuery.mockRejectedValue(new Error('planning root unresolved'))
+    rootActionStateMock.state = {
+      ...rootActionStateMock.state,
+      context: { cli: { available: true, version: '1.11.0' } },
+    }
+    rerender(<ChangeDiffEvidence changeId="add-search" onChip={onChip} />)
+    await waitFor(() => expect(onChip).toHaveBeenLastCalledWith({ label: 'error', tone: 'error' }))
   })
 })

--- a/packages/web/src/components/change-diff-evidence.tsx
+++ b/packages/web/src/components/change-diff-evidence.tsx
@@ -1,5 +1,5 @@
 /**
- * Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
  * 1. Present the CLI-provided MODIFIED-delta `diff`/`warning` fields as Change Detail evidence.
  * 2. Color the unified diff body by line role (+/-/@@) without recomputing anything locally.
  * 3. Render the exact upstream warning text beside its diff so a near-miss never swallows evidence.
@@ -7,10 +7,13 @@
  *    live mode: static snapshots and 1.10 sessions never issue the transport call.
  * 5. Degrade to the existing delta presentation when the fields are absent — no fabricated diff
  *    or warning may appear.
+ * 6. Mount directly inside the Evidence workspace detail pane: the Accordion shell is gone, the
+ *    section header keeps the title and summary facts, and `onChip` reports only derived facts
+ *    (CLI MODIFIED-delta count, typed unavailable, transport failure) for the workspace rows.
  *
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
-import { EvidenceDisclosure } from '@/components/information-disclosure'
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
@@ -20,7 +23,17 @@ import {
 } from '@openspecui/core/openspec-compat'
 import type { ChangeDiffEvidence, ChangeDiffEvidenceDelta } from '@openspecui/server'
 import { AlertTriangle, FileDiff, Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+
+/**
+ * Row-chip fact derived only from settled evidence. `neutral` carries the CLI MODIFIED-delta
+ * count; `unavailable` names a typed degradation; `error` names a transport failure. Nothing
+ * is fabricated while the session or fetch is still pending (`null`).
+ */
+export interface ChangeDiffEvidenceChip {
+  label: string
+  tone: 'neutral' | 'unavailable' | 'error'
+}
 
 function diffLineRole(line: string): 'add' | 'remove' | 'hunk' | 'context' {
   if (line.startsWith('@@')) return 'hunk'
@@ -109,8 +122,42 @@ function DiffProvenance({
   )
 }
 
-/** CLI MODIFIED-delta diff evidence for the Change Evidence tab (live 1.11 sessions only). */
-export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
+/**
+ * Structure-agnostic section frame for the Evidence workspace detail pane. The heading and
+ * summary line preserve the facts the former Accordion trigger carried; the content is
+ * presented directly — the workspace, not a disclosure, owns reveal behavior.
+ */
+function RequirementDiffsSection({
+  summary,
+  children,
+}: {
+  summary: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section
+      data-evidence-section="requirement-diffs"
+      aria-label="Requirement diffs"
+      className="min-w-0"
+    >
+      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
+        <h3 className="min-w-0 text-xs font-semibold">Requirement diffs</h3>
+        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
+      </header>
+      <div className="min-w-0 pt-3">{children}</div>
+    </section>
+  )
+}
+
+/** CLI MODIFIED-delta diff evidence for the Change Evidence workspace (live 1.11 sessions only). */
+export function ChangeDiffEvidence({
+  changeId,
+  onChip,
+}: {
+  changeId: string
+  /** Receives the currently derived row-chip fact; `null` means "no fact, no chip". */
+  onChip?: (chip: ChangeDiffEvidenceChip | null) => void
+}) {
   const rootAction = useRootActionState()
   const cli = rootAction.context?.cli
   // `show --diff` exists only on OpenSpec 1.11. A detected-but-below-1.11 session (admitted 1.10
@@ -150,73 +197,92 @@ export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
     }
   }, [changeId, diffCapable, staticMode])
 
+  // Row-chip fact for the workspace list — derived from the same settled states the section
+  // renders, never from a fabricated count. Undetected/pending sessions report no chip.
+  const chip = useMemo<ChangeDiffEvidenceChip | null>(() => {
+    if (staticMode) return { label: 'unavailable', tone: 'unavailable' }
+    if (!diffCapable) {
+      if (cli?.available !== true) return null
+      return { label: 'unavailable', tone: 'unavailable' }
+    }
+    if (error) return { label: 'error', tone: 'error' }
+    if (!evidence) return null
+    if (evidence.kind !== 'executed') return { label: 'unavailable', tone: 'unavailable' }
+    const modified = evidence.deltas.filter((delta) => delta.operation === 'MODIFIED').length
+    return { label: `${modified} MODIFIED`, tone: 'neutral' }
+  }, [cli?.available, diffCapable, error, evidence, staticMode])
+
+  useEffect(() => {
+    onChip?.(chip)
+  }, [chip, onChip])
+
   if (staticMode) {
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="Unavailable in static snapshot">
+      <RequirementDiffsSection summary="Unavailable in static snapshot">
         <p className="text-muted-foreground">
           Requirement diffs are live CLI evidence from `show --diff` and are not captured in this
           static snapshot. The delta content shown on this page remains the captured local
           presentation.
         </p>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
   if (!diffCapable) {
     // Only a detected-but-below-1.11 CLI names its line. While CLI evidence is still pending
-    // (or the runner is unavailable) the disclosure stays neutral instead of claiming the
+    // (or the runner is unavailable) the section stays neutral instead of claiming the
     // session was classified.
     if (cli?.available !== true) {
       return (
-        <EvidenceDisclosure title="Requirement diffs" summary="CLI diff evidence">
+        <RequirementDiffsSection summary="CLI diff evidence">
           <p className="text-muted-foreground">
             Requirement diff evidence from `show --diff` appears here on admitted OpenSpec CLI 1.11
             sessions once the CLI is detected.
           </p>
-        </EvidenceDisclosure>
+        </RequirementDiffsSection>
       )
     }
     const detected = cli.version ? ` (detected ${cli.version.trim()})` : ''
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="Unavailable on this CLI line">
+      <RequirementDiffsSection summary="Unavailable on this CLI line">
         <p className="text-muted-foreground">
           Requirement diffs require an admitted OpenSpec CLI 1.11 session{detected}. This
           session&apos;s CLI does not declare the `show --diff` capability, so the delta
           presentation keeps using the captured local content.
         </p>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
   if (pending && !evidence && !error) {
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="Loading CLI diff evidence">
+      <RequirementDiffsSection summary="Loading CLI diff evidence">
         <p className="text-muted-foreground flex items-center gap-2">
           <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
           Fetching `show --diff` evidence from the official CLI…
         </p>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
   if (error) {
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="Transport failure">
+      <RequirementDiffsSection summary="Transport failure">
         <div className="text-destructive flex items-start gap-2 break-words" role="alert">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
           <span className="min-w-0 break-all">{error}</span>
         </div>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
   if (!evidence) {
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="CLI diff evidence">
+      <RequirementDiffsSection summary="CLI diff evidence">
         <p className="text-muted-foreground">
           Requirement diff evidence from `show --diff` appears here on 1.11 sessions.
         </p>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
@@ -228,7 +294,7 @@ export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
           ? 'The detected OpenSpec CLI does not declare the 1.11 requirement-diff capability.'
           : 'The planning root is unavailable, so requirement-diff evidence cannot be fetched.'
     return (
-      <EvidenceDisclosure title="Requirement diffs" summary="CLI evidence unavailable">
+      <RequirementDiffsSection summary="CLI evidence unavailable">
         <div className="space-y-1">
           <p className="text-muted-foreground">
             Requirement diffs are unavailable for this session. The delta presentation keeps using
@@ -238,7 +304,7 @@ export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
             {detail}
           </p>
         </div>
-      </EvidenceDisclosure>
+      </RequirementDiffsSection>
     )
   }
 
@@ -249,25 +315,20 @@ export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
 
   if (modifiedDeltas.length === 0) {
     return (
-      <EvidenceDisclosure
-        title="Requirement diffs"
-        summary={`${modifiedCount} MODIFIED · CLI provided no diff fields`}
-      >
-        <p className="text-muted-foreground">
-          The CLI reported {modifiedCount} MODIFIED {modifiedCount === 1 ? 'delta' : 'deltas'} with
-          no requirement-diff fields. No diff is fabricated locally.
-        </p>
-        <DiffProvenance provenance={evidence.provenance} />
-      </EvidenceDisclosure>
+      <RequirementDiffsSection summary={`${modifiedCount} MODIFIED · CLI provided no diff fields`}>
+        <div className="min-w-0 space-y-3">
+          <p className="text-muted-foreground">
+            The CLI reported {modifiedCount} MODIFIED {modifiedCount === 1 ? 'delta' : 'deltas'}{' '}
+            with no requirement-diff fields. No diff is fabricated locally.
+          </p>
+          <DiffProvenance provenance={evidence.provenance} />
+        </div>
+      </RequirementDiffsSection>
     )
   }
 
   return (
-    <EvidenceDisclosure
-      title="Requirement diffs"
-      summary={`${modifiedCount} MODIFIED · CLI show --diff`}
-      defaultOpen
-    >
+    <RequirementDiffsSection summary={`${modifiedCount} MODIFIED · CLI show --diff`}>
       <div className="min-w-0 space-y-3">
         <p className="text-muted-foreground flex items-center gap-1.5">
           <FileDiff className="h-3.5 w-3.5 shrink-0" aria-hidden />
@@ -293,6 +354,6 @@ export function ChangeDiffEvidence({ changeId }: { changeId: string }) {
         })}
         <DiffProvenance provenance={evidence.provenance} />
       </div>
-    </EvidenceDisclosure>
+    </RequirementDiffsSection>
   )
 }

--- a/packages/web/src/components/change-evidence-panel.test.tsx
+++ b/packages/web/src/components/change-evidence-panel.test.tsx
@@ -1,16 +1,18 @@
 /**
- * Orthogonal intents (created 2026-08-03 Asia/Shanghai):
- * 1. Prove the complete Change evidence hierarchy is available through the Evidence panel.
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
+ * 1. Prove the summary/paths and CLI-result sections carry the complete layered evidence
+ *    surface the Evidence workspace addresses as list rows.
  * 2. Keep nested raw CLI payload on-demand and bounded.
  * 3. Preserve explicit static provenance unavailability.
  *
  * Original request (2026-08-03): use a tab as the carrier between necessary and complete Change evidence.
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import type { ChangeStatus, CliReferenceIndexEntry } from '@openspecui/core'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ChangeReferenceEvidence } from './change-context-summary'
-import { ChangeEvidencePanel } from './change-evidence-panel'
+import { ChangeCliResultSection, ChangeSummaryPathsSection } from './change-evidence-panel'
 
 function status(): ChangeStatus {
   return {
@@ -67,42 +69,53 @@ const references: CliReferenceIndexEntry[] = [
   },
 ]
 
-describe('ChangeEvidencePanel', () => {
+describe('Change evidence workspace sections', () => {
   afterEach(() => cleanup())
 
-  it('renders readable facts and the full layered evidence surface', () => {
+  it('renders readable facts with the layered artifact and reference disclosures first', () => {
     const referenceEvidence: ChangeReferenceEvidence = { state: 'current', references }
 
-    render(<ChangeEvidencePanel status={status()} referenceEvidence={referenceEvidence} />)
+    render(<ChangeSummaryPathsSection status={status()} referenceEvidence={referenceEvidence} />)
 
-    const panel = screen.getByRole('region', { name: 'Change Evidence' })
-    expect(panel.className).toContain('overflow-y-auto')
-    expect(panel.className).toContain('overflow-x-hidden')
+    const section = screen.getByRole('region', { name: 'Summary & paths' })
+    expect(section.getAttribute('data-evidence-section')).toBe('summary-paths')
     expect(screen.getByText('/planning/openspec/changes/add-auth')).toBeVisible()
     expect(screen.getByRole('button', { name: /Artifact outputs/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: /^References/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /CLI result/ })).toBeTruthy()
-    expect(screen.queryByRole('button', { name: /Raw CLI payload/ })).toBeNull()
+    expect(screen.queryByRole('button', { name: /CLI result/ })).toBeNull()
+  })
 
-    fireEvent.click(screen.getByRole('button', { name: /CLI result/ }))
+  it('renders the CLI result with the raw payload disclosure as the last addressed section', () => {
+    render(<ChangeCliResultSection status={status()} />)
+
+    const section = screen.getByRole('region', { name: 'CLI result' })
+    expect(section.getAttribute('data-evidence-section')).toBe('cli-result')
+    // The CLI facts render directly — only the raw payload stays on-demand and bounded.
+    expect(within(section).getByText('status')).toBeVisible()
+    expect(screen.getByRole('button', { name: /Raw CLI payload/ })).toBeTruthy()
+
     fireEvent.click(screen.getByRole('button', { name: /Raw CLI payload/ }))
     expect(screen.getByText((_, element) => element?.tagName === 'PRE')).toBeVisible()
   })
 
-  it('states that static snapshots do not publish live evidence', () => {
+  it('states that static snapshots do not publish live evidence and omits the CLI section', () => {
     const referenceEvidence: ChangeReferenceEvidence = { state: 'unavailable', reason: 'static' }
 
-    render(
-      <ChangeEvidencePanel
-        status={{ ...status(), provenance: { kind: 'static' } }}
-        referenceEvidence={referenceEvidence}
-      />
+    const { container } = render(
+      <>
+        <ChangeSummaryPathsSection
+          status={{ ...status(), provenance: { kind: 'static' } }}
+          referenceEvidence={referenceEvidence}
+        />
+        <ChangeCliResultSection status={{ ...status(), provenance: { kind: 'static' } }} />
+      </>
     )
 
-    expect(screen.getByRole('region', { name: 'Change Evidence' })).toHaveTextContent(
+    expect(screen.getByRole('region', { name: 'Summary & paths' })).toHaveTextContent(
       'CLI Change context and Reference evidence are unavailable in this static snapshot.'
     )
     fireEvent.click(screen.getByRole('button', { name: /Artifact outputs/ }))
     expect(screen.getByText('tasks.md')).toBeVisible()
+    expect(container.querySelector('[data-evidence-section="cli-result"]')).toBeNull()
   })
 })

--- a/packages/web/src/components/change-evidence-panel.tsx
+++ b/packages/web/src/components/change-evidence-panel.tsx
@@ -1,17 +1,52 @@
 /**
- * Orthogonal intents (created 2026-08-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
  * 1. Render complete source-attributed Change paths, action context, and CLI evidence.
- * 2. Preserve layered Artifact, Reference, CLI-result, and raw-payload disclosure.
- * 3. Own bounded Evidence-tab scrolling and explicit static/unavailable presentation.
+ * 2. Expose the former stacked panel as two list-addressable Evidence workspace sections:
+ *    summary/paths first and CLI result (with the raw payload disclosure) last.
+ * 3. Preserve layered Artifact, Reference, CLI-result, and raw-payload disclosure and the
+ *    explicit static/unavailable presentation; the workspace detail pane owns scrolling.
  *
  * Original request (2026-08-03): use an Evidence tab to carry complete Change Detail information.
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import { EvidenceDisclosure } from '@/components/information-disclosure'
 import type { ChangeStatus, CliReferenceIndexEntry } from '@openspecui/core'
+import type { ReactNode } from 'react'
 import type { ChangeReferenceEvidence } from './change-context-summary'
 
-/** Complete read-only evidence panel rendered inside the Change Evidence tab. */
-export function ChangeEvidencePanel({
+/** Shared section frame for the Evidence workspace detail pane; keeps the a11y heading. */
+function WorkspaceSection({
+  id,
+  title,
+  summary,
+  children,
+  container = false,
+}: {
+  id: string
+  title: string
+  summary?: ReactNode
+  children: ReactNode
+  container?: boolean
+}) {
+  return (
+    <section
+      data-evidence-section={id}
+      aria-label={title}
+      className={container ? '@container min-w-0' : 'min-w-0'}
+    >
+      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
+        <h3 className="min-w-0 text-xs font-semibold">{title}</h3>
+        {summary ? (
+          <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
+        ) : null}
+      </header>
+      <div className="min-w-0 pt-3 text-xs">{children}</div>
+    </section>
+  )
+}
+
+/** Readable paths/facts plus the layered Artifact and Reference disclosures (first row). */
+export function ChangeSummaryPathsSection({
   status,
   referenceEvidence,
 }: {
@@ -23,12 +58,8 @@ export function ChangeEvidencePanel({
   if (provenance.kind === 'static') {
     const artifactCount = status.artifacts.length
     return (
-      <section
-        data-change-evidence-scroll-owner=""
-        aria-label="Change Evidence"
-        className="scrollbar-thin scrollbar-track-transparent flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden overscroll-contain p-4"
-      >
-        <div className="min-w-0 space-y-3 p-4 text-xs">
+      <WorkspaceSection id="summary-paths" title="Summary & paths">
+        <div className="space-y-3">
           <div className="border-border bg-muted/20 text-muted-foreground rounded-md border p-4 text-sm">
             CLI Change context and Reference evidence are unavailable in this static snapshot.
           </div>
@@ -39,19 +70,15 @@ export function ChangeEvidencePanel({
             <StaticArtifactOutputs artifacts={status.artifacts} />
           </EvidenceDisclosure>
         </div>
-      </section>
+      </WorkspaceSection>
     )
   }
 
   const artifactCount = Object.keys(provenance.artifactPaths).length
 
   return (
-    <section
-      data-change-evidence-scroll-owner=""
-      aria-label="Change Evidence"
-      className="scrollbar-thin scrollbar-track-transparent flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden overscroll-contain"
-    >
-      <div className="@container min-w-0 space-y-3 p-4 text-xs">
+    <WorkspaceSection id="summary-paths" title="Summary & paths" container>
+      <div className="min-w-0 space-y-3">
         <ReadableChangeFacts provenance={provenance} />
         <EvidenceDisclosure
           title="Artifact outputs"
@@ -78,14 +105,24 @@ export function ChangeEvidencePanel({
         <EvidenceDisclosure title="References" summary={referenceSummary(referenceEvidence)}>
           <ReferenceEvidence evidence={referenceEvidence} />
         </EvidenceDisclosure>
-        <EvidenceDisclosure
-          title="CLI result"
-          summary={`${provenance.evidence.command} · exit ${provenance.evidence.exitCode ?? 'unknown'}`}
-        >
-          <CliResultEvidence evidence={provenance.evidence} />
-        </EvidenceDisclosure>
       </div>
-    </section>
+    </WorkspaceSection>
+  )
+}
+
+/** CLI result with the raw payload disclosure (last row; live CLI provenance only). */
+export function ChangeCliResultSection({ status }: { status: ChangeStatus }) {
+  if (status.provenance.kind === 'static') return null
+  const provenance = status.provenance
+
+  return (
+    <WorkspaceSection
+      id="cli-result"
+      title="CLI result"
+      summary={`${provenance.evidence.command} · exit ${provenance.evidence.exitCode ?? 'unknown'}`}
+    >
+      <CliResultEvidence evidence={provenance.evidence} />
+    </WorkspaceSection>
   )
 }
 

--- a/packages/web/src/components/change-evidence-surface.browser.test.tsx
+++ b/packages/web/src/components/change-evidence-surface.browser.test.tsx
@@ -1,27 +1,29 @@
 /**
- * Orthogonal intents (created 2026-08-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
  * 1. Measure inline-end versus responsive block-end Header Action geometry in real Chromium.
  * 2. Prove long paths and raw CLI evidence remain horizontally contained at mobile, tablet, and desktop widths.
- * 3. Prove Evidence owns primary vertical scrolling after complete evidence is disclosed.
+ * 3. Prove the Evidence workspace detail pane owns primary vertical scrolling at every container
+ *    topology, with the crowded drill exchanging list and detail surfaces.
  * 4. Prove title identity receives width priority and continuous long titles wrap instead of truncating.
  * 5. Stop at component-browser preparation rather than claiming owner visual acceptance.
  *
  * Original request (2026-08-03): move unbounded Change Detail evidence out of the Header into a dedicated tab.
  * Owner correction (2026-08-03): keep Actions at title inline-end until responsive wrapping and unify subtitle badges.
  * Owner correction (2026-08-03): use `auto 1fr` to prioritize title identity and wrap long titles.
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Owner acceptance boundary (2026-07-20): final end-to-end visual walkthrough belongs to the owner.
  */
 import {
   ChangeContextSummary,
   type ChangeReferenceEvidence,
 } from '@/components/change-context-summary'
-import { ChangeEvidencePanel } from '@/components/change-evidence-panel'
+import { EvidenceWorkspace } from '@/components/evidence-workspace'
 import { ChangeCommandBar } from '@/components/opsx/change-command-bar'
 import { OperationInputsDialogAction } from '@/components/opsx/operation-inputs'
 import { OpsxDetailPage, OpsxDetailTabs } from '@/components/opsx/opsx-detail-layout'
 import { OpsxEntityDetailView } from '@/components/opsx/opsx-entity-detail-view'
 import type { ChangeStatus, CliReferenceIndexEntry } from '@openspecui/core'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { GitBranch } from 'lucide-react'
 import type { ComponentProps, ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -176,7 +178,11 @@ function ChangeEvidenceHarness() {
               id: 'evidence',
               label: 'Evidence',
               content: (
-                <ChangeEvidencePanel status={status} referenceEvidence={referenceEvidence} />
+                <EvidenceWorkspace
+                  changeId="fix-change-detail-evidence-surface"
+                  status={status}
+                  referenceEvidence={referenceEvidence}
+                />
               ),
             },
           ]}
@@ -194,8 +200,8 @@ afterEach(async () => {
   await page.viewport(1280, 720)
 })
 
-describe.each([390, 768, 1280])('Change Evidence at %ipx', (width) => {
-  it('keeps the Header bounded and complete evidence inside its tab scroll owner', async () => {
+describe.each([390, 768, 1280])('Change Evidence workspace at %ipx', (width) => {
+  it('keeps the Header bounded and evidence inside the workspace scroll owner', async () => {
     await page.viewport(width, 720)
     render(<ChangeEvidenceHarness />)
 
@@ -205,7 +211,10 @@ describe.each([390, 768, 1280])('Change Evidence at %ipx', (width) => {
     const actions = screen.getByTestId('opsx-detail-header-actions')
     const title = screen.getByRole('heading', { level: 1 }).querySelector('span')
     const statusRegion = screen.getByTestId('opsx-detail-status-region')
-    const evidence = screen.getByRole('region', { name: 'Change Evidence' })
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    const listPane = workspace.querySelector<HTMLElement>('[data-evidence-pane="list"]')
+    const detailPane = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    if (!listPane || !detailPane) throw new Error('Expected both evidence panes')
 
     await waitFor(() => expect(host.getBoundingClientRect().width).toBe(width))
     expect(title).not.toBeNull()
@@ -237,21 +246,72 @@ describe.each([390, 768, 1280])('Change Evidence at %ipx', (width) => {
         identityHeight + actionsHeight + 13
       )
     }
-    expect(getComputedStyle(evidence).overflowY).toBe('auto')
-    expect(getComputedStyle(evidence).overflowX).toBe('hidden')
 
-    fireEvent.click(screen.getByRole('button', { name: /Artifact outputs/ }))
-    fireEvent.click(screen.getByRole('button', { name: /^References/ }))
-    fireEvent.click(screen.getByRole('button', { name: /CLI result/ }))
-    fireEvent.click(screen.getByRole('button', { name: /Raw CLI payload/ }))
+    // The detail pane is the tab's primary reading surface and owns vertical scrolling.
+    expect(getComputedStyle(detailPane).overflowY).toBe('auto')
+    expect(getComputedStyle(detailPane).overflowX).toBe('hidden')
 
-    await waitFor(() => expect(evidence.scrollHeight).toBeGreaterThan(evidence.clientHeight))
+    const rows = within(listPane).getAllByRole('button')
+    const rowById = (id: string) => rows.find((row) => row.getAttribute('data-evidence-row') === id)
+    const summaryRow = rowById('summary-paths')
+    const cliRow = rowById('cli-result')
+    if (!summaryRow || !cliRow) throw new Error('Expected summary and CLI evidence rows')
+
+    // The ResizeObserver seam settles asynchronously after the viewport change.
+    await waitFor(() =>
+      expect(workspace.getAttribute('data-evidence-topology')).toBe(
+        width === 390 ? 'crowded' : 'spacious'
+      )
+    )
+
+    if (width === 390) {
+      // Crowded container: the list is the entry surface and rows drill into the detail.
+      expect(listPane.getBoundingClientRect().width).toBeGreaterThan(0)
+      fireEvent.click(summaryRow)
+      expect(screen.getByRole('button', { name: 'Back to evidence list' })).toBeVisible()
+      fireEvent.click(screen.getByRole('button', { name: /Artifact outputs/ }))
+      fireEvent.click(screen.getByRole('button', { name: /^References/ }))
+      fireEvent.click(screen.getByRole('button', { name: 'Back to evidence list' }))
+      // Back keeps the drilled detail mounted: re-entering shows the disclosures still open.
+      fireEvent.click(summaryRow)
+      expect(screen.getByRole('button', { name: /Artifact outputs/ })).toBeVisible()
+    } else {
+      // Spacious container: the list and the selected detail render side by side.
+      expect(listPane.getBoundingClientRect().width).toBeGreaterThan(0)
+      expect(detailPane.getBoundingClientRect().width).toBeGreaterThan(0)
+      expect(
+        listPane.getBoundingClientRect().right <= detailPane.getBoundingClientRect().left + 1
+      ).toBe(true)
+      fireEvent.click(summaryRow)
+      fireEvent.click(screen.getByRole('button', { name: /Artifact outputs/ }))
+      fireEvent.click(screen.getByRole('button', { name: /^References/ }))
+    }
+
+    // The long summary section (12 artifact outputs, 10 references, constraints) drives the
+    // detail pane's own vertical scrolling while staying horizontally contained.
+    await waitFor(() => expect(detailPane.scrollHeight).toBeGreaterThan(detailPane.clientHeight))
     expect(host.scrollWidth).toBeLessThanOrEqual(host.clientWidth)
     expect(statusRegion.scrollWidth).toBeLessThanOrEqual(statusRegion.clientWidth)
-    expect(evidence.scrollWidth).toBeLessThanOrEqual(evidence.clientWidth)
+    expect(detailPane.scrollWidth).toBeLessThanOrEqual(detailPane.clientWidth)
     expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(
       document.documentElement.clientWidth
     )
+
+    // Long raw CLI evidence stays bounded: the payload pre wraps and scrolls internally
+    // instead of widening the pane or the page.
+    fireEvent.click(cliRow)
+    fireEvent.click(screen.getByRole('button', { name: /Raw CLI payload/ }))
+    await waitFor(() => {
+      expect(detailPane.querySelector('[data-evidence-detail="cli-result"] pre')).not.toBeNull()
+    })
+    const rawPayload = detailPane.querySelector<HTMLElement>(
+      '[data-evidence-detail="cli-result"] pre'
+    )
+    if (!rawPayload) throw new Error('Expected the raw payload pre')
+    expect(rawPayload.scrollHeight).toBeGreaterThan(rawPayload.clientHeight)
+    expect(rawPayload.scrollWidth).toBeLessThanOrEqual(rawPayload.clientWidth)
+    expect(detailPane.scrollWidth).toBeLessThanOrEqual(detailPane.clientWidth)
+    expect(host.scrollWidth).toBeLessThanOrEqual(host.clientWidth)
   })
 })
 

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -1,0 +1,252 @@
+/**
+ * Orthogonal intents (created 2026-08-28 Asia/Shanghai):
+ * 1. Own the Change Evidence tab's container-responsive list-detail workspace topology.
+ * 2. Preserve the decision-plane evidence layer order (summary/paths -> requirement diffs ->
+ *    archived validation -> CLI/raw payload) in keyboard-reachable list rows.
+ * 3. Derive row chips only from settled section facts; never fabricate counts or verdicts.
+ * 4. Keep the crowded drill presentational: the detail replaces the list with a back
+ *    affordance, and back restores the list without unmounting settled evidence.
+ * 5. Keep sub-selection local runtime state — it never enters routes or browser storage.
+ *
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
+ */
+import {
+  ArchivedValidationEvidence,
+  type ArchivedValidationEvidenceChip,
+} from '@/components/archived-validation-evidence'
+import { Badge } from '@/components/badge'
+import type { ChangeReferenceEvidence } from '@/components/change-context-summary'
+import { ChangeDiffEvidence, type ChangeDiffEvidenceChip } from '@/components/change-diff-evidence'
+import {
+  ChangeCliResultSection,
+  ChangeSummaryPathsSection,
+} from '@/components/change-evidence-panel'
+import { cn } from '@/lib/utils'
+import type { ChangeStatus } from '@openspecui/core'
+import { ArrowLeft } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+
+/**
+ * Spacious threshold: below this inline size the workspace collapses to one column and the
+ * list becomes the drill entry surface. 640px sustains the widest list rail (280px) plus a
+ * ~360px detail reading column — the minimum at which the `@[32rem]` fact/provenance grids
+ * inside every section still render as two columns without horizontal pressure.
+ */
+const EVIDENCE_SPACIOUS_MIN_WIDTH = 640
+
+/** Row-chip fact union across sections; `tone` picks the semantic color, never a count. */
+export interface EvidenceChipFact {
+  label: string
+  tone: 'neutral' | 'positive' | 'negative' | 'unavailable' | 'error'
+}
+
+interface EvidenceWorkspaceSection {
+  id: string
+  label: string
+  /** Only settled facts may project a chip; `null`/absent renders no chip. */
+  chip?: EvidenceChipFact | null
+  content: ReactNode
+}
+
+const CHIP_TONE_CLASS: Record<EvidenceChipFact['tone'], string> = {
+  neutral: 'border-border bg-muted text-muted-foreground',
+  positive: 'border border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  negative: 'border border-destructive/40 bg-destructive/10 text-destructive',
+  unavailable: 'border-border bg-muted/60 text-muted-foreground',
+  error: 'border border-destructive/40 bg-destructive/10 text-destructive',
+}
+
+/**
+ * Container-width topology state through the same ResizeObserver seam the Git list-detail
+ * layout uses: the observed box is the workspace container itself, never the viewport, so
+ * the drill semantics track the CSS `@container` grid breakpoint (640px) exactly.
+ */
+function useSpaciousEvidenceLayout() {
+  const ref = useRef<HTMLElement | null>(null)
+  const [spacious, setSpacious] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(([entry]) => {
+      setSpacious((entry?.contentRect.width ?? 0) >= EVIDENCE_SPACIOUS_MIN_WIDTH)
+    })
+
+    observer.observe(node)
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  return { ref, spacious }
+}
+
+/** Container-responsive list-detail workspace that carries the whole Change Evidence tab. */
+export function EvidenceWorkspace({
+  changeId,
+  status,
+  referenceEvidence,
+}: {
+  changeId: string
+  status: ChangeStatus
+  referenceEvidence: ChangeReferenceEvidence
+}) {
+  const { ref, spacious } = useSpaciousEvidenceLayout()
+  const [selectedId, setSelectedId] = useState('summary-paths')
+  const [drilled, setDrilled] = useState(false)
+  const [diffChip, setDiffChip] = useState<ChangeDiffEvidenceChip | null>(null)
+  const [validationChip, setValidationChip] = useState<ArchivedValidationEvidenceChip | null>(null)
+
+  const handleDiffChip = useCallback((chip: ChangeDiffEvidenceChip | null) => {
+    setDiffChip(chip)
+  }, [])
+  const handleValidationChip = useCallback((chip: ArchivedValidationEvidenceChip | null) => {
+    setValidationChip(chip)
+  }, [])
+
+  // Decision-plane layer order; static snapshots publish no CLI-result section (the same
+  // fact the stacked panel expressed by omitting it).
+  const sections = useMemo<readonly EvidenceWorkspaceSection[]>(() => {
+    const liveSections: EvidenceWorkspaceSection[] =
+      status.provenance.kind === 'static'
+        ? []
+        : [
+            {
+              id: 'cli-result',
+              label: 'CLI result',
+              content: <ChangeCliResultSection status={status} />,
+            },
+          ]
+    return [
+      {
+        id: 'summary-paths',
+        label: 'Summary & paths',
+        content: (
+          <ChangeSummaryPathsSection status={status} referenceEvidence={referenceEvidence} />
+        ),
+      },
+      {
+        id: 'requirement-diffs',
+        label: 'Requirement diffs',
+        chip: diffChip,
+        content: <ChangeDiffEvidence changeId={changeId} onChip={handleDiffChip} />,
+      },
+      {
+        id: 'archived-validation',
+        label: 'Archived validation',
+        chip: validationChip,
+        content: <ArchivedValidationEvidence onChip={handleValidationChip} />,
+      },
+      ...liveSections,
+    ]
+  }, [
+    changeId,
+    diffChip,
+    handleDiffChip,
+    handleValidationChip,
+    referenceEvidence,
+    status,
+    validationChip,
+  ])
+
+  const activeSection = sections.find((section) => section.id === selectedId) ?? sections[0]
+  // Crowded drill topology: the list is the entry surface; an activated row reveals the
+  // detail as the visible surface. Spacious shows both panes side by side at all times.
+  const showList = spacious || !drilled
+  const showDetail = spacious || drilled
+
+  const selectSection = useCallback(
+    (id: string) => {
+      setSelectedId(id)
+      if (!spacious) setDrilled(true)
+    },
+    [spacious]
+  )
+  const backToList = useCallback(() => {
+    setDrilled(false)
+  }, [])
+
+  return (
+    <section
+      ref={ref}
+      aria-label="Change Evidence"
+      data-evidence-workspace=""
+      data-evidence-topology={spacious ? 'spacious' : 'crowded'}
+      className="@container/evidence-workspace flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+    >
+      <div className="@[40rem]:grid-cols-[clamp(12.5rem,24cqw,17.5rem)_minmax(0,1fr)] grid min-h-0 min-w-0 flex-1 grid-cols-1 overflow-hidden">
+        <nav
+          aria-label="Evidence sections"
+          data-evidence-pane="list"
+          hidden={!showList || undefined}
+          className={cn(
+            'scrollbar-thin scrollbar-track-transparent border-border/60 @[40rem]:border-r min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
+            !showList && 'hidden'
+          )}
+        >
+          <ul className="divide-border/20 m-0 list-none divide-y p-0">
+            {sections.map((section) => {
+              const selected = section.id === activeSection.id
+              return (
+                <li key={section.id}>
+                  <button
+                    type="button"
+                    data-evidence-row={section.id}
+                    aria-current={selected ? 'true' : undefined}
+                    onClick={() => selectSection(section.id)}
+                    className={cn(
+                      'focus-visible:ring-primary hover:bg-muted flex min-h-10 w-full min-w-0 items-center justify-between gap-2 px-3 text-left text-xs outline-none focus-visible:ring-2 focus-visible:ring-inset',
+                      selected && 'bg-primary text-primary-foreground hover:bg-primary font-medium'
+                    )}
+                  >
+                    <span className="min-w-0 truncate">{section.label}</span>
+                    {section.chip ? (
+                      <Badge tone="custom" size="xs" className={CHIP_TONE_CLASS[section.chip.tone]}>
+                        {section.chip.label}
+                      </Badge>
+                    ) : null}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </nav>
+        <div
+          data-evidence-pane="detail"
+          data-change-evidence-scroll-owner=""
+          hidden={!showDetail || undefined}
+          className={cn(
+            'scrollbar-thin scrollbar-track-transparent min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
+            showDetail ? 'flex flex-col' : 'hidden'
+          )}
+        >
+          {!spacious && drilled ? (
+            <button
+              type="button"
+              data-evidence-back=""
+              aria-label="Back to evidence list"
+              onClick={backToList}
+              className="bg-background/95 border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-primary sticky top-0 z-10 flex min-h-9 w-full min-w-0 items-center gap-1.5 border-b px-3 text-xs outline-none backdrop-blur focus-visible:ring-2 focus-visible:ring-inset"
+            >
+              <ArrowLeft className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              Evidence list
+            </button>
+          ) : null}
+          {sections.map((section) => (
+            <div
+              key={section.id}
+              data-evidence-detail={section.id}
+              // Every section stays mounted so re-selection never refetches settled evidence;
+              // `hidden` keeps the inactive ones out of the accessibility tree.
+              hidden={section.id !== activeSection.id}
+              className="min-w-0 px-4 pb-4"
+            >
+              {section.content}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -191,8 +191,12 @@ export function EvidenceWorkspace({
       const rowId = pendingRestoreRowId.current
       pendingRestoreRowId.current = null
       if (rowId) rowRefs.current.get(rowId)?.focus()
+    } else if (drilled && spacious && document.activeElement === backRef.current) {
+      // Growing into the spacious topology unmounts the back affordance; move that focus to
+      // the selected row instead of letting it fall to body.
+      rowRefs.current.get(selectedId)?.focus()
     }
-  }, [drilled, spacious])
+  }, [drilled, spacious, selectedId])
 
   return (
     <section

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -104,6 +104,10 @@ export function EvidenceWorkspace({
   const backRef = useRef<HTMLButtonElement | null>(null)
   const drilledByRowId = useRef<string | null>(null)
   const pendingRestoreRowId = useRef<string | null>(null)
+  // Captured while the back affordance still exists: once the spacious topology unmounts it,
+  // its ref is already null and document.activeElement has fallen to body, so focus ownership
+  // must be recorded by focus events rather than inspected after the fact.
+  const backHadFocus = useRef(false)
   const [diffChip, setDiffChip] = useState<ChangeDiffEvidenceChip | null>(null)
   const [validationChip, setValidationChip] = useState<ArchivedValidationEvidenceChip | null>(null)
 
@@ -191,9 +195,10 @@ export function EvidenceWorkspace({
       const rowId = pendingRestoreRowId.current
       pendingRestoreRowId.current = null
       if (rowId) rowRefs.current.get(rowId)?.focus()
-    } else if (drilled && spacious && document.activeElement === backRef.current) {
-      // Growing into the spacious topology unmounts the back affordance; move that focus to
-      // the selected row instead of letting it fall to body.
+    } else if (drilled && spacious && backHadFocus.current) {
+      // Growing into the spacious topology unmounts the back affordance; move its captured
+      // focus to the selected row instead of letting it fall to body.
+      backHadFocus.current = false
       rowRefs.current.get(selectedId)?.focus()
     }
   }, [drilled, spacious, selectedId])
@@ -262,6 +267,12 @@ export function EvidenceWorkspace({
               type="button"
               data-evidence-back=""
               aria-label="Back to evidence list"
+              onFocus={() => {
+                backHadFocus.current = true
+              }}
+              onBlur={() => {
+                backHadFocus.current = false
+              }}
               onClick={backToList}
               className="bg-background/95 border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-primary sticky top-0 z-10 flex min-h-9 w-full min-w-0 items-center gap-1.5 border-b px-3 text-xs outline-none backdrop-blur focus-visible:ring-2 focus-visible:ring-inset"
             >

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -5,7 +5,9 @@
  *    archived validation -> CLI/raw payload) in keyboard-reachable list rows.
  * 3. Derive row chips only from settled section facts; never fabricate counts or verdicts.
  * 4. Keep the crowded drill presentational: the detail replaces the list with a back
- *    affordance, and back restores the list without unmounting settled evidence.
+ *    affordance, and back restores the list without unmounting settled evidence; focus
+ *    follows the drill (row -> back affordance -> originating row) so keyboard users never
+ *    land on a hidden element.
  * 5. Keep sub-selection local runtime state — it never enters routes or browser storage.
  *
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
@@ -66,6 +68,9 @@ function useSpaciousEvidenceLayout() {
   const [spacious, setSpacious] = useState(false)
 
   useEffect(() => {
+    // No-ResizeObserver environments stay on the crowded base on purpose: any engine old
+    // enough to lack ResizeObserver also lacks `@container`, so the CSS grid stays on its
+    // single-column base and the JS topology never disagrees with the rendered one.
     const node = ref.current
     if (!node || typeof ResizeObserver === 'undefined') return
 
@@ -95,6 +100,10 @@ export function EvidenceWorkspace({
   const { ref, spacious } = useSpaciousEvidenceLayout()
   const [selectedId, setSelectedId] = useState('summary-paths')
   const [drilled, setDrilled] = useState(false)
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>())
+  const backRef = useRef<HTMLButtonElement | null>(null)
+  const drilledByRowId = useRef<string | null>(null)
+  const pendingRestoreRowId = useRef<string | null>(null)
   const [diffChip, setDiffChip] = useState<ChangeDiffEvidenceChip | null>(null)
   const [validationChip, setValidationChip] = useState<ArchivedValidationEvidenceChip | null>(null)
 
@@ -159,13 +168,31 @@ export function EvidenceWorkspace({
   const selectSection = useCallback(
     (id: string) => {
       setSelectedId(id)
-      if (!spacious) setDrilled(true)
+      if (!spacious) {
+        drilledByRowId.current = id
+        setDrilled(true)
+      }
     },
     [spacious]
   )
   const backToList = useCallback(() => {
+    pendingRestoreRowId.current = drilledByRowId.current
+    drilledByRowId.current = null
     setDrilled(false)
   }, [])
+
+  // Focus handoff for the crowded drill: opening the detail moves focus to the back
+  // affordance (the first control of the newly revealed surface); returning moves it back
+  // to the row that opened the drill. Without this, keyboard focus stays on a hidden row.
+  useEffect(() => {
+    if (drilled && !spacious) {
+      backRef.current?.focus()
+    } else if (!drilled) {
+      const rowId = pendingRestoreRowId.current
+      pendingRestoreRowId.current = null
+      if (rowId) rowRefs.current.get(rowId)?.focus()
+    }
+  }, [drilled, spacious])
 
   return (
     <section
@@ -191,6 +218,10 @@ export function EvidenceWorkspace({
               return (
                 <li key={section.id}>
                   <button
+                    ref={(node) => {
+                      if (node) rowRefs.current.set(section.id, node)
+                      else rowRefs.current.delete(section.id)
+                    }}
                     type="button"
                     data-evidence-row={section.id}
                     aria-current={selected ? 'true' : undefined}
@@ -223,6 +254,7 @@ export function EvidenceWorkspace({
         >
           {!spacious && drilled ? (
             <button
+              ref={backRef}
               type="button"
               data-evidence-back=""
               aria-label="Back to evidence list"

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -16,7 +16,7 @@
  */
 import type { RootActionState } from '@/lib/use-root-action-state'
 import type { ChangeStatus } from '@openspecui/core'
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { createContext, type ComponentProps, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeView } from './change-view'
@@ -134,12 +134,17 @@ const liveCliChangeStatus = {
  * the same ResizeObserver seam the production Git list-detail layout uses: a stubbed observer
  * reports one synthetic content width per observe() call.
  */
+const evidenceResizeCallbacks: ResizeObserverCallback[] = []
+let evidenceContainerWidth = 320
+
 function stubEvidenceResizeObserver(width: number) {
+  evidenceContainerWidth = width
   class MockResizeObserver {
     private readonly callback: ResizeObserverCallback
 
     constructor(callback: ResizeObserverCallback) {
       this.callback = callback
+      evidenceResizeCallbacks.push(callback)
     }
 
     observe(target: Element) {
@@ -148,7 +153,7 @@ function stubEvidenceResizeObserver(width: number) {
         [
           {
             contentRect: {
-              width,
+              width: evidenceContainerWidth,
               height: element.clientHeight || 320,
             } as DOMRectReadOnly,
           } as ResizeObserverEntry,
@@ -162,6 +167,17 @@ function stubEvidenceResizeObserver(width: number) {
   }
 
   vi.stubGlobal('ResizeObserver', MockResizeObserver)
+}
+
+/** Simulate the workspace container growing or shrinking after the initial observation. */
+function resizeEvidenceContainerTo(width: number) {
+  evidenceContainerWidth = width
+  for (const callback of [...evidenceResizeCallbacks]) {
+    callback(
+      [{ contentRect: { width, height: 320 } as DOMRectReadOnly } as ResizeObserverEntry],
+      null as unknown as ResizeObserver
+    )
+  }
 }
 
 vi.mock('@/lib/use-opsx', () => ({
@@ -277,6 +293,7 @@ describe('ChangeView', () => {
   })
 
   beforeEach(() => {
+    evidenceResizeCallbacks.length = 0
     statusMock.mockReset()
     applyInstructionsMock.mockReset().mockReturnValue({ data: undefined })
     changeFilesMock.mockReset()
@@ -746,6 +763,36 @@ describe('ChangeView', () => {
     expect(
       document.activeElement?.closest('[data-evidence-pane]')?.getAttribute('data-evidence-pane')
     ).toBe('list')
+  })
+
+  it('moves focus off the unmounting back affordance when a drill grows spacious', async () => {
+    routedTabState.selectedTab = 'evidence'
+    stubEvidenceResizeObserver(320)
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    expect(workspace.getAttribute('data-evidence-topology')).toBe('crowded')
+
+    fireEvent.click(within(workspace).getByRole('button', { name: /Archived validation/ }))
+    const back = screen.getByRole('button', { name: 'Back to evidence list' })
+    expect(document.activeElement).toBe(back)
+
+    // Growing the container unmounts the back affordance; its captured focus must land on
+    // the selected row instead of falling to body.
+    await act(async () => {
+      resizeEvidenceContainerTo(1200)
+    })
+    expect(workspace.getAttribute('data-evidence-topology')).toBe('spacious')
+    const selectedRow = within(workspace).getByRole('button', {
+      name: /Archived validation/,
+    })
+    expect(document.activeElement).toBe(selectedRow)
   })
 
   it('does not refetch settled diff evidence across a crowded drill and back', async () => {

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -29,6 +29,20 @@ const openArchiveModalMock = vi.hoisted(() => vi.fn())
 const isStaticModeMock = vi.hoisted(() => vi.fn(() => false))
 const routedTabState = vi.hoisted(() => ({ selectedTab: undefined as string | undefined }))
 
+const diffEvidenceQueryMock = vi.hoisted(() =>
+  vi.fn((..._args: unknown[]) => Promise.reject(new Error('not under test')))
+)
+
+vi.mock('@/lib/trpc', () => ({
+  trpcClient: {
+    change: {
+      diffEvidence: {
+        query: (...args: unknown[]) => diffEvidenceQueryMock(...args),
+      },
+    },
+  },
+}))
+
 vi.mock('@/lib/static-mode', () => ({
   isStaticMode: () => isStaticModeMock(),
 }))
@@ -703,6 +717,65 @@ describe('ChangeView', () => {
         .getByRole('button', { name: /Requirement diffs/ })
         .getAttribute('aria-current')
     ).toBe('true')
+  })
+
+  it('hands keyboard focus to the back affordance on drill and back to the originating row', () => {
+    routedTabState.selectedTab = 'evidence'
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    expect(workspace.getAttribute('data-evidence-topology')).toBe('crowded')
+
+    const row = within(workspace).getByRole('button', {
+      name: /Archived validation/,
+    }) as HTMLButtonElement
+    row.focus()
+    fireEvent.click(row)
+
+    const back = screen.getByRole('button', { name: 'Back to evidence list' })
+    expect(document.activeElement).toBe(back)
+
+    fireEvent.click(back)
+    expect(document.activeElement).toBe(row)
+    expect(
+      document.activeElement?.closest('[data-evidence-pane]')?.getAttribute('data-evidence-pane')
+    ).toBe('list')
+  })
+
+  it('does not refetch settled diff evidence across a crowded drill and back', async () => {
+    routedTabState.selectedTab = 'evidence'
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    const list = workspace.querySelector<HTMLElement>('[data-evidence-pane="list"]')
+    expect(list).not.toBeNull()
+    if (!list) throw new Error('Expected the evidence list pane')
+
+    fireEvent.click(within(list).getByRole('button', { name: /Requirement diffs/ }))
+    const detail = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    expect(detail).toBeVisible()
+
+    // The mounted section settled its single fetch; drilling back and re-entering must not
+    // spawn another one — the sections stay mounted, only visibility changes.
+    const settledCalls = diffEvidenceQueryMock.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: 'Back to evidence list' }))
+    expect(list).toBeVisible()
+    fireEvent.click(within(list).getByRole('button', { name: /Requirement diffs/ }))
+    expect(detail).toBeVisible()
+
+    expect(diffEvidenceQueryMock.mock.calls.length).toBe(settledCalls)
   })
 
   it('shows the list and the selected detail together in a spacious container', () => {

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -1,19 +1,22 @@
 /**
- * Orthogonal intents (updated 2026-08-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-08-28 Asia/Shanghai):
  * 1. Verify change detail fallbacks and schema-driven artifact rendering.
  * 2. Verify retained errors and non-current authority lock actions without entering the Header.
  * 3. Verify Apply inputs remain separate and open from a Header Action Dialog.
  * 4. Verify active Change alone owns the routed Evidence tab and explicit unavailable facts.
+ * 5. Verify the Evidence tab renders the container-responsive list-detail workspace with
+ *    keyboard-reachable rows, crowded drill/back, and unfabricated row chips.
  *
  * Original request (2026-07-15): "Root-dependent actions remain locked until root selection succeeds."
  * Review request (2026-07-23): "代码已经提交，开始review。如果有问题，那么可更新change。"
  * Original request (2026-07-28): keep progress divergence direct while compressing its source counts.
  * Original request (2026-08-03): move complete Change evidence into a dedicated tab page.
  * Owner correction (2026-08-03): move Actions inline with the title, unify subtitle badges, and localize unavailable Tooltips.
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import type { RootActionState } from '@/lib/use-root-action-state'
 import type { ChangeStatus } from '@openspecui/core'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { createContext, type ComponentProps, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeView } from './change-view'
@@ -23,7 +26,12 @@ const applyInstructionsMock = vi.hoisted(() => vi.fn())
 const changeFilesMock = vi.hoisted(() => vi.fn())
 const rootActionMock = vi.hoisted(() => vi.fn())
 const openArchiveModalMock = vi.hoisted(() => vi.fn())
+const isStaticModeMock = vi.hoisted(() => vi.fn(() => false))
 const routedTabState = vi.hoisted(() => ({ selectedTab: undefined as string | undefined }))
+
+vi.mock('@/lib/static-mode', () => ({
+  isStaticMode: () => isStaticModeMock(),
+}))
 
 const rootActionFailureCases: Array<Extract<RootActionState, { status: 'blocked' | 'checking' }>> =
   [
@@ -57,6 +65,90 @@ const retainedChangeStatus = {
   ],
   provenance: { kind: 'static' },
 } satisfies ChangeStatus
+
+const liveCliChangeStatus = {
+  changeName: 'Extract Terminal View Webcomponent',
+  schemaName: 'opsx-collab-pr-loop',
+  isPlanningComplete: false,
+  applyRequires: [],
+  artifacts: [
+    { id: 'implementation', outputPath: 'implementation.md', status: 'ready', requires: [] },
+  ],
+  provenance: {
+    kind: 'cli',
+    planningHome: {
+      kind: 'repo',
+      root: '/planning',
+      changesDir: '/planning/openspec/changes',
+      defaultSchema: 'opsx-collab-pr-loop',
+    },
+    changeRoot: '/planning/openspec/changes/extract-terminal-view-webcomponent',
+    artifactPaths: {
+      implementation: {
+        outputPath: 'implementation.md',
+        resolvedOutputPath:
+          '/planning/openspec/changes/extract-terminal-view-webcomponent/implementation.md',
+        existingOutputPaths: [],
+      },
+    },
+    nextSteps: ['Apply the change.'],
+    actionContext: {
+      mode: 'repo-local',
+      sourceOfTruth: 'repo',
+      planningArtifacts: ['implementation'],
+      linkedContext: [],
+      allowedEditRoots: ['/planning'],
+      requiresAffectedAreaSelection: false,
+      constraints: [],
+    },
+    root: { path: '/planning', source: 'nearest' },
+    evidence: {
+      command: 'status',
+      success: true,
+      stdout: '{"changeName":"extract-terminal-view-webcomponent"}',
+      stderr: '',
+      exitCode: 0,
+      payload: { changeName: 'extract-terminal-view-webcomponent' },
+      diagnostics: [],
+      selector: {},
+    },
+  },
+} satisfies ChangeStatus
+
+/**
+ * jsdom ships no layout engine, so the workspace's spacious topology state is driven through
+ * the same ResizeObserver seam the production Git list-detail layout uses: a stubbed observer
+ * reports one synthetic content width per observe() call.
+ */
+function stubEvidenceResizeObserver(width: number) {
+  class MockResizeObserver {
+    private readonly callback: ResizeObserverCallback
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback
+    }
+
+    observe(target: Element) {
+      const element = target as HTMLElement
+      this.callback(
+        [
+          {
+            contentRect: {
+              width,
+              height: element.clientHeight || 320,
+            } as DOMRectReadOnly,
+          } as ResizeObserverEntry,
+        ],
+        this as unknown as ResizeObserver
+      )
+    }
+
+    disconnect() {}
+    unobserve() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+}
 
 vi.mock('@/lib/use-opsx', () => ({
   useOpsxApplyInstructionsSubscription: applyInstructionsMock,
@@ -167,12 +259,14 @@ vi.mock('@tanstack/react-router', () => ({
 describe('ChangeView', () => {
   afterEach(() => {
     cleanup()
+    vi.unstubAllGlobals()
   })
 
   beforeEach(() => {
     statusMock.mockReset()
     applyInstructionsMock.mockReset().mockReturnValue({ data: undefined })
     changeFilesMock.mockReset()
+    isStaticModeMock.mockReset().mockReturnValue(false)
     rootActionMock.mockReset().mockReturnValue({
       status: 'ready',
       disabled: false,
@@ -463,6 +557,184 @@ describe('ChangeView', () => {
       'CLI Change context and Reference evidence are unavailable in this static snapshot.'
     )
     expect(screen.queryByText('artifact:implementation')).toBeNull()
+  })
+
+  it('replaces the stacked full-width accordions with a list-detail Evidence workspace', () => {
+    routedTabState.selectedTab = 'evidence'
+    isStaticModeMock.mockReturnValue(true)
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    expect(workspace.getAttribute('data-evidence-workspace')).not.toBeNull()
+    // Rows preserve the decision-plane layer order; static snapshots publish no CLI-result row.
+    const rows = Array.from(workspace.querySelectorAll<HTMLElement>('[data-evidence-row]'))
+    expect(rows.map((row) => row.getAttribute('data-evidence-row'))).toEqual([
+      'summary-paths',
+      'requirement-diffs',
+      'archived-validation',
+    ])
+    // The old stacked full-width accordion triggers are gone from the Evidence tab: the row
+    // buttons carry no disclosure state, and the section titles now live in detail headings.
+    expect(screen.queryByRole('button', { name: /Requirement diffs/, expanded: false })).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: /Archived validation/, expanded: false })
+    ).toBeNull()
+    // Chips derive only from settled facts: static degradation names unavailable, and a row
+    // without a fact (summary/paths) shows no chip at all.
+    const diffRow = rows.find(
+      (row) => row.getAttribute('data-evidence-row') === 'requirement-diffs'
+    )
+    expect(diffRow).not.toBeUndefined()
+    if (diffRow) expect(within(diffRow).getByText('unavailable')).toBeTruthy()
+    const validationRow = rows.find(
+      (row) => row.getAttribute('data-evidence-row') === 'archived-validation'
+    )
+    expect(validationRow).not.toBeUndefined()
+    if (validationRow) expect(within(validationRow).getByText('unavailable')).toBeTruthy()
+    const summaryRow = rows.find((row) => row.getAttribute('data-evidence-row') === 'summary-paths')
+    expect(summaryRow).not.toBeUndefined()
+    if (summaryRow) expect(within(summaryRow).queryByText('unavailable')).toBeNull()
+  })
+
+  it('adds the CLI-result row in the layer order for live CLI provenance', () => {
+    routedTabState.selectedTab = 'evidence'
+    statusMock.mockReturnValue({
+      data: liveCliChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    const rows = Array.from(workspace.querySelectorAll<HTMLElement>('[data-evidence-row]'))
+    expect(rows.map((row) => row.getAttribute('data-evidence-row'))).toEqual([
+      'summary-paths',
+      'requirement-diffs',
+      'archived-validation',
+      'cli-result',
+    ])
+    fireEvent.click(within(workspace).getByRole('button', { name: /CLI result/ }))
+    const detail = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    expect(detail).not.toBeNull()
+    if (detail) {
+      expect(within(detail).getByText('status')).toBeVisible()
+      expect(within(detail).getByRole('button', { name: /Raw CLI payload/ })).toBeVisible()
+    }
+  })
+
+  it('keeps every evidence row a natural keyboard-reachable button', () => {
+    routedTabState.selectedTab = 'evidence'
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    const rows = Array.from(workspace.querySelectorAll<HTMLButtonElement>('[data-evidence-row]'))
+    expect(rows.length).toBe(3)
+    for (const row of rows) {
+      expect(row.tagName).toBe('BUTTON')
+      expect(row.getAttribute('tabindex')).not.toBe('-1')
+    }
+    fireEvent.click(rows[2])
+    const detail = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    expect(detail).not.toBeNull()
+    if (detail) {
+      expect(within(detail).getByRole('heading', { name: 'Archived validation' })).toBeVisible()
+    }
+  })
+
+  it('drills from the crowded list into the detail and back without losing settled state', () => {
+    routedTabState.selectedTab = 'evidence'
+    isStaticModeMock.mockReturnValue(true)
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    // jsdom has no ResizeObserver, so the workspace starts crowded — the mobile-first base.
+    expect(workspace.getAttribute('data-evidence-topology')).toBe('crowded')
+    const list = workspace.querySelector<HTMLElement>('[data-evidence-pane="list"]')
+    const detail = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    expect(list).not.toBeNull()
+    expect(detail).not.toBeNull()
+    if (!list || !detail) throw new Error('Expected both evidence panes')
+
+    // Before drilling the list is the only visible surface.
+    expect(list).toBeVisible()
+    expect(detail).not.toBeVisible()
+
+    fireEvent.click(within(list).getByRole('button', { name: /Requirement diffs/ }))
+
+    expect(detail).toBeVisible()
+    expect(list).not.toBeVisible()
+    const diffDetail = detail.querySelector<HTMLElement>(
+      '[data-evidence-detail="requirement-diffs"]'
+    )
+    expect(diffDetail).not.toBeNull()
+    if (diffDetail) {
+      expect(within(diffDetail).getByRole('heading', { name: 'Requirement diffs' })).toBeVisible()
+      expect(within(diffDetail).getByText('Unavailable in static snapshot')).toBeVisible()
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to evidence list' }))
+
+    // Back restores the list while the drilled detail stays mounted (no refetch surface loss)
+    // and the row selection is preserved for the next entry.
+    expect(list).toBeVisible()
+    expect(detail).not.toBeVisible()
+    expect(detail.querySelector('[data-evidence-detail="requirement-diffs"] h3')).not.toBeNull()
+    expect(
+      within(list)
+        .getByRole('button', { name: /Requirement diffs/ })
+        .getAttribute('aria-current')
+    ).toBe('true')
+  })
+
+  it('shows the list and the selected detail together in a spacious container', () => {
+    stubEvidenceResizeObserver(1200)
+    routedTabState.selectedTab = 'evidence'
+    statusMock.mockReturnValue({
+      data: retainedChangeStatus,
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ChangeView />)
+
+    const workspace = screen.getByRole('region', { name: 'Change Evidence' })
+    expect(workspace.getAttribute('data-evidence-topology')).toBe('spacious')
+    const list = workspace.querySelector<HTMLElement>('[data-evidence-pane="list"]')
+    const detail = workspace.querySelector<HTMLElement>('[data-evidence-pane="detail"]')
+    expect(list).not.toBeNull()
+    expect(detail).not.toBeNull()
+    if (!list || !detail) throw new Error('Expected both evidence panes')
+
+    // Spacious shows both panes without any drill, and no back affordance exists.
+    expect(list).toBeVisible()
+    expect(detail).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Back to evidence list' })).toBeNull()
+    expect(within(detail).getByRole('heading', { name: 'Summary & paths' })).toBeVisible()
+
+    // Selecting another row keeps both panes visible.
+    fireEvent.click(within(list).getByRole('button', { name: /Archived validation/ }))
+    expect(list).toBeVisible()
+    expect(detail).toBeVisible()
+    expect(within(detail).getByRole('heading', { name: 'Archived validation' })).toBeInTheDocument()
   })
 
   it('falls back to the shared content document tab when no artifact tab is available', () => {

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -16,7 +16,7 @@
  */
 import type { RootActionState } from '@/lib/use-root-action-state'
 import type { ChangeStatus } from '@openspecui/core'
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { createContext, type ComponentProps, type ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChangeView } from './change-view'
@@ -30,7 +30,7 @@ const isStaticModeMock = vi.hoisted(() => vi.fn(() => false))
 const routedTabState = vi.hoisted(() => ({ selectedTab: undefined as string | undefined }))
 
 const diffEvidenceQueryMock = vi.hoisted(() =>
-  vi.fn((..._args: unknown[]) => Promise.reject(new Error('not under test')))
+  vi.fn((..._args: unknown[]): Promise<unknown> => Promise.reject(new Error('not under test')))
 )
 
 vi.mock('@/lib/trpc', () => ({
@@ -750,13 +750,44 @@ describe('ChangeView', () => {
 
   it('does not refetch settled diff evidence across a crowded drill and back', async () => {
     routedTabState.selectedTab = 'evidence'
+    rootActionMock.mockReturnValue({
+      status: 'ready',
+      disabled: false,
+      observedAt: 1,
+      title: null,
+      message: null,
+      evidence: [],
+      context: {
+        launchProject: { path: '/tmp/project' },
+        planningRoot: { path: '/tmp/project', source: 'nearest', healthy: true, status: [] },
+        storeId: null,
+        cli: { available: true, version: '1.11.0' },
+      },
+    })
     statusMock.mockReturnValue({
       data: retainedChangeStatus,
       isLoading: false,
       error: null,
     })
+    // A live 1.11 session makes the diff section fetch exactly once; the mock resolves so the
+    // section settles before the drill begins (a rejecting mock would leave it pending).
+    diffEvidenceQueryMock.mockResolvedValueOnce({
+      kind: 'executed',
+      deltas: [
+        { spec: 'billing', operation: 'MODIFIED', diff: '@@ -1 +1 @@\n-old\n+new', warning: null },
+      ],
+      provenance: {
+        command: 'show upgrade-billing --json --diff',
+        root: '/tmp/project',
+        rootSource: 'nearest',
+        exitCode: 0,
+      },
+    })
 
     render(<ChangeView />)
+
+    // Wait for the live fetch to settle — the proof is only meaningful once one call happened.
+    await waitFor(() => expect(diffEvidenceQueryMock).toHaveBeenCalledTimes(1))
 
     const workspace = screen.getByRole('region', { name: 'Change Evidence' })
     const list = workspace.querySelector<HTMLElement>('[data-evidence-pane="list"]')
@@ -769,13 +800,12 @@ describe('ChangeView', () => {
 
     // The mounted section settled its single fetch; drilling back and re-entering must not
     // spawn another one — the sections stay mounted, only visibility changes.
-    const settledCalls = diffEvidenceQueryMock.mock.calls.length
     fireEvent.click(screen.getByRole('button', { name: 'Back to evidence list' }))
     expect(list).toBeVisible()
     fireEvent.click(within(list).getByRole('button', { name: /Requirement diffs/ }))
     expect(detail).toBeVisible()
 
-    expect(diffEvidenceQueryMock.mock.calls.length).toBe(settledCalls)
+    expect(diffEvidenceQueryMock).toHaveBeenCalledTimes(1)
   })
 
   it('shows the list and the selected detail together in a spacious container', () => {

--- a/packages/web/src/routes/change-view.tsx
+++ b/packages/web/src/routes/change-view.tsx
@@ -5,6 +5,7 @@
  * 3. Lock every change workflow action behind current Root Context and Status projection authority.
  * 4. Present Apply progress directly and expose project context/guidance through a Header Action Dialog.
  * 5. Keep compact Change facts in subtitle badges while routing complete CLI evidence through a dedicated tab.
+ * 6. Mount the container-responsive list-detail Evidence workspace as the sole Evidence tab surface.
  *
  * Original request (2026-07-15): "Root-dependent actions remain locked until root selection succeeds."
  * Review request (2026-07-23): "代码已经提交，开始review。如果有问题，那么可更新change。"
@@ -15,16 +16,15 @@
  * Original request (2026-08-15): 刷新/解析中状态收敛为副标题行内的 shiny 徽章，不再占据 statusRegion 块。
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。" — the Evidence
  *   tab gains the 1.11-gated CLI MODIFIED-delta diff evidence beside the existing layers.
+ * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  */
 import { ApplyProgressNotice } from '@/components/apply-progress-notice'
-import { ArchivedValidationEvidence } from '@/components/archived-validation-evidence'
 import {
   ChangeContextSummary,
   ChangeReferenceFailureNotice,
   type ChangeReferenceEvidence,
 } from '@/components/change-context-summary'
-import { ChangeDiffEvidence } from '@/components/change-diff-evidence'
-import { ChangeEvidencePanel } from '@/components/change-evidence-panel'
+import { EvidenceWorkspace } from '@/components/evidence-workspace'
 import { ChangeCommandBar } from '@/components/opsx/change-command-bar'
 import { OperationInputsDialogAction } from '@/components/opsx/operation-inputs'
 import { OpsxEntityDetailView } from '@/components/opsx/opsx-entity-detail-view'
@@ -115,11 +115,11 @@ export function ChangeView() {
               label: 'Evidence',
               icon: <FileSearch className="h-4 w-4" />,
               content: (
-                <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-                  <ChangeEvidencePanel status={status} referenceEvidence={referenceEvidence} />
-                  <ChangeDiffEvidence changeId={changeId} />
-                  <ArchivedValidationEvidence />
-                </div>
+                <EvidenceWorkspace
+                  changeId={changeId}
+                  status={status}
+                  referenceEvidence={referenceEvidence}
+                />
               ),
             },
           ]


### PR DESCRIPTION
## Summary

Owner walkthrough feedback on the Change Detail Evidence tab: the requirement-diff and archived-validation accordions were full-width, and the whole page should follow a mobile list-detail structure. This replaces the stacked accordion composition with a container-responsive list-detail workspace.

- **EvidenceWorkspace**: evidence rows in the decision-plane layer order (summary/paths → requirement diffs → archived validation → CLI/raw payload), each a native keyboard-reachable button with a fact-derived status chip (no fabricated counts).
- **Topology**: container queries (`@container`, 640px threshold, ResizeObserver seam) — spacious containers show list + detail side by side with independent scrolling; crowded containers drill from list to detail with a back affordance. Sub-selection stays local runtime state.
- **Structure-agnostic sections**: the diff and archived-validation components drop their own accordions; fetching, capability gating (1.10 never calls), static degradation, and CLI provenance are untouched.
- **Focus handoff**: drilling focuses the back affordance and back returns focus to the originating row; growing spacious while drilled moves captured focus to the selected row.
- `.gitignore` gains `__screenshots__/` for this change's vitest browser artifacts.

Change artifact: `openspec/changes/redesign-change-evidence-list-detail/`

## Review loop

Independent Codex review (gpt-5.6-terra xhigh, herdr): 6.5 → 7.0 → 7.5 → **8.5/10 (PR-ready)**. Notable catches: a vacuous 0==0 no-refetch test (rewritten against a live 1.11 session), and a focus migration that inspected state after unmount (rewritten with focus-event capture).

## Test plan

- `change-view` 21/21, evidence component suites 24/24, Chromium browser suite 5/5 (three-width topology, scroll ownership, no horizontal overflow).
- Web full unit: 189 files / 1178 tests green; typecheck, lint, format green.
- Final browser walkthrough belongs to the Owner (walkthrough servers rebuilt for re-verification).
