### PR TITLE
chore(release): apply changeset version

### DIFF
--- a/.changeset/openspec-113-line-adaptation.md
+++ b/.changeset/openspec-113-line-adaptation.md
@@ -1,8 +1,0 @@
----
-'@openspecui/core': major
-'@openspecui/server': major
-'@openspecui/web': major
-'openspecui': major
----
-
-OpenSpecUI 13: adapt to OpenSpec CLI 1.13.x as a new single-series line (`>=1.13.0 <1.14.0`); the previous 1.12 v12 window, prereleases, `>=1.14.0`, and unparseable versions are blocked by default. Apply Instructions now project the CLI-owned `missingPrerequisites` (build-order closure of unread artifacts, present even in the ready state) and `warnings` (the no-delta-specs advisory that predicts a `validate` failure) end-to-end: typed CLI contract, Core input/projection schemas, Server transport, and a direct-plane Change Detail presentation with readable build-order evidence and graceful degradation. The Agent delivery registry rotates its series to '1.13' with every 1.12 physical fact carried forward (no new tools upstream; SourceCraft's 1.12 introduction stays a provenance fact), the pinned generator baseline moves to 1.13.0 with series-aware staleness (1.12.x-generated artifacts read stale), and the pinned executable fixture matrix rotates to the published `@fission-ai/openspec@1.13.0` with the retained 1.12.0 executable proving below-admitted boundary rejections.

--- a/.changeset/walkthrough-v13-ux-polish.md
+++ b/.changeset/walkthrough-v13-ux-polish.md
@@ -1,5 +1,0 @@
----
-'@openspecui/web': patch
----
-
-Walkthrough UX polish for the OpenSpecUI 13 Apply readiness guidance and Change titles: the Apply warnings/build-order notices collapse into one always-visible summary row (warning count + build-order chain + `openspec instructions apply` attribution) whose verbatim upstream evidence is one explicit expansion away, restoring the page to advisory-free default height while keeping direct-plane discovery; and every Change surface (Changes list, Dashboard rows, Change Detail header) now derives one shared display title — an informative proposal heading wins, generic `# Proposal` scaffold headings and parser-less rows fall back to the change id — ending the list/detail title mismatch.

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/app
 
+## 13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/app",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/browser-translator/CHANGELOG.md
+++ b/packages/browser-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/browser-translator
 
+## 13.0.0
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/browser-translator/package.json
+++ b/packages/browser-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/browser-translator",
   "private": true,
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Browser-side translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # openspecui
 
+## 13.0.0
+
+### Major Changes
+
+- 67f5533: OpenSpecUI 13: adapt to OpenSpec CLI 1.13.x as a new single-series line (`>=1.13.0 <1.14.0`); the previous 1.12 v12 window, prereleases, `>=1.14.0`, and unparseable versions are blocked by default. Apply Instructions now project the CLI-owned `missingPrerequisites` (build-order closure of unread artifacts, present even in the ready state) and `warnings` (the no-delta-specs advisory that predicts a `validate` failure) end-to-end: typed CLI contract, Core input/projection schemas, Server transport, and a direct-plane Change Detail presentation with readable build-order evidence and graceful degradation. The Agent delivery registry rotates its series to '1.13' with every 1.12 physical fact carried forward (no new tools upstream; SourceCraft's 1.12 introduction stays a provenance fact), the pinned generator baseline moves to 1.13.0 with series-aware staleness (1.12.x-generated artifacts read stale), and the pinned executable fixture matrix rotates to the published `@fission-ai/openspec@1.13.0` with the retained 1.12.0 executable proving below-admitted boundary rejections.
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openspecui",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "OpenSpec UI - Visual interface for spec-driven development",
   "type": "module",
   "main": "dist/index.mjs",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @openspecui/core
 
+## 13.0.0
+
+### Major Changes
+
+- 67f5533: OpenSpecUI 13: adapt to OpenSpec CLI 1.13.x as a new single-series line (`>=1.13.0 <1.14.0`); the previous 1.12 v12 window, prereleases, `>=1.14.0`, and unparseable versions are blocked by default. Apply Instructions now project the CLI-owned `missingPrerequisites` (build-order closure of unread artifacts, present even in the ready state) and `warnings` (the no-delta-specs advisory that predicts a `validate` failure) end-to-end: typed CLI contract, Core input/projection schemas, Server transport, and a direct-plane Change Detail presentation with readable build-order evidence and graceful degradation. The Agent delivery registry rotates its series to '1.13' with every 1.12 physical fact carried forward (no new tools upstream; SourceCraft's 1.12 introduction stays a provenance fact), the pinned generator baseline moves to 1.13.0 with series-aware staleness (1.12.x-generated artifacts read stale), and the pinned executable fixture matrix rotates to the published `@fission-ai/openspec@1.13.0` with the retained 1.12.0 executable proving below-admitted boundary rejections.
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/core",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Core OpenSpec adapter and parser",
   "files": [
     "dist"

--- a/packages/local-ct2-translator/CHANGELOG.md
+++ b/packages/local-ct2-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-ct2-translator
 
+## 13.0.0
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/local-ct2-translator/package.json
+++ b/packages/local-ct2-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-ct2-translator",
   "private": true,
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Server-side CTranslate2 translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-llama-translator/CHANGELOG.md
+++ b/packages/local-llama-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-llama-translator
 
+## 13.0.0
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/local-llama-translator/package.json
+++ b/packages/local-llama-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-llama-translator",
   "private": true,
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Server-side llama.cpp translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/local-translator/CHANGELOG.md
+++ b/packages/local-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/local-translator
 
+## 13.0.0
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/local-translator/package.json
+++ b/packages/local-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/local-translator",
   "private": true,
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Server-side local translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/openai-completion-translator/CHANGELOG.md
+++ b/packages/openai-completion-translator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @openspecui/openai-completion-translator
 
+## 13.0.0
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/openai-completion-translator/package.json
+++ b/packages/openai-completion-translator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openspecui/openai-completion-translator",
   "private": true,
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "OpenAI completion translator engine for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/search/CHANGELOG.md
+++ b/packages/search/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/search
 
+## 13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/search",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Shared search engine and worker providers for OpenSpecUI",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @openspecui/server
 
+## 13.0.0
+
+### Major Changes
+
+- 67f5533: OpenSpecUI 13: adapt to OpenSpec CLI 1.13.x as a new single-series line (`>=1.13.0 <1.14.0`); the previous 1.12 v12 window, prereleases, `>=1.14.0`, and unparseable versions are blocked by default. Apply Instructions now project the CLI-owned `missingPrerequisites` (build-order closure of unread artifacts, present even in the ready state) and `warnings` (the no-delta-specs advisory that predicts a `validate` failure) end-to-end: typed CLI contract, Core input/projection schemas, Server transport, and a direct-plane Change Detail presentation with readable build-order evidence and graceful degradation. The Agent delivery registry rotates its series to '1.13' with every 1.12 physical fact carried forward (no new tools upstream; SourceCraft's 1.12 introduction stays a provenance fact), the pinned generator baseline moves to 1.13.0 with series-aware staleness (1.12.x-generated artifacts read stale), and the pinned executable fixture matrix rotates to the published `@fission-ai/openspec@1.13.0` with the retained 1.12.0 executable proving below-admitted boundary rejections.
+
+### Patch Changes
+
+- Updated dependencies [67f5533]
+  - @openspecui/core@13.0.0
+  - @openspecui/local-ct2-translator@13.0.0
+  - @openspecui/local-llama-translator@13.0.0
+  - @openspecui/local-translator@13.0.0
+  - @openspecui/openai-completion-translator@13.0.0
+  - @openspecui/search@13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/server",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "type": "module",
   "main": "dist/index.mjs",
   "exports": {

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @openspecui/web
 
+## 13.0.0
+
+### Major Changes
+
+- 67f5533: OpenSpecUI 13: adapt to OpenSpec CLI 1.13.x as a new single-series line (`>=1.13.0 <1.14.0`); the previous 1.12 v12 window, prereleases, `>=1.14.0`, and unparseable versions are blocked by default. Apply Instructions now project the CLI-owned `missingPrerequisites` (build-order closure of unread artifacts, present even in the ready state) and `warnings` (the no-delta-specs advisory that predicts a `validate` failure) end-to-end: typed CLI contract, Core input/projection schemas, Server transport, and a direct-plane Change Detail presentation with readable build-order evidence and graceful degradation. The Agent delivery registry rotates its series to '1.13' with every 1.12 physical fact carried forward (no new tools upstream; SourceCraft's 1.12 introduction stays a provenance fact), the pinned generator baseline moves to 1.13.0 with series-aware staleness (1.12.x-generated artifacts read stale), and the pinned executable fixture matrix rotates to the published `@fission-ai/openspec@1.13.0` with the retained 1.12.0 executable proving below-admitted boundary rejections.
+
+### Patch Changes
+
+- cb4c75d: Walkthrough UX polish for the OpenSpecUI 13 Apply readiness guidance and Change titles: the Apply warnings/build-order notices collapse into one always-visible summary row (warning count + build-order chain + `openspec instructions apply` attribution) whose verbatim upstream evidence is one explicit expansion away, restoring the page to advisory-free default height while keeping direct-plane discovery; and every Change surface (Changes list, Dashboard rows, Change Detail header) now derives one shared display title — an informative proposal heading wins, generic `# Proposal` scaffold headings and parser-less rows fall back to the change id — ending the list/detail title mismatch.
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openspecui/web",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "type": "module",
   "bin": {
     "openspecui-ssg": "./dist-ssg/ssg-cli.mjs"

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @openspecui/website
 
+## 13.0.0
+
 ## 12.0.0
 
 ### Major Changes

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,40 +1,40 @@
 {
- "name": "@openspecui/website",
- "version": "12.0.0",
- "private": true,
- "type": "module",
- "scripts": {
-  "dev": "vite --host=127.0.0.1 --port 13006",
-  "build": "vite build && node scripts/llms.mjs",
-  "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-  "test": "vitest run",
-  "cf:dev": "pnpm build && wrangler pages dev dist",
-  "cf:deploy": "pnpm build && wrangler pages deploy dist --project-name openspecui-website",
-  "cf:project:create": "wrangler pages project create openspecui-website --production-branch main"
- },
- "dependencies": {
-  "@fontsource-variable/jetbrains-mono": "^5.2.8",
-  "@fontsource/share-tech-mono": "^5.2.7",
-  "clsx": "^2.1.1",
-  "tailwind-merge": "^3.4.0"
- },
- "devDependencies": {
-  "@sveltejs/adapter-static": "^3.0.10",
-  "@sveltejs/kit": "^2.59.1",
-  "@sveltejs/vite-plugin-svelte": "^7.1.2",
-  "@tailwindcss/vite": "^4.2.1",
-  "@testing-library/jest-dom": "^6.6.3",
-  "@testing-library/svelte": "^5.3.1",
-  "jsdom": "^25.0.1",
-  "lucide-svelte": "^0.472.0",
-  "mdsvex": "^0.12.7",
-  "shiki": "^3.17.0",
-  "svelte": "^5.55.5",
-  "svelte-check": "^4.4.8",
-  "tailwindcss": "^4.2.1",
-  "typescript": "^5.9.3",
-  "vite": "^8.0.0",
-  "vitest": "^4.1.0",
-  "wrangler": "^4.72.0"
- }
+  "name": "@openspecui/website",
+  "version": "13.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host=127.0.0.1 --port 13006",
+    "build": "vite build && node scripts/llms.mjs",
+    "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
+    "cf:dev": "pnpm build && wrangler pages dev dist",
+    "cf:deploy": "pnpm build && wrangler pages deploy dist --project-name openspecui-website",
+    "cf:project:create": "wrangler pages project create openspecui-website --production-branch main"
+  },
+  "dependencies": {
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource/share-tech-mono": "^5.2.7",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.4.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.10",
+    "@sveltejs/kit": "^2.59.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/svelte": "^5.3.1",
+    "jsdom": "^25.0.1",
+    "lucide-svelte": "^0.472.0",
+    "mdsvex": "^0.12.7",
+    "shiki": "^3.17.0",
+    "svelte": "^5.55.5",
+    "svelte-check": "^4.4.8",
+    "tailwindcss": "^4.2.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0",
+    "vitest": "^4.1.0",
+    "wrangler": "^4.72.0"
+  }
 }


### PR DESCRIPTION
Automated by `pnpm changeversion`.

- Enter, continue, or exit the requested Changesets prerelease mode
- Run `changeset version`
- Commit version/changelog updates
- Create PR and wait for required checks
- Merge PR, sync local main, and wait for GitHub release automation