### PR TITLE
fix(website): llms generation as a post-build orchestrated step

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@openspecui/website",
-  "version": "12.0.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite --host=127.0.0.1 --port 13006",
-    "build": "vite build",
-    "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "test": "vitest run",
-    "cf:dev": "pnpm build && wrangler pages dev dist",
-    "cf:deploy": "pnpm build && wrangler pages deploy dist --project-name openspecui-website",
-    "cf:project:create": "wrangler pages project create openspecui-website --production-branch main"
-  },
-  "dependencies": {
-    "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@fontsource/share-tech-mono": "^5.2.7",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.4.0"
-  },
-  "devDependencies": {
-    "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.59.1",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@tailwindcss/vite": "^4.2.1",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/svelte": "^5.3.1",
-    "jsdom": "^25.0.1",
-    "lucide-svelte": "^0.472.0",
-    "mdsvex": "^0.12.7",
-    "shiki": "^3.17.0",
-    "svelte": "^5.55.5",
-    "svelte-check": "^4.4.8",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.0",
-    "vitest": "^4.1.0",
-    "wrangler": "^4.72.0"
-  }
+ "name": "@openspecui/website",
+ "version": "12.0.0",
+ "private": true,
+ "type": "module",
+ "scripts": {
+  "dev": "vite --host=127.0.0.1 --port 13006",
+  "build": "vite build && node scripts/llms.mjs",
+  "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+  "test": "vitest run",
+  "cf:dev": "pnpm build && wrangler pages dev dist",
+  "cf:deploy": "pnpm build && wrangler pages deploy dist --project-name openspecui-website",
+  "cf:project:create": "wrangler pages project create openspecui-website --production-branch main"
+ },
+ "dependencies": {
+  "@fontsource-variable/jetbrains-mono": "^5.2.8",
+  "@fontsource/share-tech-mono": "^5.2.7",
+  "clsx": "^2.1.1",
+  "tailwind-merge": "^3.4.0"
+ },
+ "devDependencies": {
+  "@sveltejs/adapter-static": "^3.0.10",
+  "@sveltejs/kit": "^2.59.1",
+  "@sveltejs/vite-plugin-svelte": "^7.1.2",
+  "@tailwindcss/vite": "^4.2.1",
+  "@testing-library/jest-dom": "^6.6.3",
+  "@testing-library/svelte": "^5.3.1",
+  "jsdom": "^25.0.1",
+  "lucide-svelte": "^0.472.0",
+  "mdsvex": "^0.12.7",
+  "shiki": "^3.17.0",
+  "svelte": "^5.55.5",
+  "svelte-check": "^4.4.8",
+  "typescript": "^5.9.3",
+  "vite": "^8.0.0",
+  "vitest": "^4.1.0",
+  "wrangler": "^4.72.0"
+ }
 }

--- a/packages/website/scripts/llms.mjs
+++ b/packages/website/scripts/llms.mjs
@@ -1,0 +1,23 @@
+/*
+ * Orthogonal intents (created 2026-09-06 Asia/Shanghai):
+ * 1. The ONE llms.txt generation point, run AFTER vite build completes
+ *    (orchestrated call, unipty precedent). The plugin-form closeBundle
+ *    raced adapter-static's dist write on cold CI builders (rolldown
+ *    closeBundle ordering) — the orchestrated form is deterministic.
+ *
+ * Config lives here (vite.config.ts no longer wires the plugin).
+ */
+import { generateLlmsTxt } from '../vite-plugins/llms-txt.mjs'
+
+await generateLlmsTxt(new URL('../dist/', import.meta.url).pathname, {
+  siteUrl: 'https://www.openspecui.com',
+  title: 'OpenSpecUI',
+  summary:
+    'OpenSpecUI gives OpenSpec projects a visual frontend and a static documentation site: dashboard, change workflow, config workbench, terminals, and static export.',
+  // the root index is a JS locale redirect — no LLM content lives there
+  exclude: ['404.html', 'index.html'],
+  locale: {
+    segments: ['en', 'zh'],
+    default: 'en',
+  },
+})

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -1,9 +1,10 @@
 /*
  * Orthogonal intents (updated 2026-09-06 Asia/Shanghai):
  * 1. SvelteKit + Tailwind v4 + vitest wiring for the static site build.
- * 2. AI export layer: the @jixoai llms-txt vite plugin (ONE generation
- *    point — runs in the SSR build's closeBundle, after adapter-static
- *    wrote the final dist; en/zh locale mirrors, absolute URLs).
+ * 2. AI export layer moved OUT of the build plugins: the llmsTxt
+ *    closeBundle form raced adapter-static's dist write on cold CI
+ *    builders; generation now runs as a post-build orchestrated step
+ *    (scripts/llms.mjs, the package build script).
  *
  * Original request (2026-09-06): 官网接入 @jixoai registry（jixoai-ui 0.3.0）。
  * The `@openspecui/web-src` alias retired with the palette import.
@@ -13,25 +14,12 @@ import tailwindcss from '@tailwindcss/vite'
 import { svelteTesting } from '@testing-library/svelte/vite'
 import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
-import { llmsTxt } from './vite-plugins/llms-txt.mjs'
 
 export default defineConfig({
   plugins: [
     sveltekit(),
     tailwindcss(),
     svelteTesting(),
-    llmsTxt({
-      siteUrl: 'https://www.openspecui.com',
-      title: 'OpenSpecUI',
-      summary:
-        'OpenSpecUI gives OpenSpec projects a visual frontend and a static documentation site: dashboard, change workflow, config workbench, terminals, and static export.',
-      // the root index is a JS locale redirect — no LLM content lives there
-      exclude: ['404.html', 'index.html'],
-      locale: {
-        segments: ['en', 'zh'],
-        default: 'en',
-      },
-    }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
Follow-up to #278: the llmsTxt() closeBundle form raced adapter-static's dist write on cold CI builders (rolldown closeBundle ordering — deterministic on warm local dist, failed on cold CI). Generation moves to scripts/llms.mjs run after vite build (unipty orchestrated precedent). Cold build + typecheck + tests verified locally.