### PR TITLE
Walkthrough UX polish: collapsible Apply readiness summary + unified Change display title

### DIFF
--- a/.changeset/walkthrough-v13-ux-polish.md
+++ b/.changeset/walkthrough-v13-ux-polish.md
@@ -1,0 +1,5 @@
+---
+'@openspecui/web': patch
+---
+
+Walkthrough UX polish for the OpenSpecUI 13 Apply readiness guidance and Change titles: the Apply warnings/build-order notices collapse into one always-visible summary row (warning count + build-order chain + `openspec instructions apply` attribution) whose verbatim upstream evidence is one explicit expansion away, restoring the page to advisory-free default height while keeping direct-plane discovery; and every Change surface (Changes list, Dashboard rows, Change Detail header) now derives one shared display title — an informative proposal heading wins, generic `# Proposal` scaffold headings and parser-less rows fall back to the change id — ending the list/detail title mismatch.

--- a/openspec/changes/target-openspec-cli-113-line/loop/implementation.md
+++ b/openspec/changes/target-openspec-cli-113-line/loop/implementation.md
@@ -177,6 +177,21 @@ dispositioned:
 4. **N4 (fixed)**: `agent-command-content.test.ts` and `tool-init-state.test.ts` now state that their
    openspec-cli-112 generator fixtures are historical/boundary evidence; positive v13 acceptance lives
    in the official-cli-v13 suites.
+- Owner walkthrough round (2026-09-12, post-merge): functional acceptance PASSED; two UX defects
+  filed and fixed on `fix/walkthrough-v13-ux` (branched off merged main):
+  1. The always-expanded Apply warnings/build-order blocks consumed the Change Detail page.
+     `ApplyProgressNotice` now renders ONE collapsible summary row (`data-apply-notice="summary"`:
+     warning count + full build-order chain + CLI attribution, `role="status"`, default collapsed)
+     whose expansion reveals the verbatim upstream evidence on the same direct plane
+     (`warnings`/`build-order` detail anchors preserved); divergence stays a direct uncollapsed
+     block. Spec delta updated to codify the summary-row contract; notice + route tests rewritten
+     (51/51 focused green).
+  2. Title mismatch: the Changes list titled rows with the legacy parser's proposal H1 (the
+     scaffold's generic "# Proposal"), while Change Detail titled with the CLI status changeName
+     (= id). New shared `changeDisplayTitle(id, name)` (web lib): an informative H1 wins, generic
+     `proposal` headings / blank / id-equal values fall back to the change id. Wired into
+     change-list rows + VT handoff, dashboard rows, and the Change Detail header (rows name with
+     status changeName as pre-rows fallback). Helper unit tests added.
 - Post-review CI fix (first PR check run): all three failing gates traced to one step —
   `scripts/prepare-openspec-reference.mjs` installed the submodule with `--ignore-workspace`, which
   blinds pnpm to the submodule's own `pnpm-workspace.yaml`; upstream 1.13.0 moved its dependency

--- a/openspec/changes/target-openspec-cli-113-line/specs/opsx-workflow-ui/spec.md
+++ b/openspec/changes/target-openspec-cli-113-line/specs/opsx-workflow-ui/spec.md
@@ -43,23 +43,27 @@ SHALL NOT be reused as positive evidence for the current line.
 ### Requirement: Apply Readiness Guidance Surface
 
 Change Detail SHALL present CLI-owned Apply readiness guidance when an admitted OpenSpec CLI session provides
-it. `warnings` SHALL render on the direct plane with CLI provenance and exact upstream text, without hover or
-expansion being required to discover a predicted validation failure. `missingPrerequisites` SHALL render as
-readable build-order next-step evidence, visually distinct from blockers. Both SHALL degrade to the existing
-presentation when the fields are absent, and neither SHALL gate or relabel the Apply action itself.
+it, as ONE always-visible summary row on the direct status plane: the row names the warning count, the
+complete build-order chain, and the owning CLI command, so a predicted validation failure is discoverable
+without hover or expansion while the page is not consumed by advisory prose. The exact upstream warning text
+SHALL remain on the same direct plane behind one explicit expansion of that row (a Tooltip-only surface is
+forbidden). `missingPrerequisites` SHALL stay visually and semantically distinct from blockers. Both SHALL
+degrade to the existing presentation when the fields are absent, and neither SHALL gate or relabel the Apply
+action itself.
 
 #### Scenario: Warning renders on the direct plane
 
 - **GIVEN** an admitted 1.13 session provides Apply Instructions with the no-delta-specs warning
 - **WHEN** Change Detail renders apply guidance
-- **THEN** the warning text SHALL be visible in the direct evidence layer with CLI provenance
-- **AND** it SHALL NOT exist only inside Tooltip or collapsed disclosure content
+- **THEN** one summary row SHALL be visible in the direct evidence layer naming the warning count and CLI
+  provenance without hover
+- **AND** the verbatim warning text SHALL become visible with one explicit expansion on the same plane
 
 #### Scenario: Build-order chain is readable evidence
 
 - **GIVEN** Apply Instructions report `missingPrerequisites`
 - **WHEN** Change Detail renders apply guidance
-- **THEN** the chain SHALL be presented as ordered artifact ids
+- **THEN** the chain SHALL be presented as ordered artifact ids inside the summary row
 - **AND** it SHALL NOT be styled or labeled as a blocker when `state` is `ready`
 
 #### Scenario: Degrade without the fields

--- a/packages/web/src/components/apply-progress-notice.test.tsx
+++ b/packages/web/src/components/apply-progress-notice.test.tsx
@@ -4,8 +4,9 @@
  * 2. Prove compact source counts retain keyboard-reachable explanations.
  * 3. Prove agreement renders one subtitle badge and never a separate block.
  * 4. Prove the divergence notice is absent when the sources agree.
- * 5. Prove OpenSpec 1.13 Apply warnings stay on the direct plane with CLI attribution
- *    and verbatim upstream text, never only inside a Tooltip or collapsed disclosure.
+ * 5. Prove OpenSpec 1.13 Apply guidance renders as ONE always-visible summary row (count +
+ *    build-order chain + CLI attribution) whose verbatim upstream text is one explicit
+ *    expansion away on the same direct plane — never Tooltip-only, never undiscoverable.
  * 6. Prove missingPrerequisites renders as a readable build-order chain distinct from blockers.
  * 7. Prove absent 1.13 fields degrade to the existing presentation with no synthesized state.
  *
@@ -13,6 +14,8 @@
  * Original request (2026-07-28): supporting 6.x evidence should use Badge + Tooltip or Accordion.
  * Original request (2026-08-15): Owner walkthrough: agreement is one badge in the subtitle row.
  * Original request (2026-09-12): "Openspec 1.13.0 释放了，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进。让 codex 参与。"
+ * Original request (2026-09-12): Owner walkthrough: collapse the always-expanded warning/build-order
+ *   blocks into one summary row; the page must not be consumed by advisory guidance.
  */
 import type { ApplyInstructionProgress } from '@openspecui/core'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
@@ -103,7 +106,7 @@ describe('ApplyProgressNotice OpenSpec 1.13 evidence', () => {
     cleanup()
   })
 
-  it('keeps upstream Apply warnings on the direct plane with CLI attribution', () => {
+  it('summarizes warnings in one visible row and reveals verbatim text on explicit expansion', () => {
     render(
       <ApplyProgressNotice
         applyInstructionProgress={progress(false)}
@@ -111,17 +114,25 @@ describe('ApplyProgressNotice OpenSpec 1.13 evidence', () => {
       />
     )
 
-    const notice = screen.getByRole('status', {
-      name: 'Apply warnings from openspec instructions apply',
+    // Collapsed: the summary row is the direct plane — count, CLI attribution, no hover needed
+    // to discover the predicted validation failure; the long verbatim text is not sprawled yet.
+    const summary = screen.getByRole('status', {
+      name: 'Apply readiness guidance from openspec instructions apply',
     })
-    expect(notice).toBeVisible()
-    expect(notice).toHaveTextContent('Apply warnings')
-    expect(notice).toHaveTextContent('openspec instructions apply')
-    // The upstream message survives verbatim on the direct plane — no Tooltip-only copy.
+    expect(summary).toBeVisible()
+    expect(summary).toHaveTextContent('1 apply warning')
+    expect(summary).toHaveTextContent('openspec instructions apply')
+    expect(screen.queryByText(upstreamApplyWarning)).toBeNull()
+
+    // One explicit expansion reveals the verbatim upstream message on the same direct plane.
+    fireEvent.click(summary.querySelector('button[aria-controls]')!)
     expect(screen.getByText(upstreamApplyWarning)).toBeVisible()
+    expect(
+      screen.getByText('Apply warnings — reported by openspec instructions apply')
+    ).toBeVisible()
   })
 
-  it('renders missingPrerequisites as a readable build-order chain, never a blocker', () => {
+  it('shows the build-order chain in the summary row without expansion, never as a blocker', () => {
     render(
       <ApplyProgressNotice
         applyInstructionProgress={progress(false)}
@@ -129,28 +140,49 @@ describe('ApplyProgressNotice OpenSpec 1.13 evidence', () => {
       />
     )
 
-    const notice = screen.getByRole('status', { name: 'Apply build-order prerequisites' })
-    expect(notice).toBeVisible()
-    expect(notice).toHaveTextContent('Next in build order')
-    expect(notice).toHaveTextContent('specs')
-    expect(notice).toHaveTextContent('design')
-    expect(notice).toHaveTextContent('openspec instructions apply')
+    // The chain is short enough to live in the summary itself: readable next-step evidence.
+    const summary = screen.getByRole('status', {
+      name: 'Apply readiness guidance from openspec instructions apply',
+    })
+    expect(summary).toBeVisible()
+    expect(summary).toHaveTextContent('next in build order: specs → design')
+    expect(summary).toHaveTextContent('openspec instructions apply')
     // Build-order evidence keeps status semantics and never adopts the blocker alert role.
-    expect(notice.getAttribute('role')).toBe('status')
+    expect(summary.getAttribute('role')).toBe('status')
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('combines warnings and the chain into one summary row and expands both', () => {
+    render(
+      <ApplyProgressNotice
+        applyInstructionProgress={progress(false)}
+        warnings={[upstreamApplyWarning, 'second warning']}
+        missingPrerequisites={['specs', 'design']}
+      />
+    )
+
+    const summary = screen.getByRole('status', {
+      name: 'Apply readiness guidance from openspec instructions apply',
+    })
+    expect(summary).toHaveTextContent('2 apply warnings')
+    expect(summary).toHaveTextContent('next in build order: specs → design')
+    fireEvent.click(summary.querySelector('button[aria-controls]')!)
+    expect(screen.getByText(upstreamApplyWarning)).toBeVisible()
+    expect(screen.getByText('second warning')).toBeVisible()
   })
 
   it('keeps the existing divergence presentation when the 1.13 fields are absent', () => {
     render(<ApplyProgressNotice applyInstructionProgress={progress(true)} />)
 
     // Absent keys degrade to the previous surface exactly: the divergence notice renders
-    // and no warning/build-order block or empty-state text is synthesized.
+    // and no guidance summary row or empty-state text is synthesized.
     expect(screen.getByText('Upstream task progress divergence')).toBeVisible()
     expect(screen.queryByText('Apply warnings')).toBeNull()
     expect(screen.queryByText('Next in build order')).toBeNull()
     expect(
-      screen.queryByRole('status', { name: 'Apply warnings from openspec instructions apply' })
+      screen.queryByRole('status', {
+        name: 'Apply readiness guidance from openspec instructions apply',
+      })
     ).toBeNull()
-    expect(screen.queryByRole('status', { name: 'Apply build-order prerequisites' })).toBeNull()
   })
 })

--- a/packages/web/src/components/apply-progress-notice.tsx
+++ b/packages/web/src/components/apply-progress-notice.tsx
@@ -4,11 +4,12 @@
  * 2. Compress agreement to one subtitle badge; keep divergence a direct blocker.
  * 3. Keep divergence's two objective source counts side by side with their causes.
  * 4. Keep tooltips as the keyboard-reachable explanation for every compact count.
- * 5. Render OpenSpec 1.13 Apply `warnings` verbatim on the direct plane with CLI
- *    attribution; they predict a validation failure, so a Tooltip-only surface is forbidden.
- * 6. Render OpenSpec 1.13 `missingPrerequisites` as a readable build-order chain that
- *    stays evidence (status semantics), visually and semantically distinct from blockers,
- *    including when the Apply state is already `ready`.
+ * 5. Render OpenSpec 1.13 Apply `warnings`/`missingPrerequisites` as ONE always-visible summary
+ *    row (count + build-order chain, CLI attribution) whose verbatim evidence is one explicit
+ *    expansion away on the same direct plane — advisory guidance must stay discoverable without
+ *    consuming the page; a Tooltip-only surface remains forbidden.
+ * 6. Keep `missingPrerequisites` visually and semantically distinct from blockers (status
+ *    semantics), including when the Apply state is already `ready`.
  * 7. Degrade to the previous presentation when either 1.13 field is absent — absent keys
  *    are the upstream encoding for "none", so no empty state is ever synthesized.
  *
@@ -17,11 +18,13 @@
  * Original request (2026-08-15): Owner walkthrough: agreement is one badge in the subtitle row,
  *   not a two-line block; only divergence owns a notice.
  * Original request (2026-09-12): "Openspec 1.13.0 释放了，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进。让 codex 参与。"
+ * Original request (2026-09-12): Owner walkthrough: the always-expanded warning/build-order blocks
+ *   consumed the page; collapse them behind one summary row while keeping direct-plane discovery.
  */
 import { InformationBadge } from '@/components/information-disclosure'
 import type { ApplyInstructionProgress } from '@openspecui/core'
-import { AlertTriangle, ListOrdered } from 'lucide-react'
-import { Fragment } from 'react'
+import { AlertTriangle, ChevronDown, ChevronRight, ListOrdered } from 'lucide-react'
+import { Fragment, useState } from 'react'
 
 /**
  * One compact, source-attributed Apply progress badge for the Change subtitle row.
@@ -48,9 +51,13 @@ export function ApplyProgressBadge({
 /** Upstream command that owns every fact rendered by these notices. */
 const APPLY_COMMAND_ATTRIBUTION = 'openspec instructions apply'
 
+const GUIDANCE_DETAIL_ID = 'apply-readiness-guidance-detail'
+
 /**
  * Render the Apply/tracked divergence as one direct, source-attributed blocker, plus the
- * OpenSpec 1.13 `warnings` and `missingPrerequisites` evidence as direct-plane notices.
+ * OpenSpec 1.13 `warnings` and `missingPrerequisites` evidence as one collapsible summary row:
+ * the row itself names the warning count and the build-order chain (discovery needs no hover),
+ * and expanding reveals the verbatim upstream evidence on the same direct plane.
  * Returns null when none apply — the agreement case lives in the subtitle badge row via
  * {@link ApplyProgressBadge}, and absent 1.13 keys render nothing.
  */
@@ -68,59 +75,95 @@ export function ApplyProgressNotice({
   const divergence = applyInstructionProgress.divergence
   const hasWarnings = (warnings?.length ?? 0) > 0
   const hasPrerequisites = (missingPrerequisites?.length ?? 0) > 0
+  const [expanded, setExpanded] = useState(false)
   if (!divergence && !hasWarnings && !hasPrerequisites) return null
+
+  const guidanceSummaryParts: string[] = []
+  if (hasWarnings) {
+    const count = warnings!.length
+    guidanceSummaryParts.push(`${count} apply warning${count > 1 ? 's' : ''}`)
+  }
+  if (hasPrerequisites) {
+    guidanceSummaryParts.push(`next in build order: ${missingPrerequisites!.join(' → ')}`)
+  }
 
   return (
     <>
-      {hasWarnings ? (
+      {hasWarnings || hasPrerequisites ? (
         <div
           role="status"
-          data-apply-notice="warnings"
-          aria-label={`Apply warnings from ${APPLY_COMMAND_ATTRIBUTION}`}
-          className="flex min-w-0 items-start gap-2 border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100"
+          data-apply-notice="summary"
+          aria-label={`Apply readiness guidance from ${APPLY_COMMAND_ATTRIBUTION}`}
+          className={
+            hasWarnings
+              ? 'flex min-w-0 items-center gap-2 border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs text-amber-950 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100'
+              : 'text-muted-foreground flex min-w-0 items-center gap-2 rounded-md border px-3 py-1.5 text-xs'
+          }
         >
-          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-          <div className="min-w-0 space-y-1">
-            <div className="font-medium">
-              Apply warnings — reported by {APPLY_COMMAND_ATTRIBUTION}
-            </div>
-            <ul className="space-y-1">
-              {warnings?.map((warning) => (
-                <li key={warning} className="break-words">
-                  {warning}
-                </li>
-              ))}
-            </ul>
-          </div>
+          {hasWarnings ? (
+            <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          ) : (
+            <ListOrdered className="h-4 w-4 shrink-0" aria-hidden="true" />
+          )}
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
+            aria-controls={GUIDANCE_DETAIL_ID}
+            className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
+          >
+            <span className="truncate font-medium">{guidanceSummaryParts.join(' · ')}</span>
+            <span className="text-muted-foreground shrink-0 font-normal">
+              — {APPLY_COMMAND_ATTRIBUTION}
+            </span>
+          </button>
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+          )}
         </div>
       ) : null}
-      {hasPrerequisites ? (
+      {expanded && (hasWarnings || hasPrerequisites) ? (
         <div
-          role="status"
-          data-apply-notice="build-order"
-          aria-label="Apply build-order prerequisites"
-          className="text-muted-foreground flex min-w-0 items-start gap-2 rounded-md border px-3 py-2 text-xs"
+          id={GUIDANCE_DETAIL_ID}
+          className="text-muted-foreground space-y-2 rounded-md border px-3 py-2 text-xs"
         >
-          <ListOrdered className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-          <div className="min-w-0 space-y-1">
-            <div className="text-foreground font-medium">
-              Next in build order — reported by {APPLY_COMMAND_ATTRIBUTION}
+          {hasWarnings ? (
+            <div data-apply-notice="warnings" className="min-w-0 space-y-1">
+              <div className="text-foreground font-medium">
+                Apply warnings — reported by {APPLY_COMMAND_ATTRIBUTION}
+              </div>
+              <ul className="space-y-1">
+                {warnings?.map((warning) => (
+                  <li key={warning} className="break-words">
+                    {warning}
+                  </li>
+                ))}
+              </ul>
             </div>
-            <div className="flex flex-wrap items-center gap-1">
-              {missingPrerequisites?.map((artifactId, index) => (
-                <Fragment key={artifactId}>
-                  {index > 0 ? (
-                    <span className="text-muted-foreground/70" aria-hidden="true">
-                      →
+          ) : null}
+          {hasPrerequisites ? (
+            <div data-apply-notice="build-order" className="min-w-0 space-y-1">
+              <div className="text-foreground font-medium">
+                Next in build order — reported by {APPLY_COMMAND_ATTRIBUTION}
+              </div>
+              <div className="flex flex-wrap items-center gap-1">
+                {missingPrerequisites?.map((artifactId, index) => (
+                  <Fragment key={artifactId}>
+                    {index > 0 ? (
+                      <span className="text-muted-foreground/70" aria-hidden="true">
+                        →
+                      </span>
+                    ) : null}
+                    <span className="bg-muted break-words rounded border px-1 py-0.5 font-mono [overflow-wrap:anywhere]">
+                      {artifactId}
                     </span>
-                  ) : null}
-                  <span className="bg-muted break-words rounded border px-1 py-0.5 font-mono [overflow-wrap:anywhere]">
-                    {artifactId}
-                  </span>
-                </Fragment>
-              ))}
+                  </Fragment>
+                ))}
+              </div>
             </div>
-          </div>
+          ) : null}
         </div>
       ) : null}
       {divergence ? (

--- a/packages/web/src/lib/change-display-title.test.ts
+++ b/packages/web/src/lib/change-display-title.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Orthogonal intents (created 2026-09-12 Asia/Shanghai):
+ * 1. Pin the shared Change display-title derivation used by list, dashboard, and detail.
+ * 2. Generic scaffold headings ("# Proposal") fall back to the change id.
+ * 3. Informative proposal headings win; absent/parser-less rows fall back to the id.
+ *
+ * Original request (2026-09-12): Owner walkthrough: unify the Change title across surfaces —
+ *   the list showed the generic "Proposal" heading while the detail showed the change id.
+ */
+import { describe, expect, it } from 'vitest'
+import { changeDisplayTitle } from './change-display-title'
+
+describe('changeDisplayTitle', () => {
+  it('prefers an informative proposal heading', () => {
+    expect(changeDisplayTitle('add-search', 'Add Search')).toBe('Add Search')
+  })
+
+  it('falls back to the change id for the generic scaffold heading', () => {
+    expect(changeDisplayTitle('no-specs-but-tasks', 'Proposal')).toBe('no-specs-but-tasks')
+    // Case-insensitive: the scaffold heading is a structural marker, not a name.
+    expect(changeDisplayTitle('a', 'proposal')).toBe('a')
+  })
+
+  it('falls back to the change id when the heading equals the id, is blank, or is absent', () => {
+    expect(changeDisplayTitle('add-search', 'add-search')).toBe('add-search')
+    expect(changeDisplayTitle('add-search', '   ')).toBe('add-search')
+    expect(changeDisplayTitle('add-search', null)).toBe('add-search')
+    expect(changeDisplayTitle('add-search', undefined)).toBe('add-search')
+  })
+
+  it('trims a real heading before use', () => {
+    expect(changeDisplayTitle('a', '  Add Search  ')).toBe('Add Search')
+  })
+})

--- a/packages/web/src/lib/change-display-title.ts
+++ b/packages/web/src/lib/change-display-title.ts
@@ -1,0 +1,30 @@
+/**
+ * Orthogonal intents (created 2026-09-12 Asia/Shanghai):
+ * 1. Derive one shared display title for a Change across list, dashboard, and detail surfaces.
+ * 2. Treat the proposal H1 as a human-readable title only when it is informative.
+ * 3. Fall back to the change id (the CLI's own canonical name) otherwise.
+ *
+ * Original request (2026-09-12): Owner walkthrough: the Changes list showed the generic proposal
+ *   heading "Proposal" as the row title while Change Detail showed the change id — unify the scheme.
+ */
+
+/**
+ * Heading texts that carry no identity information. `openspec new change` scaffolds proposals with
+ * the bare heading "# Proposal"; showing it as a row title reads as a parsing bug rather than a name.
+ */
+const GENERIC_PROPOSAL_HEADINGS = new Set(['proposal'])
+
+/**
+ * One display title for a Change, identical on every surface.
+ *
+ * `name` is the legacy parser's proposal H1 (absent for parser-less custom schemas); the change id
+ * is the CLI-owned canonical identity (`openspec list --json` names changes by directory). The H1
+ * wins only when it is a real, differentiated title; generic headings and the id itself fall back
+ * to the id, so no surface ever shows two different titles for the same Change.
+ */
+export function changeDisplayTitle(changeId: string, name?: string | null): string {
+  const trimmed = name?.trim()
+  if (!trimmed || trimmed === changeId) return changeId
+  if (GENERIC_PROPOSAL_HEADINGS.has(trimmed.toLowerCase())) return changeId
+  return trimmed
+}

--- a/packages/web/src/routes/change-list.tsx
+++ b/packages/web/src/routes/change-list.tsx
@@ -14,6 +14,8 @@
  * Original request (2026-07-21): "Changes页面的右上角没有 New,你要不要快速补一个"
 
  * Original request (2026-08-15): "v9的适配需要同时适配 1.8和1.9。"
+ * Original request (2026-09-12): Owner walkthrough: unify the Change display title — generic
+ *   "# Proposal" headings fall back to the change id on every surface.
  */
 import { ChangeRow, ChangeRowChevron } from '@/components/change-row'
 import {
@@ -22,6 +24,7 @@ import {
   RealtimeRevalidateCue,
   RealtimeSkeletonLine,
 } from '@/components/realtime'
+import { changeDisplayTitle } from '@/lib/change-display-title'
 import {
   classifyChangeWorkflowPhase,
   inferTrackedArtifactStatus,
@@ -197,7 +200,7 @@ export function ChangeList() {
                     __vtHandoff: {
                       family: 'changes',
                       entityId: change.id,
-                      title: change.name,
+                      title: changeDisplayTitle(change.id, change.name),
                       subtitle: change.id,
                     },
                   })}
@@ -208,7 +211,7 @@ export function ChangeList() {
                   <div className="flex items-center gap-3">
                     <ChangeRow
                       changeId={change.id}
-                      name={change.name}
+                      name={changeDisplayTitle(change.id, change.name)}
                       phase={phase}
                       updatedAt={change.updatedAt}
                       formatTime={formatRelativeTime}

--- a/packages/web/src/routes/change-view.test.tsx
+++ b/packages/web/src/routes/change-view.test.tsx
@@ -28,6 +28,9 @@ import { ChangeView } from './change-view'
 const statusMock = vi.hoisted(() => vi.fn())
 const applyInstructionsMock = vi.hoisted(() => vi.fn())
 const changeFilesMock = vi.hoisted(() => vi.fn())
+const changesSubscriptionMock = vi.hoisted(() =>
+  vi.fn(() => ({ data: undefined, isLoading: false, error: null }))
+)
 const rootActionMock = vi.hoisted(() => vi.fn())
 const openArchiveModalMock = vi.hoisted(() => vi.fn())
 const isStaticModeMock = vi.hoisted(() => vi.fn(() => false))
@@ -199,6 +202,7 @@ vi.mock('@/lib/use-opsx', () => ({
 
 vi.mock('@/lib/use-subscription', () => ({
   useChangeFilesSubscription: changeFilesMock,
+  useChangesSubscription: changesSubscriptionMock,
 }))
 
 vi.mock('@/lib/use-root-action-state', () => ({
@@ -617,18 +621,24 @@ describe('ChangeView', () => {
     render(<ChangeView />)
 
     const region = screen.getByTestId('opsx-detail-status-region')
-    // The warning text is verbatim on the direct plane — not only inside the Apply inputs
-    // dialog, a Tooltip, or a collapsed disclosure.
+    // Collapsed by default: one summary row carries the warning count, the full build-order
+    // chain, and CLI attribution — discoverable without hover or expansion, and the long
+    // verbatim text does not consume the page.
+    const summary = within(region).getByRole('status', {
+      name: 'Apply readiness guidance from openspec instructions apply',
+    })
+    expect(summary).toBeVisible()
+    expect(summary).toHaveTextContent('1 apply warning')
+    expect(summary).toHaveTextContent('next in build order: specs → design')
+    expect(within(region).queryByText(/This change has no delta specs/)).toBeNull()
+    // One explicit expansion reveals the verbatim upstream warning on the same direct plane.
+    fireEvent.click(summary.querySelector('button[aria-controls]')!)
     expect(
       within(region).getByText(
         /This change has no delta specs and does not declare `skip_specs: true`/
       )
     ).toBeVisible()
     expect(within(region).getByText(/^Apply warnings/)).toBeVisible()
-    // The build-order chain names every missing prerequisite id beside the warning.
-    expect(within(region).getByText(/^Next in build order/)).toBeVisible()
-    expect(within(region).getByText('specs')).toBeVisible()
-    expect(within(region).getByText('design')).toBeVisible()
     // Ready-state build-order evidence never adopts the blocker alert role.
     expect(within(region).queryByRole('alert')).toBeNull()
   })

--- a/packages/web/src/routes/change-view.tsx
+++ b/packages/web/src/routes/change-view.tsx
@@ -20,6 +20,8 @@
  * Original request (2026-09-03): "Openspec 1.12.0 刚刚放出来，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进" — the Evidence tab gains the findings evidence section.
  * Original request (2026-08-28): "使用移动端的 list-detail 思维……分成两栏，左侧 list，右侧详情。这种结构替代手风琴会更好"
  * Original request (2026-09-12): "Openspec 1.13.0 释放了，你更新一下，调查变更内容，然后开始规划适配工作，我们将用标准工作流worktree来推进。让 codex 参与。"
+ * Original request (2026-09-12): Owner walkthrough: unify the Change display title (generic "# Proposal"
+ *   headings fall back to the change id) and collapse Apply readiness guidance into one summary row.
  *   — the status region gains the OpenSpec 1.13 Apply `warnings` and `missingPrerequisites`
  *   direct-plane evidence beside the existing divergence notice.
  */
@@ -37,7 +39,8 @@ import { RootActionNotice } from '@/components/root-action-notice'
 import { buildOpsxComposeHref, type OpsxComposeActionId } from '@/lib/opsx-compose'
 import { useChangeOperatorLauncher } from '@/lib/use-change-operator-launcher'
 import { useOpsxApplyInstructionsSubscription, useOpsxStatusSubscription } from '@/lib/use-opsx'
-import { useChangeFilesSubscription } from '@/lib/use-subscription'
+import { useChangeFilesSubscription, useChangesSubscription } from '@/lib/use-subscription'
+import { changeDisplayTitle } from '@/lib/change-display-title'
 import { vtNavController } from '@/lib/view-transitions/navigation'
 import { readSharedElementHandoffState } from '@/lib/view-transitions/shared-elements'
 import { useLocation, useParams } from '@tanstack/react-router'
@@ -57,6 +60,14 @@ export function ChangeView() {
   const { data: status, isLoading, error } = statusProjection
   const { data: applyInstructions } = useOpsxApplyInstructionsSubscription({ change: changeId })
   const { data: files } = useChangeFilesSubscription(changeId)
+  const changesProjection = useChangesSubscription()
+  const changesRows = changesProjection.data
+  // Same derivation as the Changes list rows; the CLI status name is the canonical id in
+  // practice, so it only ever serves as a pre-rows fallback, never a second title source.
+  const displayTitle = changeDisplayTitle(
+    changeId,
+    changesRows?.find((row) => row.id === changeId)?.name ?? status?.changeName
+  )
 
   const handleComposeAction = useCallback(
     (actionId: OpsxComposeActionId, artifactId?: string) => {
@@ -154,7 +165,7 @@ export function ChangeView() {
       backTo="/changes"
       backTitle="Back to Changes"
       icon={GitBranch}
-      title={status?.changeName}
+      title={displayTitle}
       subtitle={
         status ? (
           <ChangeContextSummary

--- a/packages/web/src/routes/dashboard.tsx
+++ b/packages/web/src/routes/dashboard.tsx
@@ -20,6 +20,8 @@
  * Original request (2026-07-31): "基于真实的布局去做骨架屏，或者说是直接让卡片自身去支持 Pending 样式"
  * Original request (2026-07-31): "Code Git Snapshot 的 Other Worktrees 默认隐藏 (detached)。然后commitList这里默认显示5个就好"
  * Original request (2026-07-31): "检查目前的这个 Code Git Snapshot，它非常慢，有时候甚至要十几秒"
+ * Original request (2026-09-12): Owner walkthrough: unify the Change display title — generic
+ *   "# Proposal" headings fall back to the change id on every surface.
  * Owner correction (2026-07-31): Hidden documents pause the timer; visibility resumes the remaining delay or refreshes once when the absolute deadline elapsed.
 
  */
@@ -42,6 +44,7 @@ import {
   RealtimeSkeleton,
 } from '@/components/realtime'
 import type { SelectOption } from '@/components/select'
+import { changeDisplayTitle } from '@/lib/change-display-title'
 import {
   classifyChangeWorkflowPhase,
   inferTrackedArtifactStatus,
@@ -710,7 +713,7 @@ export function Dashboard() {
                   __vtHandoff: {
                     family: 'changes',
                     entityId: change.id,
-                    title: change.name,
+                    title: changeDisplayTitle(change.id, change.name),
                     subtitle: change.id,
                   },
                 })}
@@ -724,7 +727,7 @@ export function Dashboard() {
                 <div className="flex min-w-0 items-center gap-3">
                   <ChangeRow
                     changeId={change.id}
-                    name={change.name}
+                    name={changeDisplayTitle(change.id, change.name)}
                     phase={phase}
                     updatedAt={change.updatedAt}
                     formatTime={formatRelativeTime}


### PR DESCRIPTION
## Summary

Two fixes from the Owner's acceptance walkthrough of the OpenSpecUI 13 instance:

1. **Apply readiness guidance no longer consumes the page.** The always-expanded warnings/build-order blocks are now ONE always-visible summary row — warning count + the full build-order chain + `openspec instructions apply` attribution (`role="status"`, collapsed by default). One explicit expansion reveals the verbatim upstream evidence on the same direct plane; Tooltip-only remains forbidden, and the divergence notice keeps its direct uncollapsed block. The change's spec delta (`Apply Readiness Guidance Surface`) is updated to codify the summary-row contract.

2. **One Change title everywhere.** The Changes list titled rows with the legacy parser's proposal H1 (the scaffold's generic `# Proposal`), while Change Detail used the CLI status name (= id). New shared `changeDisplayTitle(id, name)` in the web lib: an informative proposal heading wins; generic/blank/id-equal values fall back to the change id. Wired into the Changes list rows + VT handoff, Dashboard rows, and the Change Detail header (rows name with the status name as pre-rows fallback).

## Evidence

- Focused suites green: 51/51 (helper + notice + change-view + change-list), 25/25 (dashboard + continuity), 39/39 final re-verify; web typecheck green; scoped prettier clean.
- Browser self-verification on the live acceptance instance (screenshots recorded): collapsed summary renders one line with count + `specs → design`; expansion reveals verbatim evidence; Changes list row titles read `["no-specs-but-tasks","fresh-blocked-change"]` (no generic "Proposal"); Detail header shows the same id title.
- Full web suite classification: 8 failures were load-induced timeouts (acceptance dev server + gates running concurrently; terminal/ssg files re-verified green in isolation) plus one pre-existing View-Transition scroll flake reproduced on unmodified `main` — unrelated to this change's files.

## Notes

- The acceptance instance at `http://localhost:3517` already serves the rebuilt assets for re-walkthrough.
- Changeset: `@openspecui/web` patch.