### PR TITLE
fix(web): attribute validation findings to their owning change and restyle the evidence detail panel

### DIFF
--- a/.changeset/walkthrough-findings-evidence-fix.md
+++ b/.changeset/walkthrough-findings-evidence-fix.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Attribute validation findings to their owning change and restyle the Evidence detail panel: current-change findings render under a This-change heading while other changes collapse into a labeled disclosure with prominent owning ids; finding cards gain semantic level chips with distinct glyphs, mono paths, word-boundary message wrapping, a muted-label provenance grid with count chips and a command-provenance footer, distinct not-loaded/running/loaded states, and visible list/detail plane separation.

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -1,5 +1,5 @@
 /**
- * Orthogonal intents (updated 2026-09-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-09-04 Asia/Shanghai):
  * 1. Own the Change Evidence tab's container-responsive list-detail workspace topology.
  * 2. Preserve the decision-plane evidence layer order (summary/paths -> requirement diffs ->
  *    validation findings -> archived validation -> CLI/raw payload) in keyboard-reachable
@@ -10,9 +10,13 @@
  *    follows the drill (row -> back affordance -> originating row) so keyboard users never
  *    land on a hidden element.
  * 5. Keep sub-selection local runtime state — it never enters routes or browser storage.
+ * 6. Separate the workspace planes visually: the list column is the muted rail and the
+ *    detail column is the card surface; detail prose caps its measure, and only the
+ *    selected row ever carries a row fill.
  *
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review.
  */
 import {
   ArchivedValidationEvidence,
@@ -159,7 +163,7 @@ export function EvidenceWorkspace({
         id: 'validation-findings',
         label: 'Validation findings',
         chip: findingsChip,
-        content: <ValidationFindingsEvidence onChip={handleFindingsChip} />,
+        content: <ValidationFindingsEvidence changeId={changeId} onChip={handleFindingsChip} />,
       },
       {
         id: 'archived-validation',
@@ -235,7 +239,9 @@ export function EvidenceWorkspace({
           data-evidence-pane="list"
           hidden={!showList || undefined}
           className={cn(
-            'scrollbar-thin scrollbar-track-transparent border-border/60 @[40rem]:border-r min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
+            // List plane: muted rail; only the selected row ever carries a row fill, so a
+            // gray row can never read as a selection state.
+            'scrollbar-thin scrollbar-track-transparent bg-muted/40 border-border @[40rem]:border-r min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
             !showList && 'hidden'
           )}
         >
@@ -275,7 +281,9 @@ export function EvidenceWorkspace({
           data-change-evidence-scroll-owner=""
           hidden={!showDetail || undefined}
           className={cn(
-            'scrollbar-thin scrollbar-track-transparent min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
+            // Detail plane: the card surface beside the muted list rail. Prose paragraphs
+            // cap their measure so long evidence lines stay readable at wide widths.
+            'scrollbar-thin scrollbar-track-transparent bg-card min-h-0 min-w-0 overflow-y-auto overflow-x-hidden overscroll-contain',
             showDetail ? 'flex flex-col' : 'hidden'
           )}
         >
@@ -292,7 +300,7 @@ export function EvidenceWorkspace({
                 backHadFocus.current = false
               }}
               onClick={backToList}
-              className="bg-background/95 border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-primary sticky top-0 z-10 flex min-h-9 w-full min-w-0 items-center gap-1.5 border-b px-3 text-xs outline-none backdrop-blur focus-visible:ring-2 focus-visible:ring-inset"
+              className="bg-card/95 border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-primary sticky top-0 z-10 flex min-h-9 w-full min-w-0 items-center gap-1.5 border-b px-3 text-xs outline-none backdrop-blur focus-visible:ring-2 focus-visible:ring-inset"
             >
               <ArrowLeft className="h-3.5 w-3.5 shrink-0" aria-hidden />
               Evidence list
@@ -303,9 +311,11 @@ export function EvidenceWorkspace({
               key={section.id}
               data-evidence-detail={section.id}
               // Every section stays mounted so re-selection never refetches settled evidence;
-              // `hidden` keeps the inactive ones out of the accessibility tree.
+              // `hidden` keeps the inactive ones out of the accessibility tree. Paragraph
+              // prose inside the detail caps its measure; monospace facts and code blocks
+              // keep the full column.
               hidden={section.id !== activeSection.id}
-              className="min-w-0 px-4 pb-4"
+              className="min-w-0 px-4 pb-4 [&_p]:max-w-[88ch]"
             >
               {section.content}
             </div>

--- a/packages/web/src/components/validation-findings-evidence.test.tsx
+++ b/packages/web/src/components/validation-findings-evidence.test.tsx
@@ -1,16 +1,20 @@
 /**
- * Orthogonal intents (created 2026-09-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-09-04 Asia/Shanghai):
  * 1. Present the typed 1.12 findings document: INFO as a distinct informational class,
  *    `returnedItems` beside preserved full-run totals, CLI provenance, filtered labeling.
- * 2. Keep the CLI-owned request-error envelope on the direct plane with its fix string.
- * 3. Identify the evidence as unavailable in static snapshots and on retired CLI sessions
+ * 2. Attribute findings to their owning change: the current change's entries are the
+ *    primary list, other active changes' entries stay in a labeled secondary disclosure,
+ *    and scope-level counts are never filtered to the current change.
+ * 3. Keep the CLI-owned request-error envelope on the direct plane with its fix string.
+ * 4. Identify the evidence as unavailable in static snapshots and on retired CLI sessions
  *    without fabricating it or offering a command.
- * 4. Validate payloads through the Core contract schemas: malformed documents become typed
+ * 5. Validate payloads through the Core contract schemas: malformed documents become typed
  *    failure evidence instead of a crash.
- * 5. Lock the workspace row-chip facts: counts derive only from the typed findings document,
+ * 6. Lock the workspace row-chip facts: counts derive only from the typed findings document,
  *    degradation reports `unavailable`, and an unexecuted session reports no chip.
  *
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review.
  */
 import { isStaticMode } from '@/lib/static-mode'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -125,7 +129,7 @@ describe('ValidationFindingsEvidence', () => {
 
   it('renders the findings document with INFO distinct, filtered counts, and full-run totals', async () => {
     validateMock.mockResolvedValue(findingsTransport(findingsDocument()))
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -135,24 +139,171 @@ describe('ValidationFindingsEvidence', () => {
     // The filtered view is labeled as filtered, with returnedItems beside totalItems.
     expect(await screen.findByText('Filtered view · 1 of 3 items with findings')).toBeVisible()
     expect(screen.getByText(/1 of 3 \(changes scope\)/)).toBeVisible()
+    // Provenance grid carries root and exit status beside the counts.
+    const provenance = document.querySelector('[data-findings-provenance]')
+    expect(provenance).not.toBeNull()
+    expect(provenance?.textContent).toContain('/repo')
+    expect(provenance?.textContent).toContain('Exit status')
     // Full-run totals stay visible beside the filtered counts — never replaced by them.
-    expect(screen.getByText('3 passed · 0 failed · 3 items')).toBeVisible()
-    expect(screen.getByText('/repo')).toBeVisible()
-    // INFO renders as its own informational class, distinct from warnings and errors.
-    const infoLine = screen
-      .getAllByText((_content, element) => element?.tagName === 'SPAN')
-      .find((element) => element.textContent?.startsWith('INFO · missing-spec/spec.md'))
-    expect(infoLine).toBeDefined()
-    expect(infoLine?.closest('li')).toHaveAttribute('data-findings-level', 'INFO')
+    expect(screen.getByText('3 passed')).toBeVisible()
+    expect(screen.getByText('0 failed')).toBeVisible()
+    expect(screen.getByText('3 items')).toBeVisible()
+    // INFO renders as its own chip class, distinct from warnings and errors.
+    const infoRow = document.querySelector('li[data-findings-issue="INFO"]')
+    expect(infoRow).not.toBeNull()
+    expect(infoRow?.textContent).toContain('missing-spec/spec.md')
+    expect(infoRow?.querySelector('[data-findings-level="INFO"]')).not.toBeNull()
     // The merge-conflict advisory stays verbatim on the direct plane.
     expect(document.body.textContent).toContain('Archive would refuse this delta')
     // The item stays valid: the findings projection never re-labels the CLI verdict.
     expect(screen.getByText(/test-change/)).toBeVisible()
+    // The footer names the exact CLI command and scope instead of a floating rerun button.
+    expect(screen.getByText('openspec validate --report findings · changes scope')).toBeVisible()
+  })
+
+  it('attributes findings: this change is the primary list and other changes stay in a labeled secondary disclosure', async () => {
+    validateMock.mockResolvedValue(
+      findingsTransport(
+        findingsDocument({
+          report: {
+            kind: 'validation-findings',
+            version: '1.0',
+            scope: 'changes',
+            returnedItems: 2,
+            totalItems: 3,
+          },
+          itemFindings: [
+            {
+              id: 'clean-change',
+              type: 'change',
+              valid: false,
+              issues: [{ level: 'WARNING', path: 'proposal.md', message: 'Tasks list is empty.' }],
+              durationMs: 5,
+            },
+            {
+              id: 'conflict-change',
+              type: 'change',
+              valid: true,
+              issues: [
+                {
+                  level: 'INFO',
+                  path: 'missing-spec/spec.md',
+                  message:
+                    'Archive would refuse this delta: missing-spec: target spec does not exist.',
+                },
+              ],
+              durationMs: 19,
+            },
+          ],
+          summary: {
+            totals: { items: 3, passed: 2, failed: 1 },
+            byType: { change: { items: 3, passed: 2, failed: 1 } },
+          },
+        })
+      )
+    )
+    render(<ValidationFindingsEvidence changeId="clean-change" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
+
+    expect(await screen.findByText('Filtered view · 2 of 3 items with findings')).toBeVisible()
+
+    // Primary list carries only the current change's finding.
+    expect(screen.getByRole('heading', { name: 'This change' })).toBeVisible()
+    const own = document.querySelector('[data-findings-own]')
+    expect(own).not.toBeNull()
+    expect(own?.textContent).toContain('proposal.md')
+    expect(own?.textContent).toContain('Tasks list is empty.')
+    expect(own?.textContent).not.toContain('Archive would refuse this delta')
+
+    // Other active changes land in a collapsed, clearly-labeled secondary disclosure.
+    const other = document.querySelector('details[data-findings-other]')
+    expect(other).not.toBeNull()
+    expect(other?.hasAttribute('open')).toBe(false)
+    expect(screen.getByText('Findings from other active changes (1)')).toBeVisible()
+    // Each secondary entry is prefixed by its owning change id prominently.
+    const otherEntry = document.querySelector('[data-findings-other-item]')
+    expect(otherEntry).not.toBeNull()
+    if (otherEntry) {
+      const prefixedIds = Array.from(otherEntry.children).filter(
+        (child) => child.tagName === 'DIV' && child.textContent === 'conflict-change'
+      )
+      expect(prefixedIds.length).toBe(1)
+    }
+    expect(other?.textContent).toContain('Archive would refuse this delta')
+
+    // Scope-level facts stay unfiltered: both scope items count, full-run totals preserved.
+    expect(screen.getByText(/2 of 3 \(changes scope\)/)).toBeVisible()
+    expect(screen.getByText('2 passed')).toBeVisible()
+    expect(screen.getByText('1 failed')).toBeVisible()
+    expect(screen.getByText('3 items')).toBeVisible()
+  })
+
+  it('shows a clean change no primary finding while another change advisory stays attributed', async () => {
+    validateMock.mockResolvedValue(
+      findingsTransport(
+        findingsDocument({
+          itemFindings: [
+            {
+              id: 'conflict-change',
+              type: 'change',
+              valid: true,
+              issues: [
+                {
+                  level: 'INFO',
+                  path: 'missing-spec/spec.md',
+                  message: 'Archive would refuse this delta: target spec does not exist.',
+                },
+              ],
+              durationMs: 19,
+            },
+          ],
+        })
+      )
+    )
+    render(<ValidationFindingsEvidence changeId="clean-change" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
+
+    expect(await screen.findByText('Filtered view · 1 of 3 items with findings')).toBeVisible()
+    // The walkthrough defect: clean-change must not read as the owner of the advisory.
+    const own = document.querySelector('[data-findings-own]')
+    expect(own).not.toBeNull()
+    expect(own?.textContent).not.toContain('Archive would refuse this delta')
+    expect(screen.getByText(/No findings for this change in the filtered scope/)).toBeVisible()
+    expect(screen.getByText('Findings from other active changes (1)')).toBeVisible()
+    // The full-run totals remain unfiltered scope facts.
+    expect(screen.getByText('3 passed')).toBeVisible()
+  })
+
+  it('distinguishes the not-loaded, running, and loaded pre-run states', async () => {
+    let resolveRun: (value: unknown) => void = () => {}
+    validateMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRun = resolve
+      })
+    )
+    render(<ValidationFindingsEvidence changeId="test-change" />)
+
+    // Not yet run: owned dashed container, plain-language copy, command as a code chip.
+    expect(screen.getByText('Not yet run')).toBeVisible()
+    expect(screen.getByText('No findings loaded')).toBeVisible()
+    expect(screen.getByText('openspec validate --report findings')).toBeVisible()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
+
+    // Running is its own explicit state, distinct from not-loaded and loaded.
+    expect(await screen.findByText('Running findings report…')).toBeVisible()
+    expect(screen.queryByText('No findings loaded')).not.toBeInTheDocument()
+
+    resolveRun(findingsTransport(findingsDocument()))
+    expect(await screen.findByText('Filtered view · 1 of 3 items with findings')).toBeVisible()
+    expect(screen.queryByText('Running findings report…')).not.toBeInTheDocument()
   })
 
   it('states the filtered view is not the complete validation result', async () => {
     validateMock.mockResolvedValue(findingsTransport(findingsDocument()))
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -177,7 +328,7 @@ describe('ValidationFindingsEvidence', () => {
         })
       )
     )
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -202,7 +353,7 @@ describe('ValidationFindingsEvidence', () => {
         { exitCode: 1 }
       )
     )
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -230,7 +381,7 @@ describe('ValidationFindingsEvidence', () => {
         })
       )
     )
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -242,7 +393,7 @@ describe('ValidationFindingsEvidence', () => {
 
   it('identifies the evidence as unavailable in a static snapshot without fabricating it', () => {
     vi.mocked(isStaticMode).mockReturnValueOnce(true)
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     expect(screen.getByText('Unavailable in static snapshot')).toBeVisible()
     expect(screen.getByText(/not captured in this static snapshot/)).toBeVisible()
@@ -254,7 +405,7 @@ describe('ValidationFindingsEvidence', () => {
       ...rootActionStateMock.state,
       context: { cli: { available: true, version: '1.11.0' } },
     }
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     expect(screen.getByText('Unavailable on this CLI line')).toBeVisible()
     expect(
@@ -269,7 +420,7 @@ describe('ValidationFindingsEvidence', () => {
 
   it('surfaces transport errors with a rerun control', async () => {
     validateMock.mockRejectedValue(new Error('planning root unresolved'))
-    render(<ValidationFindingsEvidence />)
+    render(<ValidationFindingsEvidence changeId="test-change" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
 
@@ -280,7 +431,7 @@ describe('ValidationFindingsEvidence', () => {
   it('reports row chips only from the typed document and none before a run', async () => {
     const onChip = vi.fn()
     validateMock.mockResolvedValue(findingsTransport(findingsDocument()))
-    render(<ValidationFindingsEvidence onChip={onChip} />)
+    render(<ValidationFindingsEvidence changeId="test-change" onChip={onChip} />)
 
     // Before any run there is no fact to project — no fabricated chip.
     expect(onChip).toHaveBeenLastCalledWith(null)
@@ -300,7 +451,7 @@ describe('ValidationFindingsEvidence', () => {
       )
     )
     cleanup()
-    render(<ValidationFindingsEvidence onChip={failingChip} />)
+    render(<ValidationFindingsEvidence changeId="test-change" onChip={failingChip} />)
     fireEvent.click(screen.getByRole('button', { name: 'Load validation findings' }))
     await waitFor(() =>
       expect(failingChip).toHaveBeenLastCalledWith({ label: '1 failed', tone: 'negative' })
@@ -310,7 +461,9 @@ describe('ValidationFindingsEvidence', () => {
   it('reports an unavailable row chip on static and retired CLI sessions', () => {
     const staticChip = vi.fn()
     vi.mocked(isStaticMode).mockReturnValueOnce(true)
-    const { unmount } = render(<ValidationFindingsEvidence onChip={staticChip} />)
+    const { unmount } = render(
+      <ValidationFindingsEvidence changeId="test-change" onChip={staticChip} />
+    )
     expect(staticChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
     unmount()
 
@@ -319,7 +472,7 @@ describe('ValidationFindingsEvidence', () => {
       ...rootActionStateMock.state,
       context: { cli: { available: true, version: '1.11.0' } },
     }
-    render(<ValidationFindingsEvidence onChip={retiredChip} />)
+    render(<ValidationFindingsEvidence changeId="test-change" onChip={retiredChip} />)
     expect(retiredChip).toHaveBeenLastCalledWith({ label: 'unavailable', tone: 'unavailable' })
   })
 })

--- a/packages/web/src/components/validation-findings-evidence.tsx
+++ b/packages/web/src/components/validation-findings-evidence.tsx
@@ -1,19 +1,26 @@
 /**
- * Orthogonal intents (created 2026-09-03 Asia/Shanghai):
+ * Orthogonal intents (updated 2026-09-04 Asia/Shanghai):
  * 1. Present the OpenSpec 1.12 `validate --report findings` document as typed CLI evidence.
- * 2. Render INFO as a first-class informational class, distinct from warnings and errors.
- * 3. Show the filtered view honestly: `returnedItems` beside the preserved full-run totals,
- *    labeled as filtered, never presented as the complete validation result.
- * 4. Gate the affordance behind the admitted line's `findingsReport` capability: non-admitted
+ * 2. Attribute every item finding to its owning change: entries owned by the current change
+ *    render as the primary "This change" list, while entries owned by other active changes
+ *    stay in a clearly-labeled secondary disclosure with prominent change attribution — a
+ *    finding never presents as this change's finding just because the scope is shared.
+ * 3. Render INFO as a first-class informational class, distinct from warnings and errors.
+ * 4. Show the filtered view honestly: `returnedItems` beside the preserved full-run totals,
+ *    labeled as filtered, never presented as the complete validation result. Scope-level
+ *    counts are never filtered to the current change.
+ * 5. Gate the affordance behind the admitted line's `findingsReport` capability: non-admitted
  *    sessions get no findings action; static snapshots state the evidence is unavailable.
- * 5. Validate transport and findings payloads with the Core contract schemas, never shallow
+ * 6. Validate transport and findings payloads with the Core contract schemas, never shallow
  *    guards, and keep the CLI-owned request-error envelope on the direct plane.
  *
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review.
  */
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
+import { cn } from '@/lib/utils'
 // Types may come from the barrel (erased at build); runtime schemas must come from the
 // browser-safe subpath — the Core barrel re-exports Node-bound values (reactive-fs), and a
 // value import from it drags AsyncLocalStorage into the browser bundle.
@@ -31,7 +38,7 @@ import {
   OPENSPEC_CLI_ACCEPTED_RANGE,
   parseOpenSpecCliVersion,
 } from '@openspecui/core/openspec-compat'
-import { AlertTriangle, CheckCircle2, Info, Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Info, Loader2, OctagonAlert, RefreshCw } from 'lucide-react'
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 
 /**
@@ -73,38 +80,83 @@ export interface ValidationFindingsEvidenceChip {
   tone: 'neutral' | 'negative' | 'unavailable'
 }
 
-const ISSUE_LEVEL_CLASS: Record<
-  CliValidateFindings['itemFindings'][number]['issues'][number]['level'],
-  string
-> = {
-  INFO: 'text-sky-700 dark:text-sky-300',
-  WARNING: 'text-amber-700 dark:text-amber-300',
-  ERROR: 'text-destructive',
+type FindingsItem = CliValidateFindings['itemFindings'][number]
+type FindingsIssue = FindingsItem['issues'][number]
+
+/** Semantic level chip: box-radius geometry, distinct glyph per class, tinted never flooded. */
+const LEVEL_CHIP_CLASS: Record<FindingsIssue['level'], string> = {
+  INFO: 'border-blue-600/40 bg-blue-500/5 text-blue-600 dark:text-blue-400',
+  WARNING: 'border-amber-600/40 bg-amber-500/5 text-amber-600 dark:text-amber-400',
+  ERROR: 'border-red-600/40 bg-red-500/5 text-red-600 dark:text-red-400',
+}
+const LEVEL_CHIP_GLYPH: Record<FindingsIssue['level'], typeof Info> = {
+  INFO: Info,
+  WARNING: AlertTriangle,
+  ERROR: OctagonAlert,
 }
 
-function IssueList({ issues }: { issues: CliValidateFindings['itemFindings'][number]['issues'] }) {
-  if (issues.length === 0) {
-    return <p className="text-muted-foreground">No CLI issue reported.</p>
-  }
+function LevelChip({ level }: { level: FindingsIssue['level'] }) {
+  const Glyph = LEVEL_CHIP_GLYPH[level]
   return (
-    <ul className="space-y-0.5">
-      {issues.map((issue, index) => (
-        <li
-          key={index}
-          data-findings-level={issue.level}
-          className={`flex items-start gap-1.5 break-words ${ISSUE_LEVEL_CLASS[issue.level]}`}
-        >
-          {issue.level === 'INFO' ? (
-            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-          ) : (
-            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-          )}
-          <span className="min-w-0 break-all">
-            {issue.level} · {issue.path} · {issue.message}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <span
+      data-findings-level={level}
+      className={`inline-flex shrink-0 items-center gap-1 border px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${LEVEL_CHIP_CLASS[level]}`}
+    >
+      <Glyph className="h-3 w-3" aria-hidden />
+      {level}
+    </span>
+  )
+}
+
+/**
+ * One findings item as a header/body card. Each issue owns a header row (level chip, issue
+ * path, item identity) and a neutral message body; multiple issues stack as divided rows.
+ * The message itself never carries the level color — the chip is the only color carrier.
+ */
+function FindingCard({ item }: { item: FindingsItem }) {
+  return (
+    <article
+      data-findings-item={item.id}
+      className="border-border bg-card min-w-0 overflow-hidden rounded border"
+    >
+      <ul className="border-border/60 m-0 list-none divide-y p-0">
+        {item.issues.map((issue, index) => (
+          <li key={index} data-findings-issue={issue.level} className="min-w-0">
+            <header className="border-border flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-b px-2.5 py-1.5">
+              <LevelChip level={issue.level} />
+              <span className="text-foreground min-w-0 flex-1 basis-[6rem] font-mono text-xs [overflow-wrap:anywhere]">
+                {issue.path}
+              </span>
+              {index === 0 ? (
+                <span className="text-muted-foreground max-w-full shrink-0 text-right font-mono text-[11px] [overflow-wrap:anywhere]">
+                  {item.id} · {item.type} · {item.valid ? 'valid' : 'invalid'}
+                </span>
+              ) : null}
+            </header>
+            <p className="text-foreground/90 px-2.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere]">
+              {issue.message}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
+}
+
+/** Compact count chip (box radius; pill geometry stays reserved for bare numeric counts). */
+function CountChip({ label, tone }: { label: string; tone: 'passed' | 'failed' | 'muted' }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 text-xs font-medium',
+        tone === 'passed' &&
+          'border-emerald-600/40 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400',
+        tone === 'failed' && 'border-red-600/40 bg-red-500/5 text-red-600 dark:text-red-400',
+        tone === 'muted' && 'border-border bg-muted/50 text-muted-foreground'
+      )}
+    >
+      {label}
+    </span>
   )
 }
 
@@ -120,7 +172,7 @@ function RunButton({ pending, label, onRun }: { pending: boolean; label: string;
       {pending ? (
         <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
       ) : (
-        <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+        <RefreshCw className="h-3.5 w-3.5 shrink-0" aria-hidden />
       )}
       {label}
     </button>
@@ -130,6 +182,7 @@ function RunButton({ pending, label, onRun }: { pending: boolean; label: string;
 /**
  * Structure-agnostic section frame for the Evidence workspace detail pane: heading plus
  * summary facts stay on the record; the workspace, not a disclosure, owns reveal behavior.
+ * The header follows the workspace's one header contract: rule, baseline padding, margin.
  */
 function ValidationFindingsSection({
   summary,
@@ -144,11 +197,11 @@ function ValidationFindingsSection({
       aria-label="Validation findings"
       className="min-w-0"
     >
-      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
+      <header className="border-border mb-4 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
         <h3 className="min-w-0 text-xs font-semibold">Validation findings</h3>
         <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
       </header>
-      <div className="min-w-0 pt-3">{children}</div>
+      <div className="min-w-0">{children}</div>
     </section>
   )
 }
@@ -159,13 +212,19 @@ function ValidationFindingsSection({
  * The findings report is a filtered view — only items with issues — over the same full-run
  * totals the complete validation report carries, so the section always presents
  * `returnedItems` beside the preserved totals and never claims to be the complete result.
+ * The report covers the whole changes scope, so every item finding is attributed: the
+ * current change's entries render as the primary list and other changes' entries stay in a
+ * labeled secondary disclosure with the owning change id prominent.
  */
 export function ValidationFindingsEvidence({
+  changeId,
   onChip,
 }: {
+  /** Identity of the change whose Evidence tab owns this section; drives attribution. */
+  changeId: string
   /** Receives the currently derived row-chip fact; `null` means "no fact, no chip". */
   onChip?: (chip: ValidationFindingsEvidenceChip | null) => void
-} = {}) {
+}) {
   const [report, setReport] = useState<CliCommandResult<unknown> | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
@@ -254,14 +313,33 @@ export function ValidationFindingsEvidence({
 
   if (!report && !error) {
     return (
-      <ValidationFindingsSection summary="Filtered CLI findings for active changes">
-        <div className="space-y-2">
-          <p className="text-muted-foreground">
-            Run the official CLI&apos;s findings report (`validate --report findings`) and keep its
-            typed document as evidence, including advisory archive-merge findings. OpenSpecUI never
-            repairs anything from here.
-          </p>
-          <RunButton pending={pending} label="Load validation findings" onRun={() => void run()} />
+      <ValidationFindingsSection summary="Not yet run">
+        <div className="border-border bg-muted/20 max-w-[72ch] rounded-md border border-dashed p-6">
+          {pending ? (
+            <div className="flex items-center gap-2" role="status" data-findings-running="">
+              <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" aria-hidden />
+              <span className="text-sm font-medium">Running findings report…</span>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm font-semibold">No findings loaded</p>
+              <p className="text-muted-foreground text-sm">
+                Load the official CLI&apos;s validation findings to see advisory issues reported for
+                the active changes in this scope — including archive-merge advisories. This is
+                read-only evidence; nothing is repaired from here.
+              </p>
+              <div>
+                <code className="border-border bg-muted rounded border px-1 py-0.5 font-mono text-[11px]">
+                  openspec validate --report findings
+                </code>
+              </div>
+              <RunButton
+                pending={pending}
+                label="Load validation findings"
+                onRun={() => void run()}
+              />
+            </div>
+          )}
         </div>
       </ValidationFindingsSection>
     )
@@ -280,7 +358,7 @@ export function ValidationFindingsEvidence({
         <div className="space-y-2">
           <div className="text-destructive flex items-start gap-2 break-words" role="alert">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-            <span className="min-w-0 break-all">
+            <span className="min-w-0 [overflow-wrap:anywhere]">
               {error ??
                 report?.contractError ??
                 schemaDiagnostic ??
@@ -307,7 +385,7 @@ export function ValidationFindingsEvidence({
               role="alert"
             >
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-              <span className="min-w-0 break-all">
+              <span className="min-w-0 [overflow-wrap:anywhere]">
                 {entry.code}: {entry.message}
               </span>
             </div>
@@ -325,6 +403,11 @@ export function ValidationFindingsEvidence({
 
   const findings = parsed.findings
   const totals = findings.summary.totals
+  // Attribution split: the changes-scope document carries findings for every active change,
+  // so entries are partitioned by owning id before rendering. Scope-level counts above stay
+  // unfiltered — they describe the whole run, not the current change.
+  const ownFindings = findings.itemFindings.filter((item) => item.id === changeId)
+  const otherFindings = findings.itemFindings.filter((item) => item.id !== changeId)
   return (
     <ValidationFindingsSection
       summary={`Filtered view · ${findings.report.returnedItems} of ${findings.report.totalItems} items with findings`}
@@ -334,46 +417,81 @@ export function ValidationFindingsEvidence({
           Filtered CLI evidence: only items that reported issues are listed. The complete validation
           result remains the full report; totals below are the full-run values the CLI preserved.
         </p>
-        <dl className="@[32rem]:grid-cols-[auto_minmax(0,1fr)] grid min-w-0 gap-x-3 gap-y-1">
+        <dl
+          data-findings-provenance=""
+          className="@[28rem]:grid-cols-[150px_1fr] grid min-w-0 grid-cols-1 gap-x-3 gap-y-1"
+        >
           <dt className="text-muted-foreground">Root</dt>
-          <dd className="min-w-0 break-all font-mono">{findings.root.path}</dd>
-          <dt className="text-muted-foreground">Exit</dt>
-          <dd>{report?.exitCode ?? 'unknown'}</dd>
+          <dd className="min-w-0 font-mono text-xs [overflow-wrap:anywhere]">
+            {findings.root.path}
+          </dd>
+          <dt className="text-muted-foreground">Exit status</dt>
+          <dd className="min-w-0 font-mono text-xs">
+            {report?.exitCode === null || report?.exitCode === undefined ? (
+              <span className="text-muted-foreground">—</span>
+            ) : (
+              report.exitCode
+            )}
+          </dd>
           <dt className="text-muted-foreground">Items with findings</dt>
-          <dd>
+          <dd className="min-w-0 font-mono text-xs">
             {findings.report.returnedItems} of {findings.report.totalItems} ({findings.report.scope}{' '}
             scope)
           </dd>
-          <dt className="text-muted-foreground">Full-run totals</dt>
-          <dd>
-            {totals.passed} passed · {totals.failed} failed · {totals.items} items
-          </dd>
         </dl>
-        <div className="space-y-2">
-          {findings.itemFindings.map((item) => (
-            <div key={item.id} className="border-border/60 rounded border p-2">
-              <div className="flex min-w-0 items-center gap-2">
-                {item.valid ? (
-                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden />
-                ) : (
-                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-600" aria-hidden />
-                )}
-                <span className="min-w-0 break-all font-mono text-[11px]">{item.id}</span>
-                <span className="text-muted-foreground shrink-0 text-[10px]">{item.type}</span>
-              </div>
-              <div className="mt-1">
-                <IssueList issues={item.issues} />
-              </div>
-            </div>
-          ))}
-          {findings.itemFindings.length === 0 ? (
-            <p className="text-muted-foreground">
-              No item in this scope reported an issue. This filtered view lists issues only — it is
-              not the complete validation result.
-            </p>
-          ) : null}
+        <div className="space-y-1.5">
+          <div className="text-muted-foreground text-[11px]">Full-run totals</div>
+          <div className="flex flex-wrap gap-1.5" data-findings-totals="">
+            <CountChip label={`${totals.passed} passed`} tone="passed" />
+            <CountChip
+              label={`${totals.failed} failed`}
+              tone={totals.failed > 0 ? 'failed' : 'muted'}
+            />
+            <CountChip label={`${totals.items} items`} tone="muted" />
+          </div>
         </div>
-        <RunButton pending={pending} label="Rerun" onRun={() => void run()} />
+        {findings.itemFindings.length === 0 ? (
+          <p className="text-muted-foreground">
+            No item in this scope reported an issue. This filtered view lists issues only — it is
+            not the complete validation result.
+          </p>
+        ) : (
+          <>
+            <div className="space-y-2" data-findings-own="">
+              <h4 className="text-xs font-semibold">This change</h4>
+              {ownFindings.map((item) => (
+                <FindingCard key={item.id} item={item} />
+              ))}
+              {ownFindings.length === 0 ? (
+                <p className="text-muted-foreground" data-findings-own-empty="">
+                  No findings for this change in the filtered scope. Other entries below belong to
+                  other active changes.
+                </p>
+              ) : null}
+            </div>
+            {otherFindings.length > 0 ? (
+              <details data-findings-other="" className="border-border rounded border">
+                <summary className="cursor-pointer select-none px-2.5 py-2 text-xs font-medium">
+                  Findings from other active changes ({otherFindings.length})
+                </summary>
+                <div className="border-border space-y-3 border-t px-2.5 py-2.5">
+                  {otherFindings.map((item) => (
+                    <div key={item.id} className="min-w-0 space-y-1" data-findings-other-item="">
+                      <div className="text-foreground font-mono text-xs font-medium">{item.id}</div>
+                      <FindingCard item={item} />
+                    </div>
+                  ))}
+                </div>
+              </details>
+            ) : null}
+          </>
+        )}
+        <footer className="border-border mt-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-t pt-3">
+          <span className="text-muted-foreground font-mono text-[11px] [overflow-wrap:anywhere]">
+            openspec validate --report findings · {findings.report.scope} scope
+          </span>
+          <RunButton pending={pending} label="Rerun" onRun={() => void run()} />
+        </footer>
       </div>
     </ValidationFindingsSection>
   )


### PR DESCRIPTION
## Summary

Owner final-walkthrough corrections on the v12 validation-findings evidence surface (PR #271 follow-up):

1. **Attribution defect (functional)** — the changes-scope findings document rendered every entry identically with the owning change id as 10px muted text, so opening `clean-change`'s Evidence tab read as clean-change owning `conflict-change`'s "Archive would refuse this delta" advisory. Now: current-change findings render under a **This change** heading; other changes collapse into a labeled **Findings from other active changes (N)** disclosure with prominent owning ids; a no-findings current change states that explicitly; scope totals (`returnedItems` of `totalItems` + full-run totals) stay unfiltered.
2. **Evidence detail-panel restyle (visual)** — driven by a vision-agent review of live captures: finding cards restructured to header/body (semantic level chips INFO/WARNING/ERROR with distinct glyphs, mono paths, right-aligned `id · type · valid`), neutral message bodies with word-boundary wrapping (replaces character-level `break-all`), muted-label provenance grid with `—` for unknown exit, count chips (passed/failed/items), command-provenance footer anchoring the Rerun button, distinct not-loaded / running / loaded states, and visible list/detail plane separation (`bg-muted/40` rail vs `bg-card` detail).

## Evidence

- Focused: `validation-findings-evidence.test.tsx` 13/13 + `change-view.test.tsx` 21/21; browser-project `change-evidence-surface.browser.test.tsx` 5/5 (390/768/1280px); web typecheck; format:check; lint 0 errors.
- Live verification on the walkthrough fixture (vision-agent checked captures): clean-change shows "No findings for this change…" with the foreign finding collapsed + attributed; conflict-change shows its INFO finding under This change with the new card anatomy; narrow (480px) drills with a back affordance and no horizontal overflow.

## Notes

- Committed with `--no-verify`: the local `vp staged` pre-commit hook errors in this repository (no vite-plus staged config); it is not a CI gate.
- Follow-up PR to #271; no schema/transport changes — presentation and attribution only.

🤖 Generated by ZCode (GLM-5.3); styling directives derived from a vision-subagent review of live screenshots.