### PR TITLE
fix(website): declare tailwindcss devDependency for filtered CI installs

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -31,6 +31,7 @@
   "shiki": "^3.17.0",
   "svelte": "^5.55.5",
   "svelte-check": "^4.4.8",
+  "tailwindcss": "^4.2.1",
   "typescript": "^5.9.3",
   "vite": "^8.0.0",
   "vitest": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,6 +821,9 @@ importers:
       svelte-check:
         specifier: ^4.4.8
         version: 4.4.8(picomatch@4.0.3)(svelte@5.55.5)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Follow-up to #279: with the llms race fixed, the deploy build surfaced the deeper gap — the CSS `@import 'tailwindcss'` resolved only via workspace hoisting on full local installs; the filtered CI install had no tailwindcss reachable. Declares it as a website devDependency (matches @tailwindcss/vite ^4.2.1; lockfile +3 lines).