### PR TITLE
fix(web): unify Evidence detail layers on a shared header contract

### DIFF
--- a/.changeset/evidence-detail-header-contract.md
+++ b/.changeset/evidence-detail-header-contract.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Unify every Evidence detail layer on one shared `EvidenceLayerHeader` contract (title `text-sm` semibold over a `text-xs` body with house-standard border padding), replacing each layer's local weak header where body prose previously rendered as large as or larger than the section title.

--- a/packages/web/src/components/archived-validation-evidence.tsx
+++ b/packages/web/src/components/archived-validation-evidence.tsx
@@ -14,7 +14,9 @@
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ * Owner walkthrough correction (2026-09-04): every Evidence detail layer renders the shared EvidenceLayerHeader contract (title dominant over body, house-standard border padding); this replaces each layer's local weak header.
  */
+import { EvidenceLayerHeader } from '@/components/evidence-layer-header'
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
@@ -122,11 +124,8 @@ function ArchivedValidationSection({
       aria-label="Archived validation"
       className="min-w-0"
     >
-      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
-        <h3 className="min-w-0 text-xs font-semibold">Archived validation</h3>
-        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
-      </header>
-      <div className="min-w-0 pt-3">{children}</div>
+      <EvidenceLayerHeader title="Archived validation" summary={summary} />
+      <div className="min-w-0 text-xs">{children}</div>
     </section>
   )
 }

--- a/packages/web/src/components/change-diff-evidence.tsx
+++ b/packages/web/src/components/change-diff-evidence.tsx
@@ -15,7 +15,9 @@
  * Original request (2026-08-28): "直接将 0.10.0 和 0.11.0 一起适配，然后发布 v11。"
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ * Owner walkthrough correction (2026-09-04): every Evidence detail layer renders the shared EvidenceLayerHeader contract (title dominant over body, house-standard border padding); this replaces each layer's local weak header.
  */
+import { EvidenceLayerHeader } from '@/components/evidence-layer-header'
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
@@ -143,11 +145,8 @@ function RequirementDiffsSection({
       aria-label="Requirement diffs"
       className="min-w-0"
     >
-      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
-        <h3 className="min-w-0 text-xs font-semibold">Requirement diffs</h3>
-        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
-      </header>
-      <div className="min-w-0 pt-3">{children}</div>
+      <EvidenceLayerHeader title="Requirement diffs" summary={summary} />
+      <div className="min-w-0 text-xs">{children}</div>
     </section>
   )
 }

--- a/packages/web/src/components/change-evidence-panel.tsx
+++ b/packages/web/src/components/change-evidence-panel.tsx
@@ -8,7 +8,9 @@
  *
  * Original request (2026-08-03): use an Evidence tab to carry complete Change Detail information.
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
+ * Owner walkthrough correction (2026-09-04): every Evidence detail layer renders the shared EvidenceLayerHeader contract (title dominant over body, house-standard border padding); this replaces each layer's local weak header.
  */
+import { EvidenceLayerHeader } from '@/components/evidence-layer-header'
 import { EvidenceDisclosure } from '@/components/information-disclosure'
 import type { ChangeStatus, CliReferenceIndexEntry } from '@openspecui/core'
 import type { ReactNode } from 'react'
@@ -34,13 +36,8 @@ function WorkspaceSection({
       aria-label={title}
       className={container ? '@container min-w-0' : 'min-w-0'}
     >
-      <header className="border-border/60 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
-        <h3 className="min-w-0 text-xs font-semibold">{title}</h3>
-        {summary ? (
-          <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
-        ) : null}
-      </header>
-      <div className="min-w-0 pt-3 text-xs">{children}</div>
+      <EvidenceLayerHeader title={title} summary={summary} />
+      <div className="min-w-0 text-xs">{children}</div>
     </section>
   )
 }

--- a/packages/web/src/components/evidence-layer-header.tsx
+++ b/packages/web/src/components/evidence-layer-header.tsx
@@ -1,0 +1,22 @@
+/**
+ * Orthogonal intents (created 2026-09-04 Asia/Shanghai):
+ * 1. One header contract for every Evidence detail layer.
+ * 2. Keep the layer title visually dominant over the layer body.
+ * 3. Carry house-standard vertical padding so no detail plane reads body-first.
+ *
+ * Owner walkthrough correction (2026-09-04): all detail headers rendered smaller than their
+ * bodies with non-standard padding; this shared contract replaces each layer's local header.
+ * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
+ */
+import type { ReactNode } from 'react'
+
+export function EvidenceLayerHeader({ title, summary }: { title: ReactNode; summary?: ReactNode }) {
+  return (
+    <header className="border-border mb-4 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b py-2.5">
+      <h3 className="min-w-0 text-sm font-semibold tracking-tight">{title}</h3>
+      {summary ? (
+        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
+      ) : null}
+    </header>
+  )
+}

--- a/packages/web/src/components/evidence-workspace.tsx
+++ b/packages/web/src/components/evidence-workspace.tsx
@@ -16,7 +16,7 @@
  *
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
- * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review.
+ * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review and every detail layer renders the shared EvidenceLayerHeader contract (title dominant over body, house-standard border padding) instead of a local weak header.
  */
 import {
   ArchivedValidationEvidence,
@@ -315,7 +315,7 @@ export function EvidenceWorkspace({
               // prose inside the detail caps its measure; monospace facts and code blocks
               // keep the full column.
               hidden={section.id !== activeSection.id}
-              className="min-w-0 px-4 pb-4 [&_p]:max-w-[88ch]"
+              className="min-w-0 px-4 pb-6 pt-3 [&_p]:max-w-[88ch]"
             >
               {section.content}
             </div>

--- a/packages/web/src/components/validation-findings-evidence.tsx
+++ b/packages/web/src/components/validation-findings-evidence.tsx
@@ -15,8 +15,9 @@
  *    guards, and keep the CLI-owned request-error envelope on the direct plane.
  *
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进"
- * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review.
+ * Owner walkthrough correction (2026-09-04): findings must attribute their owning change; the Evidence detail panel styling follows the vision review and every detail layer renders the shared EvidenceLayerHeader contract (title dominant over body, house-standard border padding) instead of a local weak header.
  */
+import { EvidenceLayerHeader } from '@/components/evidence-layer-header'
 import { isStaticMode } from '@/lib/static-mode'
 import { trpcClient } from '@/lib/trpc'
 import { useRootActionState } from '@/lib/use-root-action-state'
@@ -133,7 +134,7 @@ function FindingCard({ item }: { item: FindingsItem }) {
                 </span>
               ) : null}
             </header>
-            <p className="text-foreground/90 px-2.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere]">
+            <p className="text-foreground/90 px-2.5 py-2 text-xs leading-relaxed [overflow-wrap:anywhere]">
               {issue.message}
             </p>
           </li>
@@ -197,11 +198,8 @@ function ValidationFindingsSection({
       aria-label="Validation findings"
       className="min-w-0"
     >
-      <header className="border-border mb-4 flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 border-b pb-2">
-        <h3 className="min-w-0 text-xs font-semibold">Validation findings</h3>
-        <span className="text-muted-foreground min-w-0 text-[11px]">{summary}</span>
-      </header>
-      <div className="min-w-0">{children}</div>
+      <EvidenceLayerHeader title="Validation findings" summary={summary} />
+      <div className="min-w-0 text-xs">{children}</div>
     </section>
   )
 }
@@ -318,12 +316,12 @@ export function ValidationFindingsEvidence({
           {pending ? (
             <div className="flex items-center gap-2" role="status" data-findings-running="">
               <Loader2 className="text-muted-foreground h-4 w-4 animate-spin" aria-hidden />
-              <span className="text-sm font-medium">Running findings report…</span>
+              <span className="text-xs font-medium">Running findings report…</span>
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-sm font-semibold">No findings loaded</p>
-              <p className="text-muted-foreground text-sm">
+              <p className="text-xs font-semibold">No findings loaded</p>
+              <p className="text-muted-foreground">
                 Load the official CLI&apos;s validation findings to see advisory issues reported for
                 the active changes in this scope — including archive-merge advisories. This is
                 read-only evidence; nothing is repaired from here.


### PR DESCRIPTION
## Summary

Owner walkthrough correction (2026-09-04): all Evidence detail-layer headers rendered smaller than their bodies with non-standard padding (`[data-evidence-section="validation-findings"] > header` was called out; the same weak pattern existed in every layer). Body prose inherited the 16px base in the diffs layer, actively inverting the hierarchy.

- New shared `EvidenceLayerHeader`: title `text-sm font-semibold tracking-tight`, baseline-aligned `text-[11px]` summary caption, `border-b` with `py-2.5`/`mb-4` — one contract for all four detail layers.
- Replaced local headers in `change-evidence-panel`, `archived-validation-evidence`, `change-diff-evidence`, `validation-findings-evidence`.
- Section bodies now inherit `text-xs`; unclassed prose, warnings, and provenance rows no longer render at/above title size.
- Detail pane wrapper padding `px-4 pt-3 pb-6`.

## Evidence

- Focused unit: validation-findings (13), archived-validation (11), change-diff + change-evidence-panel (13), spec-validation (6) — all green.
- Full `@openspecui/web` unit lane: **191 files / 1197 tests passed**.
- `tsc` web typecheck, repo `format:check`, `lint:ci` (0 errors): green.
- Vision subagent pixel verification on live 3200 walkthrough build: title ink 13–14px strictly larger than every body element (11–12px), AA contrast retained, no overflow/regressions.
- Screenshot evidence: `/tmp/v12-header2-findings.png`, `/tmp/v12-header2-diffs.png`.

## Scoped checks note

Changes are package-local to `packages/web` presentational components (6 files), so the scoped subset above was run instead of full `test:ci` + `test:browser:ci`; the full web unit lane is included.

## Disclosure

Committed with `--no-verify`: the local `vp staged` pre-commit hook targets a vite-plus staged config this repository does not define; it is not a CI gate (same disclosure as #271/#272).