### PR TITLE
fix(website): mobile audit fixes — hooks code overflow + mid-page reveal

### DIFF
--- a/packages/website/src/lib/components/hook-reference.svelte
+++ b/packages/website/src/lib/components/hook-reference.svelte
@@ -1,3 +1,18 @@
+<!--
+Orthogonal intents (updated 2026-09-06 Asia/Shanghai):
+1. Render one hook's contract card: header, signature, when-to-use, stable-for list.
+2. Scroll affordance for the example code block: the mobile audit (2026-09-06)
+   confirmed the Shiki container IS scrollable but gives zero rest-state hint —
+   long lines hard-clip at the right border. The veil recipe below is the
+   registry code-card's (V1-8/V2-8) subtraction-ink dialect: a non-scrolling
+   wrapper hosts start/end edge veils (backdrop contrast pulls the backdrop
+   toward mid tone — never adds black; the mask ramp shapes the range) that
+   appear only while that direction can still scroll. The flags are
+   template-bound classes, NOT runtime attributes — svelte prunes attribute
+   selectors that never appear in compiled markup (verified live 2026-09-06).
+
+Original request (2026-09-06): 移动端审计 P1 — hooks 页代码块长行右缘截断、无滚动提示。
+-->
 <script lang="ts">
   import type { HookDoc } from '$lib/i18n/schema'
 
@@ -6,6 +21,32 @@
   }
 
   let { hook }: Props = $props()
+
+  // Veil flags: recompute from scroll events + geometry changes (the
+  // ResizeObserver also catches font load / container resizes). jsdom has no
+  // ResizeObserver — the guard keeps the vitest render path alive.
+  let scrollerEl = $state<HTMLElement | undefined>()
+  let veilStart = $state(false)
+  let veilEnd = $state(false)
+
+  $effect(() => {
+    const scroller = scrollerEl
+    if (!scroller) return
+    const sync = () => {
+      veilStart = scroller.scrollLeft > 1
+      veilEnd = scroller.scrollLeft + scroller.clientWidth < scroller.scrollWidth - 1
+    }
+    sync()
+    scroller.addEventListener('scroll', sync, { passive: true })
+    const ro = typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(sync)
+    ro?.observe(scroller)
+    const codeBox = scroller.querySelector('code')
+    if (codeBox) ro?.observe(codeBox)
+    return () => {
+      scroller.removeEventListener('scroll', sync)
+      ro?.disconnect()
+    }
+  })
 </script>
 
 <article class="border-border bg-card min-w-0 border shadow-sm">
@@ -50,16 +91,62 @@
     </div>
 
     {#if hook.exampleHtml}
-      <div
-        class="shiki-code border-border overflow-x-auto border text-[12px] leading-5"
-      >
-        <!-- Shiki HTML is generated at build time from repository-owned hook examples. -->
-        {@html hook.exampleHtml}
+      <div class="code-veil-host relative" class:veil-start={veilStart} class:veil-end={veilEnd}>
+        <div
+          class="shiki-code border-border overflow-x-auto border text-[12px] leading-5"
+          bind:this={scrollerEl}
+        >
+          <!-- Shiki HTML is generated at build time from repository-owned hook examples. -->
+          {@html hook.exampleHtml}
+        </div>
       </div>
     {:else}
-      <pre
-        class="bg-terminal text-terminal-foreground overflow-x-auto px-3 py-3 text-[12px] leading-5"
-      ><code>{hook.example}</code></pre>
+      <div class="code-veil-host relative" class:veil-start={veilStart} class:veil-end={veilEnd}>
+        <pre
+          class="bg-terminal text-terminal-foreground overflow-x-auto px-3 py-3 text-[12px] leading-5"
+          bind:this={scrollerEl}
+        ><code>{hook.example}</code></pre>
+      </div>
     {/if}
   </div>
 </article>
+
+<style>
+  /* Subtraction-ink edge veils (the registry code-card recipe, 2026-09-02):
+   * backdrop contrast(0.5) pulls whatever paints behind the strip toward mid
+   * tone — light themes darken, dark themes lighten, zero color tokens — and
+   * the mask ramp fades the effect toward the content. The veils sit on the
+   * non-scrolling wrapper so they stay pinned while the inner scroller moves. */
+  .code-veil-host::before,
+  .code-veil-host::after {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    inline-size: 1.75rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 150ms ease-out;
+    backdrop-filter: contrast(0.5);
+    -webkit-backdrop-filter: contrast(0.5);
+  }
+  .code-veil-host::before {
+    inset-inline-start: 0;
+    mask-image: linear-gradient(to right, rgb(0 0 0), transparent);
+    -webkit-mask-image: linear-gradient(to right, rgb(0 0 0), transparent);
+  }
+  .code-veil-host::after {
+    inset-inline-end: 0;
+    mask-image: linear-gradient(to left, rgb(0 0 0), transparent);
+    -webkit-mask-image: linear-gradient(to left, rgb(0 0 0), transparent);
+  }
+  .code-veil-host.veil-start::before,
+  .code-veil-host.veil-end::after {
+    opacity: 1;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .code-veil-host::before,
+    .code-veil-host::after {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/website/src/lib/components/hook-reference.test.ts
+++ b/packages/website/src/lib/components/hook-reference.test.ts
@@ -24,4 +24,17 @@ describe('HookReference', () => {
 
     expect(screen.getByText('highlighted')).toBeVisible()
   })
+
+  it('wraps the example scroller in the edge-veil host', () => {
+    render(HookReference, {
+      hook: {
+        ...en.hooks.onReadDocument,
+        exampleHtml: '<pre class="shiki"><code>highlighted</code></pre>',
+      },
+    })
+
+    const host = document.querySelector('.code-veil-host')
+    expect(host).not.toBeNull()
+    expect(host?.querySelector('.shiki-code')).not.toBeNull()
+  })
 })

--- a/packages/website/src/routes/[lang=locale]/+layout.svelte
+++ b/packages/website/src/routes/[lang=locale]/+layout.svelte
@@ -4,6 +4,9 @@ Orthogonal intents (updated 2026-09-06 Asia/Shanghai):
    theme-toggle) around the locale pages; header/footer/theme-switcher
    hand-rolled components retired with the registry adoption.
 2. Keep language-switcher project-owned (it rides the header switcher slot).
+3. Mobile-fit the switcher slot (2026-09-06 audit): compact icon theme
+   toggle below sm — the labeled full toggle + switcher + hamburger
+   overflowed the bar at ≤390px (hamburger clipped off-screen).
 
 Original request (2026-09-06): 官网接入 @jixoai registry（jixoai-ui 0.3.0）。
 -->
@@ -56,8 +59,20 @@ Original request (2026-09-06): 官网接入 @jixoai registry（jixoai-ui 0.3.0�
     </NavigationMenu>
 
     {#snippet switcher()}
+      <!-- Mobile audit fix (2026-09-06): the labeled `full` toggle + language
+           switcher + hamburger measured 365px of right-wing width — at 390px
+           and below the wing (flex-none) pushed the hamburger off-screen and
+           gave the document horizontal overflow. Below sm the wing carries the
+           compact `icon` toggle instead (the registry family form: one compact
+           control in the bar); the labeled segmented control returns ≥sm.
+           CSS-toggled twins — no JS breakpoint, no hydration flash. -->
       <div class="flex flex-wrap items-center gap-2">
-        <ThemeToggle variant="full" />
+        <span class="hidden sm:inline-flex">
+          <ThemeToggle variant="full" />
+        </span>
+        <span class="sm:hidden">
+          <ThemeToggle variant="icon" />
+        </span>
         <LanguageSwitcher {content} {lang} {pathname} />
       </div>
     {/snippet}


### PR DESCRIPTION
## 活体复查结论（390px，本机 Chromium + playwright-core）

| 审查发现 | 复核结论 | 处置 |
| --- | --- | --- |
| P1-1 hooks 页代码块长行右缘截断 | **真问题（半真）**：Shiki 容器本就可横向滚动（scrollW 648/1022 vs clientW 322），但 overlay-scrollbar 系统零静止提示，长行硬切在右边框 | 减色墨律边缘纱罩（registry code-card 配方） |
| P1-2 首页中段空白 + 空盒子 + 页尾 hero 复现 | **截图伪影**：fullPage 拼接在 scrollY=0 求值 scroll-driven view() 时间线，折叠线下 reveal 内容按设计处于 opacity 0；活体高视口（明/暗）0 个隐藏元素、正常视口步进滚动全部 opacity 1；页尾大字是 terminal-footer 的 ghost wordmark（家族收尾件，有意设计） | 无代码改动，证据见下 |
| P2 移动端 header 堆叠 | **真问题（形态不同）**：并非三行堆叠，实测 72px 单行，但 full 主题切换 + 语言切换 + 汉堡合计 365px 右翼，≤390px 时汉堡被裁出屏、文档横向溢出（scrollW 397） | <sm 收敛为 icon 变体（家族形态） |
| P2 zh header "System" 未汉化 | **锁定件**：label 硬编码于 registry 锁定的 theme-toggle（jixoai-ui.lock），不可改 | 记录摩擦，跳过 |

## 修复内容

**hook-reference.svelte**（site 自有件）
- 代码块外包一层非滚动 wrapper，::before/::after 边缘纱罩：`backdrop-filter: contrast(0.5)`（近白压暗、近黑提亮，零颜色 token，明暗主题天然互反）+ mask 渐变塑形——registry code-card 的减色墨律方言，非加黑
- 纱罩仅在对应方向仍可滚动时出现：scroll 事件 + ResizeObserver 重算标志
- 标志用模板绑定 class 而非运行时 attribute——svelte 会剪除编译产物中从未出现的 attribute 选择器（dev 环境活体实测确认此剪除）
- `prefers-reduced-motion: reduce` 下纱罩过渡关闭
- 新增结构回归测试（veil host 包裹关系）

**[lang=locale]/+layout.svelte**（site 自有件）
- switcher snippet 响应式双生：<sm 渲染 `ThemeToggle variant="icon"`（单一紧凑控件，registry 家族形态：ui 官网 switcher 槽即单 HuePopover），≥sm 恢复 full 文字分段控件；CSS 切换，无 JS 断点、无水合闪烁
- 修复后 320–900px 全宽扫描：无横向溢出、汉堡无裁切、header 单行 63px（320 极限时品牌两行 72px，锁定件内行为，可接受）

## 构建证据
- `pnpm typecheck`：0 errors（3 个警告均为锁定件 terminal-header 既有项）
- `pnpm test`：21/21 通过
- `pnpm build`：vite build + adapter-static + llms-txt（4 pages → 8 files）全绿
- 产物级活体复验（vite preview）：纱罩 opacity/backdrop 生效、双向切换正确、header 320–900px 无溢出、明暗高视口 0 隐藏 reveal

## P1-2 伪影证据（截图方法学）
- `osui-fix-prod-home-tall-light/dark.png`：390×5000 高视口真实渲染，全页内容可见
- `osui-before-home-fullpage.png`：fullPage 拼接复现审计空白（与 vision 截图同构）
- 机理：scroll-driven `animation-timeline: view()` 在 CDP captureBeyondViewport 下按 scrollY=0 求值；真实用户滚动时时间线随滚动推进（步进实测 opacity 1）；no-SDA 引擎与 reduced-motion 由 `@supports`/`animation:none` 兜底可见

## 摩擦日志
1. **锁定件阻断 zh 汉化**：theme-toggle 的 `LABEL` 硬编码 light/dark/system 且无 label props——registry 件应开放 labels/字典 props 或 i18n 槽位（建议回馈 @jixoai registry）
2. **pre-commit hook 失修**：core.hooksPath 指向 example/.vite-hooks/_，viteplus 要求 vite.config.ts 含 staged 配置但仓库从未提供，任何提交都被迫 --no-verify（本次验证以手动 typecheck/test/build 补偿）
3. **Svelte CSS 剪除陷阱**：运行时 toggle 的 attribute 选择器会被静默剪除（dev/prod 一致）；skill 的 runtime-verification 章节值得补一条"动态 attribute 选择器必须走模板绑定 class 或 :global"
4. **lightningcss 前缀去重**：产物仅保留 -webkit-backdrop-filter（Blink/WebKit 别名生效，Firefox 标准属性被去重丢弃）——与 registry code-card 产物行为一致，若需 Firefox 纪律需在 registry 层解决

Closes the mobile-audit P1/P2 items for packages/website. packages/web 与 registry 锁定件（src/lib/ui/**、src/lib/jixoai.css）零改动。