### PR TITLE
chore(release): consume the 10.0.0 base version

### DIFF
--- a/.changeset/consume-10-base.md
+++ b/.changeset/consume-10-base.md
@@ -1,0 +1,18 @@
+---
+'@openspecui/app': patch
+'@openspecui/browser-translator': patch
+'@openspecui/core': patch
+'@openspecui/local-ct2-translator': patch
+'@openspecui/local-llama-translator': patch
+'@openspecui/local-translator': patch
+'@openspecui/openai-completion-translator': patch
+'@openspecui/search': patch
+'@openspecui/server': patch
+'@openspecui/web': patch
+'@openspecui/website': patch
+'openspecui': patch
+---
+
+Consume the 10.0.0 base version without a release so the pending major
+changeset publishes OpenSpecUI as 11.0.0 (the v11 line skips a separate
+10.x release, the same base-consumption the v9 release performed).

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/app",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/browser-translator/package.json
+++ b/packages/browser-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/browser-translator",
   "private": true,
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Browser-side translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspecui",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "OpenSpec UI - Visual interface for spec-driven development",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/core",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Core OpenSpec adapter and parser",
   "files": [
     "dist"

--- a/packages/local-ct2-translator/package.json
+++ b/packages/local-ct2-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-ct2-translator",
   "private": true,
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Server-side CTranslate2 translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-llama-translator/package.json
+++ b/packages/local-llama-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-llama-translator",
   "private": true,
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Server-side llama.cpp translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-translator/package.json
+++ b/packages/local-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-translator",
   "private": true,
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Server-side local translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/openai-completion-translator/package.json
+++ b/packages/openai-completion-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/openai-completion-translator",
   "private": true,
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "OpenAI completion translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/search",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "Shared search engine and worker providers for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/server",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.mjs",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/web",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "type": "module",
   "bin": {
     "openspecui-ssg": "./dist-ssg/ssg-cli.mjs"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/website",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps the fixed group to 10.0.0 without publishing so the pending major changeset (adapt-openspec-cli-11-line) resolves to 11.0.0 at the next `pnpm changeversion`. Same base-consumption the v9 release performed for 8.0.0.